### PR TITLE
Automatically built release APKs

### DIFF
--- a/.github/workflows/release-apks.yml
+++ b/.github/workflows/release-apks.yml
@@ -1,0 +1,56 @@
+name: release
+
+on:
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  builds:
+    name: Build and upload release APK
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Install SSH key
+        uses: shimataro/ssh-key-action@v2
+        with:
+          key: ${{ secrets.TEST_USER_SSH_KEY }}
+          known_hosts: ${{ secrets.TEST_USER_KNOWN_HOSTS }}
+
+      - name: Install Node.js dependencies
+        run: yarn install
+
+      - name: Install Swig
+        run: brew install swig
+
+      - name: Build Android App Bundle
+        run: yarn bundle
+
+      - name: List APKs
+        run: |
+          ls android/app/build/outputs/apk/release
+
+      - name: Sign App Bundle
+        id: sign_app
+        uses: r0adkll/sign-android-release@v1
+        with:
+          releaseDirectory: android/app/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.ANDROID_SIGNING_KEY }}
+          alias: ${{ secrets.ANDROID_SIGNING_ALIAS }}
+          keyStorePassword: ${{ secrets.ANDROID_SIGNING_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Signed App Bundle
+          path: android/app/build/outputs/apk/release
+          if-no-files-found: error

--- a/ios/spectrum.xcodeproj/project.pbxproj
+++ b/ios/spectrum.xcodeproj/project.pbxproj
@@ -787,6 +787,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/spectrum/lightning",


### PR DESCRIPTION
All APKs are built and signed automatically for every push to master.

Right now these are just uploaded as an artifact for the workflow but once we start doing regular UI updates that need to be tested we can upload the APKs as a release asset and/or push to an alpha track on the store every time a release is tagged.