### PR TITLE
Unit test fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ android/*
 metro.config.js
 postinstall.js
 __mocks__/**
+coverage

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   tests:
     name: Run jest unit tests
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - name: Check out Git repository

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -1,6 +1,12 @@
-name: Tests
+name: tests
 
-on: pull_request
+on:
+  pull_request:
+    branches:
+      - 'master'
+  push:
+    branches:
+      - 'master'
 
 jobs:
   tests:

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -1,4 +1,4 @@
-name: Lint check
+name: elint-check
 
 on: pull_request
 

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ buck-out/
 /ios/Pods/
 ios/spectrum/lightning/Lndmobile.framework/
 android/Lndmobile/Lndmobile.aar
+coverage

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Spectrum
 
+[![Test status](https://github.com/synonymdev/spectrum/workflows/tests/badge.svg)](https://github.com/synonymdev/spectrum/actions)
+
 ### Installation
 1. Clone Spectrum & Install Dependencies:
     - `git clone git@github.com:synonymdev/spectrum.git`

--- a/__tests__/scanner.ts
+++ b/__tests__/scanner.ts
@@ -39,7 +39,6 @@ describe('QR codes', () => {
 			expect(qrData.network).toEqual('bitcoin');
 			expect(qrData.qrDataType).toEqual('bitcoinAddress');
 			expect(qrData.sats).toEqual(50000);
-			expect(qrData.label).toEqual('Nakamoto');
 			expect(qrData.message).toEqual('Donation for project xyz');
 		}
 	});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",
+    "test:coverage": "jest --coverage=true",
     "lint:check": "eslint . --ext .js,.jsx,.ts,.tsx",
     "lint:fix": "eslint . --fix --ext .js,.jsx,.ts,.tsx",
     "postinstall": "node postinstall.js",

--- a/src/screens/Activity/ActivityDetail.tsx
+++ b/src/screens/Activity/ActivityDetail.tsx
@@ -10,15 +10,7 @@ interface Props extends PropsWithChildren<any> {
 
 const ActivityDetail = (props: Props): ReactElement => {
 	const {
-		activityItem: {
-			id,
-			message,
-			activityType,
-			txType,
-			value,
-			confirmed,
-			fee,
-		},
+		activityItem: { id, message, activityType, txType, value, confirmed, fee },
 	} = props.route.params;
 
 	return (

--- a/src/screens/Activity/ActivityDetail.tsx
+++ b/src/screens/Activity/ActivityDetail.tsx
@@ -12,7 +12,7 @@ const ActivityDetail = (props: Props): ReactElement => {
 	const {
 		activityItem: {
 			id,
-			description,
+			message,
 			activityType,
 			txType,
 			value,
@@ -29,7 +29,7 @@ const ActivityDetail = (props: Props): ReactElement => {
 				<Text>
 					Type: {activityType} {txType}
 				</Text>
-				<Text>Description: {description}</Text>
+				<Text>Message: {message}</Text>
 				<Text>Value: {value}</Text>
 				<Text>Confirmed: {confirmed ? '✅' : '⌛'}</Text>
 				{fee ? <Text>Fee: {fee}</Text> : null}

--- a/src/screens/Activity/index.tsx
+++ b/src/screens/Activity/index.tsx
@@ -21,7 +21,7 @@ const ListItem = ({
 	onPress: () => void;
 }): ReactElement => {
 	const {
-		description,
+		message,
 		value,
 		activityType,
 		txType,
@@ -35,7 +35,7 @@ const ListItem = ({
 				<Text>
 					{activityType} - {txType}
 				</Text>
-				<Text>{description}</Text>
+				<Text>{message}</Text>
 				<Text>Date: {new Date(timestamp).toString()}</Text>
 			</View>
 			<View>

--- a/src/screens/Activity/index.tsx
+++ b/src/screens/Activity/index.tsx
@@ -20,14 +20,7 @@ const ListItem = ({
 	item: IActivityItem;
 	onPress: () => void;
 }): ReactElement => {
-	const {
-		message,
-		value,
-		activityType,
-		txType,
-		confirmed,
-		timestamp,
-	} = item;
+	const { message, value, activityType, txType, confirmed, timestamp } = item;
 
 	return (
 		<TouchableOpacity style={styles.item} onPress={onPress}>

--- a/src/screens/Scanner/index.tsx
+++ b/src/screens/Scanner/index.tsx
@@ -40,15 +40,14 @@ const ScannerScreen = ({ navigation }): ReactElement => {
 
 		switch (data.qrDataType) {
 			case EQRDataType.bitcoinAddress: {
-				const { address, sats: amount, message, label, network } = data;
+				const { address, sats: amount, message, network } = data;
 				updateOnChainTransaction({
 					selectedNetwork,
 					selectedWallet,
 					transaction: {
 						address,
 						amount,
-						message,
-						label,
+						label: message,
 					},
 				});
 				//Switch networks if necessary.

--- a/src/store/types/activity.ts
+++ b/src/store/types/activity.ts
@@ -10,7 +10,7 @@ export interface IActivityItem {
 	id: string;
 	value: number;
 	fee?: number; //If receiving we might not know the fee
-	description: string;
+	message: string;
 	activityType: EActivityTypes;
 	txType: TTransactionType;
 	confirmed: boolean;

--- a/src/utils/activity/index.ts
+++ b/src/utils/activity/index.ts
@@ -8,7 +8,8 @@ import { IFormattedTransaction } from '../../store/types/wallet';
  * @param settled
  * @param value
  * @param memo
- * @returns {{fee: number, description: string, id: string, type: EActivityTypes, confirmed: boolean, value: number}}
+ * @returns {{fee: number, id: string, txType: "received", activityType: EActivityTypes, message: string, confirmed: boolean, value: number, timestamp: number}}
+ * @param creationDate
  */
 export const lightningInvoiceToActivityItem = ({
 	rHash,
@@ -23,23 +24,23 @@ export const lightningInvoiceToActivityItem = ({
 	confirmed: settled ?? false,
 	value: Number(value),
 	fee: 0,
-	description: memo ?? '',
+	message: memo ?? '',
 	timestamp: Number(creationDate) * 1000,
 });
 
 /**
  * Converts lightning payment to activity item
+ * @returns {{fee: number, id: string, txType: "sent", activityType: EActivityTypes, message: string, confirmed: boolean, value: number, timestamp: number}}
+ * @param memo
  * @param paymentHash
  * @param status
  * @param value
  * @param fee
  * @param creationDate
- * @param description
- * @returns {{fee: number, description: string, id: string, txType: "sent", activityType: EActivityTypes, confirmed: boolean, value: number, timestamp: number}}
  */
 export const lightningPaymentToActivityItem = (
 	{ paymentHash, status, value, fee, creationDate }: lnrpc.IPayment,
-	description: string,
+	memo: string,
 ): IActivityItem => {
 	return {
 		id: paymentHash ?? '',
@@ -48,7 +49,7 @@ export const lightningPaymentToActivityItem = (
 		confirmed: status === 2,
 		value: Number(value),
 		fee: Number(fee),
-		description,
+		message: memo,
 		timestamp: Number(creationDate) * 1000,
 	};
 };
@@ -78,7 +79,7 @@ export const onChainTransactionsToActivityItems = (
 			confirmed: height > 0,
 			value,
 			fee,
-			description: address, //TODO, we might need to have some sort of address labeling
+			message: address, //TODO, we might need to have some sort of address labeling
 			timestamp,
 		});
 	});
@@ -127,8 +128,8 @@ export const filterActivityItems = (
 	let filteredItems: IActivityItem[] = [];
 
 	items.forEach((item) => {
-		//If there is a search set and it's not found in the description then don't bother continuing
-		if (search && item.description.indexOf(search) === -1) {
+		//If there is a search set and it's not found in the message then don't bother continuing
+		if (search && item.message.indexOf(search) === -1) {
 			return;
 		}
 

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -107,7 +107,7 @@ export const decodeQRData = async (data: string): Promise<Result<QRData[]>> => {
 		if (onChainParseResponse.isOk()) {
 			const {
 				address,
-				amount,
+				sats,
 				message,
 				label,
 				network,
@@ -116,7 +116,7 @@ export const decodeQRData = async (data: string): Promise<Result<QRData[]>> => {
 				qrDataType: EQRDataType.bitcoinAddress,
 				address,
 				network,
-				sats: amount,
+				sats,
 				label,
 				message,
 			});

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -70,7 +70,6 @@ export interface QRData {
 	sats?: number | Long;
 	address?: string;
 	lightningPaymentRequest?: string;
-	label?: string;
 	message?: string;
 }
 
@@ -105,19 +104,12 @@ export const decodeQRData = async (data: string): Promise<Result<QRData[]>> => {
 	try {
 		const onChainParseResponse = parseOnChainPaymentRequest(data);
 		if (onChainParseResponse.isOk()) {
-			const {
-				address,
-				sats,
-				message,
-				label,
-				network,
-			} = onChainParseResponse.value;
+			const { address, sats, message, network } = onChainParseResponse.value;
 			foundNetworksInQR.push({
 				qrDataType: EQRDataType.bitcoinAddress,
 				address,
 				network,
 				sats,
-				label,
 				message,
 			});
 		}

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -27,7 +27,7 @@ export const parseOnChainPaymentRequest = (
 ): Result<{
 	address: string;
 	network: TAvailableNetworks;
-	amount: number;
+	sats: number;
 	message: string;
 	label: string;
 }> => {
@@ -44,7 +44,7 @@ export const parseOnChainPaymentRequest = (
 			return ok({
 				address: data,
 				network: validateAddressResult.network,
-				amount: 0,
+				sats: 0,
 				message: '',
 				label: '',
 			});
@@ -81,7 +81,7 @@ export const parseOnChainPaymentRequest = (
 				return ok({
 					address,
 					network: validateAddressResult.network,
-					amount,
+					sats: amount * 100000000,
 					message,
 					label: message,
 				});

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -79,7 +79,7 @@ export const parseOnChainPaymentRequest = (
 				return ok({
 					address,
 					network: validateAddressResult.network,
-					sats: amount * 100000000,
+					sats: Number((amount * 100000000).toFixed(0)),
 					message,
 				});
 			} catch {

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -29,7 +29,6 @@ export const parseOnChainPaymentRequest = (
 	network: TAvailableNetworks;
 	sats: number;
 	message: string;
-	label: string;
 }> => {
 	try {
 		if (!data) {
@@ -46,7 +45,6 @@ export const parseOnChainPaymentRequest = (
 				network: validateAddressResult.network,
 				sats: 0,
 				message: '',
-				label: '',
 			});
 		}
 
@@ -83,7 +81,6 @@ export const parseOnChainPaymentRequest = (
 					network: validateAddressResult.network,
 					sats: amount * 100000000,
 					message,
-					label: message,
 				});
 			} catch {
 				return err(data);


### PR DESCRIPTION
- Test coverage command
- Tests running on MacOS for consistency. Ubuntu was causing some issues with mock dependencies.

Once the tests were actually running properly it picked up some issues I also fixed in this PR. 

The first one was parsing a on chain payment request. 

```
Expected: 50000
Received: 0.0005
```

I made `QRData` use sats but `parseOnChainPaymentRequest` returned the bitcoin amount. I changed it to use sats as the base unit. I figured because LND is using sats consistently we should probably do the same so there's never any confusion on the unit being used under hood. And then right before it's displayed in the UI we convert it to whatever. 

The second failed test was to do with the message/label not getting the expected result from `parseOnChainPaymentRequest`. Originally I added both `message` and `label` to `QRData` because of BIP21. But seems like all apps only use the message field so I guess we can just stick with `message` everywhere for now?