### PR TITLE
Updated react-native-lightning version in yarn.lock & Podfile.lock.

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -202,7 +202,7 @@ PODS:
     - React-Core
   - react-native-libsodium (0.0.1):
     - React-Core
-  - react-native-lightning (0.0.4):
+  - react-native-lightning (0.0.17):
     - React
     - SwiftProtobuf (~> 1.0)
   - react-native-netinfo (5.9.10):
@@ -493,7 +493,7 @@ SPEC CHECKSUMS:
   react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
   react-native-camera: eb89d59d50a3fc124b067134b688bccbff0ee841
   react-native-libsodium: 605739edeee166bfa4c57c51609a2096973c85f3
-  react-native-lightning: f05486703137556202ceef152829dd5500ff3c64
+  react-native-lightning: 9f766421e12d593c28fe7b53767c7263fe514d37
   react-native-netinfo: 30fb89fa913c342be82a887b56e96be6d71201dd
   react-native-randombytes: b6677f7d495c27e9ee0dbd77ebc97b3c59173729
   react-native-safe-area-context: b6e0e284002381d2ff29fa4fff42b4d8282e3c94

--- a/yarn.lock
+++ b/yarn.lock
@@ -7965,8 +7965,8 @@ react-native-keychain@^6.2.0:
     bint8array "^1.1.1"
 
 "react-native-lightning@git+ssh://git@github.com/synonymdev/react-native-lightning":
-  version "0.0.4"
-  resolved "git+ssh://git@github.com/synonymdev/react-native-lightning#caac1b775b4dfe63e16f17bdf910b60a2d6709c2"
+  version "0.0.17"
+  resolved "git+ssh://git@github.com/synonymdev/react-native-lightning#630f7f9a76654229c424ac76f06ca957277fa9a5"
 
 react-native-modal@^11.5.6:
   version "11.6.1"


### PR DESCRIPTION
This is a quick fix for the Android build. It appears that the react-native-lightning version number in yarn.lock & Podfile.lock was reverted to a previous version. This PR rectifies that.