### PR TITLE
Lightning import fixes

### DIFF
--- a/__mocks__/react-native-lightning.ts
+++ b/__mocks__/react-native-lightning.ts
@@ -20,4 +20,11 @@ class LND {
 	}
 }
 
+import LndConf from 'react-native-lightning/dist/lnd.conf';
+
+export { LndConf };
+export * from 'react-native-lightning/dist/types';
+export * from 'react-native-lightning/dist/rpc';
+
 export default new LND();
+

--- a/__tests__/activity.ts
+++ b/__tests__/activity.ts
@@ -4,7 +4,7 @@ import {
 	updateSearchFilter,
 	updateTypesFilter,
 } from '../src/store/actions/activity';
-import { lnrpc } from 'react-native-lightning/dist/rpc';
+import { lnrpc } from 'react-native-lightning';
 import { getDispatch, getStore } from '../src/store/helpers';
 import { EActivityTypes } from '../src/store/types/activity';
 import { IFormattedTransaction } from '../src/store/types/wallet';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,8 +19,7 @@ import {
 	createLightningWallet,
 	unlockLightningWallet,
 } from './store/actions/lightning';
-import { ENetworks as LndNetworks } from 'react-native-lightning/dist/types';
-import lnd from 'react-native-lightning';
+import lnd, { ENetworks as LndNetworks } from 'react-native-lightning';
 import Toast from 'react-native-toast-message';
 import { connectToElectrum, refreshWallet } from './utils/wallet';
 import './utils/translations';

--- a/src/store/actions/lightning.ts
+++ b/src/store/actions/lightning.ts
@@ -4,16 +4,17 @@ import {
 	IUnlockLightningWallet,
 } from '../types/lightning';
 import { getDispatch } from '../helpers';
-import lnd from 'react-native-lightning';
-import LndConf from 'react-native-lightning/dist/lnd.conf';
-import { ENetworks as LndNetworks } from 'react-native-lightning/dist/types';
+import lnd, {
+	lnrpc,
+	LndConf,
+	ENetworks as LndNetworks,
+} from 'react-native-lightning';
 import { connectToDefaultPeer, getCustomLndConf } from '../../utils/lightning';
 import { err, ok, Result } from '../../utils/result';
 import {
 	showErrorNotification,
 	showSuccessNotification,
 } from '../../utils/notifications';
-import { lnrpc } from 'react-native-lightning/dist/rpc';
 import { updateLightingActivityList } from './activity';
 
 const dispatch = getDispatch();

--- a/src/store/reducers/lightning.ts
+++ b/src/store/reducers/lightning.ts
@@ -1,7 +1,7 @@
 import actions from '../actions/actions';
 import { ILightning } from '../types/lightning';
 import { defaultLightningShape } from '../shapes/lightning';
-import { lnrpc } from 'react-native-lightning/dist/rpc';
+import { lnrpc } from 'react-native-lightning';
 
 const lightning = (state: ILightning, action): ILightning => {
 	switch (action.type) {

--- a/src/store/shapes/lightning.ts
+++ b/src/store/shapes/lightning.ts
@@ -1,5 +1,5 @@
 import { ILightning } from '../types/lightning';
-import { lnrpc } from 'react-native-lightning/dist/rpc';
+import { lnrpc } from 'react-native-lightning';
 
 export const defaultLightningShape: ILightning = {
 	syncProgress: 0,

--- a/src/store/types/lightning.ts
+++ b/src/store/types/lightning.ts
@@ -1,6 +1,8 @@
-import { lnrpc } from 'react-native-lightning/dist/rpc';
-import { TCurrentLndState } from 'react-native-lightning/src/lightning/types';
-import { ENetworks as LndNetworks } from 'react-native-lightning/dist/types';
+import {
+	lnrpc,
+	TCurrentLndState,
+	ENetworks as LndNetworks,
+} from 'react-native-lightning';
 
 export interface ILightning {
 	syncProgress: number;

--- a/src/utils/activity/index.ts
+++ b/src/utils/activity/index.ts
@@ -1,4 +1,4 @@
-import { lnrpc } from 'react-native-lightning/dist/rpc';
+import { lnrpc } from 'react-native-lightning';
 import { EActivityTypes, IActivityItem } from '../../store/types/activity';
 import { IFormattedTransaction } from '../../store/types/wallet';
 

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -2,18 +2,16 @@
  * Test functions for lightning development to be used until UX is finalized.
  */
 
-import lnd from 'react-native-lightning';
-import {
+import lnd, {
 	ENetworks as LndNetworks,
 	TLndConf,
-} from 'react-native-lightning/dist/types';
+	lnrpc,
+} from 'react-native-lightning';
 import { Platform } from 'react-native';
 import Clipboard from '@react-native-community/clipboard';
 import { ILightning } from '../../store/types/lightning';
 import { getStore } from '../../store/helpers';
 import { err, ok, Result } from '../result';
-import { lnrpc } from 'react-native-lightning/dist/rpc';
-
 const packageJson = require('../../../package.json');
 
 const defaultNodePubKey =


### PR DESCRIPTION
Index in [react-native-lightning](https://github.com/synonymdev/react-native-lightning) now exports other types, so they no longer need to be imported from `react-native-lightning/dist`.