### PR TITLE
Derivation Path Upgrade

### DIFF
--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -6,6 +6,7 @@ import {
 	IAddressContent,
 	IOnChainTransactionData,
 	defaultOnChainTransactionData,
+	IKeyDerivationPath,
 } from '../types/wallet';
 
 export const onChainTransaction: IWalletItem<IOnChainTransactionData> = {
@@ -45,6 +46,14 @@ export const addressIndex: IWalletItem<IAddressContent> = {
 	timestamp: null,
 };
 
+export const defaultKeyDerivationPath: IKeyDerivationPath = {
+	purpose: '84',
+	coinType: '0',
+	account: '0',
+	change: '0',
+	addressIndex: '0',
+};
+
 export const defaultWalletShape: IDefaultWalletShape = {
 	id: '',
 	name: '',
@@ -61,8 +70,11 @@ export const defaultWalletShape: IDefaultWalletShape = {
 	hasBackedUpWallet: false,
 	walletBackupTimestamp: '',
 	keyDerivationPath: {
-		bitcoin: '84',
-		bitcoinTestnet: '84',
+		bitcoin: defaultKeyDerivationPath,
+		bitcoinTestnet: {
+			...defaultKeyDerivationPath,
+			coinType: '0',
+		},
 	},
 	networkTypePath: {
 		bitcoin: '0',

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -1,8 +1,12 @@
 import { TAvailableNetworks } from '../../utils/networks';
 
 export type TAddressType = 'bech32' | 'segwit' | 'legacy'; //"84" | "49" | "44";
-
-export type TKeyDerivationPath = '84' | '49' | '44'; //"bech32" | "segwit" | "legacy";
+export type TKeyDerivationAccountType = 'onchain' | 'rgb' | 'omnibolt';
+export type TKeyDerivationPurpose = '84' | '49' | '44'; //"bech32" | "segwit" | "legacy";
+export type TKeyDerivationCoinType = '0' | '1'; //"mainnet" | "testnet";
+export type TKeyDerivationAccount = '0' | '2' | '3'; //"On-Chain Wallet" | "RGB" | "Omnibolt";
+export type TKeyDerivationChange = '0' | '1'; //"Receiving Address" | "Change Address";
+export type TKeyDerivationAddressIndex = string; //"bech32" | "segwit" | "legacy";
 
 export type NetworkTypePath = '0' | '1'; //"mainnet" | "testnet"
 
@@ -20,7 +24,6 @@ export enum EWallet {
 	selectedNetwork = 'bitcoin',
 	defaultWallet = 'wallet0',
 	aezeedPassphrase = 'shhhhhhhh123',
-	keyDerivationPath = '84',
 	addressType = 'bech32',
 }
 
@@ -28,6 +31,21 @@ export enum EOutput {
 	address = '',
 	value = 0,
 	index = 0,
+}
+
+export enum EKeyDerivationAccount {
+	onchain = 0,
+	rgb = 2,
+	omnibolt = 3,
+}
+
+// m / purpose' / coin_type' / account' / change / address_index
+export interface IKeyDerivationPath {
+	purpose: TKeyDerivationPurpose;
+	coinType: TKeyDerivationCoinType;
+	account: TKeyDerivationAccount;
+	change: TKeyDerivationChange;
+	addressIndex: TKeyDerivationAddressIndex;
 }
 
 export interface IWallet {
@@ -59,11 +77,11 @@ export interface IAddress {
 }
 
 export interface ICreateWallet {
-	wallet?: string;
+	walletName?: string;
 	mnemonic?: string;
 	addressAmount?: number;
 	changeAddressAmount?: number;
-	keyDerivationPath?: TKeyDerivationPath;
+	keyDerivationPath?: IKeyDerivationPath;
 	addressType?: TAddressType;
 }
 
@@ -133,9 +151,9 @@ export interface IDefaultWalletShape {
 	id: string;
 	name: string;
 	type: string;
-	addresses: IWalletItem<IAddressContent> | IWalletItem<{}>;
+	addresses: IWalletItem<IAddress> | IWalletItem<{}>;
 	addressIndex: IWalletItem<IAddressContent>;
-	changeAddresses: IWalletItem<IAddressContent> | IWalletItem<{}>;
+	changeAddresses: IWalletItem<IAddress> | IWalletItem<{}>;
 	changeAddressIndex: IWalletItem<IAddressContent>;
 	utxos: IWalletItem<IUtxo> | IWalletItem<[]>;
 	transactions: IWalletItem<IFormattedTransaction> | IWalletItem<{}>;
@@ -144,7 +162,7 @@ export interface IDefaultWalletShape {
 	lastUpdated: IWalletItem<number>;
 	hasBackedUpWallet: boolean;
 	walletBackupTimestamp: string;
-	keyDerivationPath: IWalletItem<TKeyDerivationPath>;
+	keyDerivationPath: IWalletItem<IKeyDerivationPath>;
 	networkTypePath: IWalletItem<string>;
 	addressType: {
 		bitcoin: TAddressType;

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -6,7 +6,7 @@ export type TKeyDerivationPurpose = '84' | '49' | '44'; //"bech32" | "segwit" | 
 export type TKeyDerivationCoinType = '0' | '1'; //"mainnet" | "testnet";
 export type TKeyDerivationAccount = '0' | '2' | '3'; //"On-Chain Wallet" | "RGB" | "Omnibolt";
 export type TKeyDerivationChange = '0' | '1'; //"Receiving Address" | "Change Address";
-export type TKeyDerivationAddressIndex = string; //"bech32" | "segwit" | "legacy";
+export type TKeyDerivationAddressIndex = string;
 
 export type NetworkTypePath = '0' | '1'; //"mainnet" | "testnet"
 

--- a/src/utils/backup/backup.ts
+++ b/src/utils/backup/backup.ts
@@ -3,11 +3,7 @@ import { err, ok, Result } from '../result';
 import { getStore } from '../../store/helpers';
 import { getKeychainValue } from '../helpers';
 import { createDefaultWallet } from '../wallet';
-import {
-	IDefaultWalletShape,
-	TAddressType,
-	TKeyDerivationPath,
-} from '../../store/types/wallet';
+import { IDefaultWalletShape, TAddressType } from '../../store/types/wallet';
 import { backpackRetrieve, backpackStore } from './backpack';
 import { bytesToHexString } from '../converters';
 
@@ -98,11 +94,12 @@ export const restoreFromBackup = async (
 			}
 
 			await createDefaultWallet({
-				wallet: key!,
+				walletName: key!,
 				addressAmount: 2,
 				changeAddressAmount: 2,
 				mnemonic: mnemonic!,
-				keyDerivationPath: keyDerivationPath as TKeyDerivationPath,
+				// @ts-ignore
+				keyDerivationPath,
 				addressType,
 			});
 		}

--- a/src/utils/backup/protos/scheme.proto
+++ b/src/utils/backup/protos/scheme.proto
@@ -14,7 +14,17 @@ message Wallet {
   string key = 1; //e.g. wallet0, wallet1
   string mnemonic = 2; //24 word seed phrase
   string passphrase = 3; //seed passphrase
-  string keyDerivationPath = 4; //Usually 84
+
+  message KeyDerivationPath {
+    string purpose = 1;
+    string coinType = 2;
+    string account = 3;
+    string change = 4;
+    string addressIndex = 5;
+  }
+
+  KeyDerivationPath keyDerivationPath = 4;
+
 
   enum AddressType {
     bech32 = 0;

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -3,7 +3,8 @@ import { TAvailableNetworks, INetwork } from '../networks';
 import {
 	TAddressType,
 	IAddress,
-	TKeyDerivationPath,
+	IKeyDerivationPath,
+	TKeyDerivationAccountType,
 } from '../../store/types/wallet';
 
 export interface IResponse<T> {
@@ -34,13 +35,14 @@ export interface IGetInfoFromAddressPath {
 }
 
 export interface IGenerateAddresses {
-	wallet: string;
+	selectedWallet: string;
 	addressAmount?: number;
 	changeAddressAmount?: number;
 	addressIndex?: number;
 	changeAddressIndex?: number;
 	selectedNetwork?: TAvailableNetworks;
-	keyDerivationPath?: TKeyDerivationPath;
+	keyDerivationPath?: IKeyDerivationPath;
+	accountType?: TKeyDerivationAccountType;
 	addressType?: TAddressType;
 }
 

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -35,13 +35,13 @@ export interface IGetInfoFromAddressPath {
 }
 
 export interface IGenerateAddresses {
-	selectedWallet: string;
+	selectedWallet?: string | undefined;
 	addressAmount?: number;
 	changeAddressAmount?: number;
 	addressIndex?: number;
 	changeAddressIndex?: number;
-	selectedNetwork?: TAvailableNetworks;
-	keyDerivationPath?: IKeyDerivationPath;
+	selectedNetwork?: TAvailableNetworks | undefined;
+	keyDerivationPath?: IKeyDerivationPath | undefined;
 	accountType?: TKeyDerivationAccountType;
 	addressType?: TAddressType;
 }


### PR DESCRIPTION
This PR makes the key derivation path much more granular. Allowing us to tweak each path as needed moving forward. The new format is as follows:

```
interface IKeyDerivationPath {
	purpose: '84' | '49' | '44'; //"bech32" | "segwit" | "legacy";
	coinType: '0' | '1'; //"mainnet" | "testnet";
	account: '0' | '2' | '3'; //"On-Chain Wallet" | "RGB" | "Omnibolt";
	change: '0' | '1'; //"Receiving Address" | "Change Address";
	addressIndex: string; //'0' | '1' | '2' | '3', etc.
}
```