### PR TITLE
Paste from clipboard button on QR scanner

### DIFF
--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -7,9 +7,11 @@ import { systemWeights } from 'react-native-typography';
 const _Camera = ({
 	onBarCodeRead = (): null => null,
 	onClose = (): null => null,
+	children = undefined,
 }: {
 	onBarCodeRead: Function;
 	onClose: Function;
+	children?: ReactElement;
 }): ReactElement => {
 	const [_data, setData] = useState('');
 	const notAuthorizedView = (
@@ -50,8 +52,9 @@ const _Camera = ({
 					message: 'Spectrum needs permission to use your camera',
 					buttonPositive: 'Okay',
 					buttonNegative: 'Cancel',
-				}}
-			/>
+				}}>
+				<View style={styles.content}>{children}</View>
+			</RNCamera>
 		</View>
 	);
 };
@@ -64,6 +67,9 @@ const styles = StyleSheet.create({
 		height: '100%',
 		width: '100%',
 		zIndex: 1000,
+	},
+	content: {
+		flex: 1,
 	},
 	notAuthorizedView: {
 		flex: 1,

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,50 +1,52 @@
-import Toast from 'react-native-toast-message';
+import Toast, { ToastPosition } from 'react-native-toast-message';
 
 type AppNotification = {
 	title?: string;
 	message: string;
 };
 
-const topOffset = 40;
+const defaultOptions = {
+	autoHide: true,
+	visibilityTime: 4000,
+	topOffset: 40,
+	bottomOffset: 120,
+};
 
-export const showErrorNotification = ({
-	title = 'Something went wrong',
-	message,
-}: AppNotification): void => {
+export const showErrorNotification = (
+	{ title = 'Something went wrong', message }: AppNotification,
+	position: ToastPosition = 'top',
+): void => {
 	Toast.show({
 		type: 'error',
 		text1: title,
 		text2: message,
-		visibilityTime: 4000,
-		autoHide: true,
-		topOffset,
+		...defaultOptions,
+		position,
 	});
 };
 
-export const showSuccessNotification = ({
-	title = 'Success!',
-	message,
-}: AppNotification): void => {
+export const showSuccessNotification = (
+	{ title = 'Success!', message }: AppNotification,
+	position: ToastPosition = 'top',
+): void => {
 	Toast.show({
 		type: 'success',
 		text1: title,
 		text2: message,
-		visibilityTime: 4000,
-		autoHide: true,
-		topOffset,
+		...defaultOptions,
+		position,
 	});
 };
 
-export const showInfoNotification = ({
-	title = '',
-	message,
-}: AppNotification): void => {
+export const showInfoNotification = (
+	{ title = '', message }: AppNotification,
+	position: ToastPosition = 'top',
+): void => {
 	Toast.show({
 		type: 'info',
 		text1: title,
 		text2: message,
-		visibilityTime: 6000,
-		autoHide: true,
-		topOffset,
+		...defaultOptions,
+		position,
 	});
 };

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -73,6 +73,7 @@ export interface QRData {
 
 /**
  * Return all networks and their payment request details if found in QR data.
+ * Can also be used to read clipboard data for any addresses or payment requests.
  * @param data
  * @returns {string}
  */


### PR DESCRIPTION
- Button on the QR scanner that allows the user to paste from clipboard if they have any addresses or payment requests copied. Useful for simulator testing. 
- Showing some toast notifications at the bottom of the screen else you can't see them with the iOS 14 clipboard warnings.

 I don't think we should ever automatically check their clipboard on iOS as those iOS 14 clipboard warnings really freak people out when they didn't initiate the check. We could probably work in a different experience on Android though.