### PR TITLE
Get RBF Data By tx_hash

### DIFF
--- a/src/screens/Wallets/BitcoinCard.tsx
+++ b/src/screens/Wallets/BitcoinCard.tsx
@@ -34,8 +34,8 @@ const BitcoinCard = (): ReactElement => {
 	);
 	const receiveAddress = useSelector(
 		(state: Store) =>
-			state.wallet.wallets[selectedWallet].addressIndex[selectedNetwork]
-				.address,
+			state.wallet.wallets[selectedWallet]?.addressIndex[selectedNetwork]
+				?.address || '',
 	);
 	const exchangeRate = useSelector((state: Store) => state.wallet.exchangeRate);
 	const bitcoinUnit = useSelector((state: Store) => state.settings.bitcoinUnit);

--- a/src/screens/Wallets/SendOnChainTransaction.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction.tsx
@@ -197,7 +197,7 @@ const SendOnChainTransaction = ({
 				if (__DEV__) {
 					console.log(response.value);
 				}
-				setRawTx(response.value.rawTx);
+				setRawTx(response.value);
 			}
 		} catch {}
 	};

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -70,6 +70,11 @@ export interface IUtxo {
 	value: number;
 }
 
+export interface IOutput {
+	address?: string; //Address to send to.
+	value?: number | Long; //Amount denominated in sats.
+}
+
 export interface IFormattedTransaction {
 	[key: string]: {
 		address: string;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -147,6 +147,14 @@ export const getFiatBalance = ({
 	}
 };
 
+export const btcToSats = (balance = 0): number => {
+	try {
+		return bitcoinUnits(balance, 'BTC').to('satoshi').value();
+	} catch (e) {
+		return 0;
+	}
+};
+
 export const getLastWordInString = (phrase = ''): string => {
 	try {
 		const n = phrase.split(' ');

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -309,12 +309,7 @@ export const createTransaction = ({
 	selectedNetwork = 'bitcoin',
 	message = '', //OP_RETURN message.
 	addressType = 'bech32',
-}: ICreateTransaction): Promise<
-	Result<{
-		rawTx: string;
-		rbfData: ICreateTransaction;
-	}>
-> => {
+}: ICreateTransaction): Promise<Result<string>> => {
 	const { currentWallet, selectedWallet } = getCurrentWallet({
 		selectedNetwork,
 		selectedWallet: wallet,
@@ -374,23 +369,6 @@ export const createTransaction = ({
 				});
 				targets.push({ script: embed.output!, value: 0 });
 			}
-
-			//Setup rbfData (Replace-By-Fee Data) for later use.
-			/*
-			 * TODO: Remove the need to save rbf data here. Create an independent function that will fetch rbf data if possible for any tx.
-			 */
-			let rbfData: ICreateTransaction = {
-				address,
-				fee,
-				amount,
-				balance,
-				utxos,
-				changeAddress,
-				wallet: selectedWallet,
-				selectedNetwork,
-				message,
-				addressType,
-			};
 
 			const getMnemonicPhraseResult = await getMnemonicPhrase(selectedWallet);
 			if (getMnemonicPhraseResult.error) {
@@ -475,7 +453,7 @@ export const createTransaction = ({
 			});
 			psbt.finalizeAllInputs();
 			const rawTx = psbt.extractTransaction().toHex();
-			return resolve(ok({ rawTx, rbfData }));
+			return resolve(ok(rawTx));
 		} catch (e) {
 			return resolve(err(e));
 		}


### PR DESCRIPTION
This adds the `getRbfData` method that will return the necessary information to create a replace-by-fee transaction for any 0-conf, RBF-enabled transaction.