### PR TITLE
Result error type can be created with a string or an error

### DIFF
--- a/src/screens/Wallets/lighting/LightningCard.tsx
+++ b/src/screens/Wallets/lighting/LightningCard.tsx
@@ -3,7 +3,7 @@
  * @flow strict-local
  */
 
-import React, { memo, useEffect, useState } from 'react';
+import React, { memo, ReactElement, useEffect, useState } from 'react';
 import { LayoutAnimation, StyleSheet, TextInput } from 'react-native';
 import { View, Text } from '../../../styles/components';
 import Receive from './../Receive';
@@ -24,7 +24,7 @@ import {
 	showSuccessNotification,
 } from '../../../utils/notifications';
 
-const LightningCard = () => {
+const LightningCard = (): ReactElement => {
 	const lightning = useSelector((state: Store) => state.lightning);
 	const [message, setMessage] = useState('');
 	const [receiveAddress, setReceiveAddress] = useState('');
@@ -82,7 +82,7 @@ const LightningCard = () => {
 	}, [sendPaymentRequest]);
 
 	if (!lightning.onChainBalance || !lightning.channelBalance) {
-		return null;
+		return <View />;
 	}
 
 	const showFundingButton =
@@ -112,7 +112,7 @@ const LightningCard = () => {
 							<Button
 								color="onSurface"
 								style={styles.sendButton}
-								onPress={() => {
+								onPress={(): void => {
 									setShowInvoiceInput(!showInvoiceInput);
 									setReceiveAddress('');
 									setReceivePaymentRequest('');
@@ -123,7 +123,7 @@ const LightningCard = () => {
 							<Button
 								color="onSurface"
 								style={styles.receiveButton}
-								onPress={async () => {
+								onPress={async (): Promise<void> => {
 									const res = await lnd.createInvoice(1, 'Spectrum test');
 
 									if (res.isErr()) {
@@ -147,7 +147,7 @@ const LightningCard = () => {
 						<Button
 							color="onSurface"
 							style={styles.fundButton}
-							onPress={async () => {
+							onPress={async (): Promise<void> => {
 								const res = await lnd.getAddress();
 								if (res.isOk()) {
 									setReceiveAddress(res.value.address);

--- a/src/store/actions/lightning.ts
+++ b/src/store/actions/lightning.ts
@@ -21,9 +21,7 @@ const dispatch = getDispatch();
  * @param network
  * @returns {Promise<unknown>}
  */
-export const startLnd = (
-	network: LndNetworks,
-): Promise<Result<string, Error>> => {
+export const startLnd = (network: LndNetworks): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		const stateRes = await lnd.currentState();
 		if (stateRes.isOk() && stateRes.value.lndRunning) {
@@ -65,11 +63,11 @@ export const createLightningWallet = ({
 	password,
 	mnemonic,
 	network,
-}: ICreateLightningWallet): Promise<Result<string, Error>> => {
+}: ICreateLightningWallet): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		const existsRes = await lnd.walletExists(network);
 		if (existsRes.isOk() && existsRes.value) {
-			return resolve(err(new Error('LND wallet already exists')));
+			return resolve(err('LND wallet already exists'));
 		}
 
 		let lndSeed: string[] = [];
@@ -110,7 +108,7 @@ export const createLightningWallet = ({
 export const unlockLightningWallet = ({
 	password,
 	network,
-}: IUnlockLightningWallet): Promise<Result<string, Error>> => {
+}: IUnlockLightningWallet): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		const stateRes = await lnd.currentState();
 		if (stateRes.isOk() && stateRes.value.grpcReady) {
@@ -120,7 +118,7 @@ export const unlockLightningWallet = ({
 
 		const existsRes = await lnd.walletExists(network);
 		if (existsRes.isOk() && !existsRes.value) {
-			return resolve(err(new Error('LND wallet does not exist')));
+			return resolve(err('LND wallet does not exist'));
 		}
 
 		const unlockRes = await lnd.unlockWallet(password);
@@ -142,7 +140,7 @@ export const unlockLightningWallet = ({
  * Updates the lightning store with the latest state of LND
  * @returns {(dispatch) => Promise<unknown>}
  */
-export const refreshLightningState = (): Promise<Result<string, Error>> => {
+export const refreshLightningState = (): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		const res = await lnd.currentState();
 		if (res.isErr()) {
@@ -161,7 +159,7 @@ export const refreshLightningState = (): Promise<Result<string, Error>> => {
  * Updates the lightning store with the latest GetInfo response from LND
  * @returns {(dispatch) => Promise<unknown>}
  */
-export const refreshLightningInfo = (): Promise<Result<string, Error>> => {
+export const refreshLightningInfo = (): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		const res = await lnd.getInfo();
 		if (res.isErr()) {
@@ -181,9 +179,7 @@ export const refreshLightningInfo = (): Promise<Result<string, Error>> => {
  * TODO: Should be removed when on chain wallet is ready to replace the built in LND wallet
  * @returns {(dispatch) => Promise<unknown>}
  */
-export const refreshLightningOnChainBalance = (): Promise<
-	Result<string, Error>
-> => {
+export const refreshLightningOnChainBalance = (): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		const res = await lnd.getWalletBalance();
 		if (res.isErr()) {
@@ -198,7 +194,7 @@ export const refreshLightningOnChainBalance = (): Promise<
 	});
 };
 
-export const refreshLightningInvoices = (): Promise<Result<string, Error>> => {
+export const refreshLightningInvoices = (): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		//TODO we might need to optimise with pagination later using indexOffset and numMaxInvoices
 		const res = await lnd.listInvoices();
@@ -218,9 +214,7 @@ export const refreshLightningInvoices = (): Promise<Result<string, Error>> => {
  * Updates the lightning store with the latest ChannelBalance response from LND
  * @returns {(dispatch) => Promise<unknown>}
  */
-export const refreshLightningChannelBalance = (): Promise<
-	Result<string, Error>
-> => {
+export const refreshLightningChannelBalance = (): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		const res = await lnd.getChannelBalance();
 		if (res.isErr()) {
@@ -325,7 +319,7 @@ const pollLndGetInfo = async (): Promise<void> => {
  */
 export const payLightningInvoice = (
 	invoice: string,
-): Promise<Result<string, Error>> => {
+): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		const res = await lnd.payInvoice(invoice);
 		if (res.isErr()) {

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -21,7 +21,7 @@ import {
 
 const dispatch = getDispatch();
 
-export const updateWallet = (payload): Promise<Result<string, Error>> => {
+export const updateWallet = (payload): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		await dispatch({
 			type: actions.UPDATE_WALLET,
@@ -37,16 +37,14 @@ export const createWallet = ({
 	changeAddressAmount = 2,
 	mnemonic = '',
 	keyDerivationPath = '84',
-}: ICreateWallet): Promise<Result<string, Error>> => {
+}: ICreateWallet): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		try {
 			const getMnemonicPhraseResponse = await getMnemonicPhrase(wallet);
 			const { error, data } = getMnemonicPhraseResponse;
 			const { wallets } = getStore().wallet;
 			if (!error && data && wallet in wallets) {
-				return resolve(
-					err(new Error(`Wallet ID, "${wallet}" already exists.`)),
-				);
+				return resolve(err(`Wallet ID, "${wallet}" already exists.`));
 			}
 
 			//Generate Mnemonic if none was provided
@@ -54,7 +52,7 @@ export const createWallet = ({
 				mnemonic = validateMnemonic(data) ? data : await generateMnemonic();
 			}
 			if (!validateMnemonic(mnemonic)) {
-				return resolve(err(new Error('Invalid Mnemonic')));
+				return resolve(err('Invalid Mnemonic'));
 			}
 			await setKeychainValue({ key: wallet, value: mnemonic });
 
@@ -100,12 +98,12 @@ export const createWallet = ({
 
 			return resolve(ok(''));
 		} catch (e) {
-			return resolve(err(new Error(e)));
+			return resolve(err(e));
 		}
 	});
 };
 
-export const updateExchangeRate = (): Promise<Result<string, Error>> => {
+export const updateExchangeRate = (): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		const settings = getStore().settings;
 		const { selectedCurrency, exchangeRateService } = settings;
@@ -120,12 +118,12 @@ export const updateExchangeRate = (): Promise<Result<string, Error>> => {
 			});
 			resolve(ok('Successfully updated the exchange rate.'));
 		} else {
-			resolve(err(new Error('Unable to acquire exchange rate data.')));
+			resolve(err('Unable to acquire exchange rate data.'));
 		}
 	});
 };
 
-export const updateAddressIndexes = (): Promise<Result<string, string>> => {
+export const updateAddressIndexes = (): Promise<Result<string>> => {
 	return new Promise(async (resolve) => {
 		const response = await getNextAvailableAddress({});
 		if (response.isErr()) {
@@ -160,7 +158,7 @@ export const addAddresses = ({
 	selectedNetwork = EWallet.selectedNetwork,
 	keyDerivationPath = EWallet.keyDerivationPath,
 	addressType = EWallet.addressType,
-}: IGenerateAddresses): Promise<Result<IGenerateAddressesResponse, Error>> => {
+}: IGenerateAddresses): Promise<Result<IGenerateAddressesResponse>> => {
 	return new Promise(async (resolve) => {
 		const generatedAddresses = await generateAddresses({
 			addressAmount,

--- a/src/utils/result.ts
+++ b/src/utils/result.ts
@@ -1,27 +1,27 @@
-export type Result<T, E> = Ok<T, E> | Err<T, E>;
+export type Result<T> = Ok<T> | Err<T>;
 
-export class Ok<T, E> {
+export class Ok<T> {
 	public constructor(public readonly value: T) {}
 
-	public isOk(): this is Ok<T, E> {
+	public isOk(): this is Ok<T> {
 		return true;
 	}
 
-	public isErr(): this is Err<T, E> {
+	public isErr(): this is Err<T> {
 		return false;
 	}
 }
 
-export class Err<T, E> {
-	public constructor(public readonly error: E) {
+export class Err<T> {
+	public constructor(public readonly error: Error) {
 		console.error(error);
 	}
 
-	public isOk(): this is Ok<T, E> {
+	public isOk(): this is Ok<T> {
 		return false;
 	}
 
-	public isErr(): this is Err<T, E> {
+	public isErr(): this is Err<T> {
 		return true;
 	}
 }
@@ -29,9 +29,15 @@ export class Err<T, E> {
 /**
  * Construct a new Ok result value.
  */
-export const ok = <T, E>(value: T): Ok<T, E> => new Ok(value);
+export const ok = <T>(value: T): Ok<T> => new Ok(value);
 
 /**
  * Construct a new Err result value.
  */
-export const err = <T, E>(error: E): Err<T, E> => new Err(error);
+export const err = <T>(error: Error | string): Err<T> => {
+	if (typeof error === 'string') {
+		return new Err(new Error(error));
+	}
+
+	return new Err(error);
+};

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -51,7 +51,7 @@ export const generateAddresses = async ({
 	selectedNetwork = EWallet.selectedNetwork,
 	keyDerivationPath = EWallet.keyDerivationPath,
 	addressType = EWallet.addressType,
-}: IGenerateAddresses): Promise<Result<IGenerateAddressesResponse, Error>> => {
+}: IGenerateAddresses): Promise<Result<IGenerateAddressesResponse>> => {
 	return new Promise(async (resolve) => {
 		try {
 			const networkTypePath =
@@ -59,7 +59,7 @@ export const generateAddresses = async ({
 			const network = networks[selectedNetwork];
 			const getMnemonicPhraseResponse = await getMnemonicPhrase(wallet);
 			if (getMnemonicPhraseResponse.error) {
-				return resolve(err(new Error(getMnemonicPhraseResponse.data)));
+				return resolve(err(getMnemonicPhraseResponse.data));
 			}
 
 			//Attempt to acquire the bip39Passphrase if available
@@ -118,7 +118,7 @@ export const generateAddresses = async ({
 			return resolve(ok({ addresses, changeAddresses }));
 		} catch (e) {
 			console.log(e);
-			return resolve(err(new Error(e)));
+			return resolve(err(e));
 		}
 	});
 };
@@ -441,7 +441,7 @@ export const getNextAvailableAddress = async ({
 	keyDerivationPath = '84',
 	addressType = 'bech32',
 }: IGetNextAvailableAddress): Promise<
-	Result<IGetNextAvailableAddressResponse, string>
+	Result<IGetNextAvailableAddressResponse>
 > => {
 	return new Promise(async (resolve) => {
 		const isConnected = await isOnline();
@@ -732,7 +732,7 @@ export const getHighestUsedIndexFromTxHashes = async ({
 	changeAddresses: IAddress | {};
 	addressIndex: IAddressContent;
 	changeAddressIndex: IAddressContent;
-}): Promise<Result<IIndexes, string>> => {
+}): Promise<Result<IIndexes>> => {
 	try {
 		let foundAddressIndex = false;
 		let foundChangeAddressIndex = false;
@@ -775,13 +775,10 @@ export const getHighestStoredAddressIndex = ({
 }: {
 	selectedWallet: string;
 	selectedNetwork: TAvailableNetworks;
-}): Result<
-	{
-		addressIndex: IAddressContent;
-		changeAddressIndex: IAddressContent;
-	},
-	string
-> => {
+}): Result<{
+	addressIndex: IAddressContent;
+	changeAddressIndex: IAddressContent;
+}> => {
 	try {
 		const wallet = getStore().wallet;
 		const addresses: IAddress =


### PR DESCRIPTION
- You can now return `err("This failed")` and an error will be created from that string. `err` accepts either strings or error types.
- No longer need to set the generic type as `Error`. Just set the return type of a successful result. Like this: `Result<string>`. 
- When `res.isErr() === true` then `res.error` will consistently be of type `error`.
- Also some eslint fixes for missing return types.