### PR TITLE
Backup create, restore and skip onboarding options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,17 @@
 import '../shim';
-import React, { memo, ReactElement, useEffect, useState } from 'react';
-import {
-	ActivityIndicator,
-	InteractionManager,
-	Platform,
-	StyleSheet,
-	UIManager,
-	View,
-} from 'react-native';
+import React, { memo, ReactElement, useEffect } from 'react';
+import { Platform, StyleSheet, UIManager } from 'react-native';
 import { useSelector } from 'react-redux';
 import { ThemeProvider } from 'styled-components/native';
 import { StatusBar, SafeAreaView } from './styles/components';
 import RootNavigator from './navigation/root/RootNavigator';
 import Store from './store/types';
 import themes from './styles/themes';
-import { getStore } from './store/helpers';
-import { createWallet, updateWallet } from './store/actions/wallet';
-import {
-	startLnd,
-	createLightningWallet,
-	unlockLightningWallet,
-} from './store/actions/lightning';
-import lnd, { ENetworks as LndNetworks } from 'react-native-lightning';
 import Toast from 'react-native-toast-message';
-import { connectToElectrum, refreshWallet } from './utils/wallet';
 import './utils/translations';
-import { startOmnibolt } from './utils/omnibolt';
-import { downloadNeutrinoCache } from './utils/lightning/cachedHeaders';
-import { backupSetup } from './store/actions/backup';
 import OnboardingNavigator from './navigation/onboarding/OnboardingNavigator';
-import { checkWalletExists } from './utils/startup';
+import { checkWalletExists, startWalletServices } from './utils/startup';
+import { getStore } from './store/helpers';
 
 if (Platform.OS === 'android') {
 	if (UIManager.setLayoutAnimationEnabledExperimental) {
@@ -40,12 +22,13 @@ if (Platform.OS === 'android') {
 const App = (): ReactElement => {
 	const { walletExists } = useSelector((state: Store) => state.wallet);
 
-	//TODO use loading to start up the wallet services
-
-	//TODO check we have a wallet already
 	useEffect(() => {
 		(async (): Promise<void> => {
 			await checkWalletExists();
+
+			if (getStore().wallet.walletExists) {
+				await startWalletServices();
+			}
 		})();
 	}, []);
 
@@ -64,10 +47,6 @@ const App = (): ReactElement => {
 const styles = StyleSheet.create({
 	container: {
 		flex: 1,
-	},
-	loaderContent: {
-		flex: 1,
-		justifyContent: 'center',
 	},
 });
 

--- a/src/navigation/onboarding/OnboardingNavigator.tsx
+++ b/src/navigation/onboarding/OnboardingNavigator.tsx
@@ -1,0 +1,42 @@
+import React, { ReactElement } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { TransitionPresets } from '@react-navigation/stack';
+import { createNativeStackNavigator } from 'react-native-screens/native-stack';
+import WelcomeScreen from '../../screens/Onboarding/Welcome';
+import OnboardingCreateAccountScreen from '../../screens/Onboarding/CreateAccount';
+import OnboardingRestoreAccountScreen from '../../screens/Onboarding/RestoreAccount';
+
+const Stack = createNativeStackNavigator();
+
+const navOptionHandler = {
+	headerShown: false,
+	gestureEnabled: true,
+	...TransitionPresets.SlideFromRightIOS,
+	detachPreviousScreen: false,
+};
+
+const OnboardingNavigator = (): ReactElement => {
+	return (
+		<NavigationContainer>
+			<Stack.Navigator initialRouteName="Welcome">
+				<Stack.Screen
+					name="Welcome"
+					component={WelcomeScreen}
+					options={navOptionHandler}
+				/>
+				<Stack.Screen
+					name="CreateAccount"
+					component={OnboardingCreateAccountScreen}
+					options={navOptionHandler}
+				/>
+				<Stack.Screen
+					name="RestoreAccount"
+					component={OnboardingRestoreAccountScreen}
+					options={navOptionHandler}
+				/>
+			</Stack.Navigator>
+		</NavigationContainer>
+	);
+};
+
+export default OnboardingNavigator;

--- a/src/screens/Onboarding/CreateAccount.tsx
+++ b/src/screens/Onboarding/CreateAccount.tsx
@@ -1,0 +1,45 @@
+import React, { ReactElement } from 'react';
+import { Text, View } from '../../styles/components';
+import { StyleSheet } from 'react-native';
+import RegisterForm from '../../screens/Settings/Backup/RegisterForm';
+import { createNewWallet } from '../../utils/startup';
+import { showErrorNotification } from '../../utils/notifications';
+
+const OnboardingCreateAccountScreen = (): ReactElement => {
+	return (
+		<View style={styles.container}>
+			<View style={styles.content}>
+				<Text style={styles.title}>Create Account</Text>
+				<RegisterForm
+					onRegister={async (): Promise<void> => {
+						const res = await createNewWallet();
+						if (res.isErr()) {
+							showErrorNotification({
+								title: 'Wallet creation failed',
+								message: res.error.message,
+							});
+						}
+					}}
+				/>
+			</View>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	content: {
+		flex: 1,
+		// alignItems: 'center',
+		margin: 20,
+	},
+	title: {
+		fontSize: 24,
+		marginBottom: 50,
+		textAlign: 'center',
+	},
+});
+
+export default OnboardingCreateAccountScreen;

--- a/src/screens/Onboarding/RestoreAccount.tsx
+++ b/src/screens/Onboarding/RestoreAccount.tsx
@@ -18,7 +18,7 @@ const OnboardingRestoreAccountScreen = (): ReactElement => {
 
 				{isRestoring ? <ActivityIndicator /> : null}
 
-				<View style={{ display: isRestoring ? 'none' : 'flex' }}>
+				<View style={isRestoring ? styles.hiddenForm : null}>
 					<RegisterForm
 						onAuthDetails={async (auth): Promise<void> => {
 							setIsRestoring(true);
@@ -59,6 +59,9 @@ const styles = StyleSheet.create({
 		fontSize: 24,
 		marginBottom: 50,
 		textAlign: 'center',
+	},
+	hiddenForm: {
+		display: 'none',
 	},
 });
 

--- a/src/screens/Onboarding/RestoreAccount.tsx
+++ b/src/screens/Onboarding/RestoreAccount.tsx
@@ -1,0 +1,65 @@
+import React, { ReactElement, useState } from 'react';
+import { Text, View } from '../../styles/components';
+import { ActivityIndicator, StyleSheet } from 'react-native';
+import RegisterForm from '../../screens/Settings/Backup/RegisterForm';
+import { restoreWallet } from '../../utils/startup';
+import {
+	showErrorNotification,
+	showInfoNotification,
+} from '../../utils/notifications';
+
+const OnboardingRestoreAccountScreen = (): ReactElement => {
+	const [isRestoring, setIsRestoring] = useState<boolean>(false);
+
+	return (
+		<View style={styles.container}>
+			<View style={styles.content}>
+				<Text style={styles.title}>Restore Account</Text>
+
+				{isRestoring ? <ActivityIndicator /> : null}
+
+				<View style={{ display: isRestoring ? 'none' : 'flex' }}>
+					<RegisterForm
+						onAuthDetails={async (auth): Promise<void> => {
+							setIsRestoring(true);
+							const res = await restoreWallet(auth);
+							if (res.isErr()) {
+								showErrorNotification({
+									title: 'Wallet restore failed',
+									message: res.error.message,
+								});
+								setIsRestoring(false);
+								return;
+							}
+
+							showInfoNotification({
+								title: 'Success',
+								message: 'Wallet is being restored',
+							});
+
+							setIsRestoring(false);
+						}}
+					/>
+				</View>
+			</View>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	content: {
+		flex: 1,
+		// alignItems: 'center',
+		margin: 20,
+	},
+	title: {
+		fontSize: 24,
+		marginBottom: 50,
+		textAlign: 'center',
+	},
+});
+
+export default OnboardingRestoreAccountScreen;

--- a/src/screens/Onboarding/Welcome.tsx
+++ b/src/screens/Onboarding/Welcome.tsx
@@ -1,0 +1,67 @@
+import React, { ReactElement } from 'react';
+import { Text, View } from '../../styles/components';
+import { StyleSheet } from 'react-native';
+import Button from '../../components/Button';
+import { createNewWallet } from '../../utils/startup';
+import { showErrorNotification } from '../../utils/notifications';
+
+const OnboardingWelcomeScreen = ({
+	navigation,
+}: {
+	navigation: any;
+}): ReactElement => {
+	return (
+		<View style={styles.container}>
+			<View style={styles.content}>
+				<Text style={styles.title}>Welcome</Text>
+
+				<Button
+					style={styles.button}
+					text={'Create new account'}
+					onPress={(): void => {
+						navigation.navigate('CreateAccount');
+					}}
+				/>
+				<Button
+					style={styles.button}
+					text={'Restore'}
+					onPress={(): void => {
+						navigation.navigate('RestoreAccount');
+					}}
+				/>
+				<Button
+					style={styles.button}
+					text={'Skip (no automated backups)'}
+					onPress={async (): Promise<void> => {
+						const res = await createNewWallet();
+						if (res.isErr()) {
+							showErrorNotification({
+								title: 'Wallet creation failed',
+								message: res.error.message,
+							});
+						}
+					}}
+				/>
+			</View>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	content: {
+		flex: 1,
+	},
+	title: {
+		fontSize: 24,
+		marginBottom: 50,
+		textAlign: 'center',
+	},
+	button: {
+		marginTop: 10,
+	},
+});
+
+export default OnboardingWelcomeScreen;

--- a/src/screens/Settings/Backup/RegisterForm.tsx
+++ b/src/screens/Settings/Backup/RegisterForm.tsx
@@ -1,0 +1,123 @@
+import React, { memo, ReactElement, useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { useSelector } from 'react-redux';
+import { TextInput } from '../../../styles/components';
+import Button from '../../../components/Button';
+import { registerBackpack } from '../../../store/actions/backup';
+import {
+	showErrorNotification,
+	showSuccessNotification,
+} from '../../../utils/notifications';
+import Store from '../../../store/types';
+import { IBackpackAuth } from '../../../utils/backup/backpack';
+
+/**
+ * Either restore or creates a new account.
+ * Pass onRegister to trigger a backup account creation. Pass onAuthDetails to just get user auth details from inputs.
+ * @param onRegister
+ * @param onAuthDetails
+ * @returns {JSX.Element}
+ * @constructor
+ */
+const BackupRegisterForm = ({
+	onRegister,
+	onAuthDetails,
+}: {
+	onRegister?: () => void;
+	onAuthDetails?: (auth: IBackpackAuth) => void;
+}): ReactElement => {
+	const backupState = useSelector((state: Store) => state.backup);
+	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+	const [username, setUsername] = useState<string>(backupState.username);
+	const [password, setPassword] = useState<string>('');
+
+	return (
+		<>
+			<TextInput
+				textAlignVertical={'center'}
+				underlineColorAndroid="transparent"
+				style={styles.textInput}
+				placeholder="Username"
+				autoCapitalize="none"
+				autoCompleteType="off"
+				autoCorrect={false}
+				onChangeText={setUsername}
+				value={username}
+			/>
+			<TextInput
+				textAlignVertical={'center'}
+				underlineColorAndroid="transparent"
+				style={styles.textInput}
+				placeholder="Password"
+				autoCapitalize="none"
+				autoCompleteType="off"
+				autoCorrect={false}
+				onChangeText={setPassword}
+				value={password}
+				textContentType={'newPassword'}
+				secureTextEntry
+			/>
+
+			{onRegister ? (
+				<Button
+					text={isSubmitting ? 'Registering...' : 'Register'}
+					disabled={isSubmitting}
+					onPress={async (): Promise<void> => {
+						setIsSubmitting(true);
+						const registrationResult = await registerBackpack({
+							username,
+							password,
+						});
+
+						if (registrationResult.isErr()) {
+							showErrorNotification({
+								title: 'Failed to register',
+								message: registrationResult.error.message,
+							});
+						} else {
+							showSuccessNotification({
+								title: 'Success',
+								message: 'Backup registered',
+							});
+
+							onRegister();
+						}
+
+						setIsSubmitting(false);
+					}}
+				/>
+			) : null}
+
+			{onAuthDetails ? (
+				<Button
+					text="Retrieve"
+					disabled={isSubmitting}
+					onPress={async (): Promise<void> => {
+						onAuthDetails({
+							username,
+							password,
+						});
+					}}
+				/>
+			) : null}
+		</>
+	);
+};
+
+const styles = StyleSheet.create({
+	textInput: {
+		minHeight: 50,
+		borderRadius: 5,
+		fontWeight: 'bold',
+		fontSize: 18,
+		textAlign: 'center',
+		color: 'gray',
+		borderBottomWidth: 1,
+		borderColor: 'gray',
+		paddingHorizontal: 10,
+		backgroundColor: 'white',
+		marginVertical: 5,
+	},
+});
+
+export default memo(BackupRegisterForm);

--- a/src/screens/Settings/Backup/index.tsx
+++ b/src/screens/Settings/Backup/index.tsx
@@ -87,19 +87,6 @@ const styles = StyleSheet.create({
 		textAlign: 'center',
 		marginBottom: 20,
 	},
-	textInput: {
-		minHeight: 50,
-		borderRadius: 5,
-		fontWeight: 'bold',
-		fontSize: 18,
-		textAlign: 'center',
-		color: 'gray',
-		borderBottomWidth: 1,
-		borderColor: 'gray',
-		paddingHorizontal: 10,
-		backgroundColor: 'white',
-		marginVertical: 5,
-	},
 });
 
 export default memo(BackupSettings);

--- a/src/screens/Settings/Backup/index.tsx
+++ b/src/screens/Settings/Backup/index.tsx
@@ -6,23 +6,19 @@ import {
 	Feather,
 	Text,
 	TouchableOpacity,
-	TextInput,
 } from '../../../styles/components';
 import Button from '../../../components/Button';
-import { registerBackpack } from '../../../store/actions/backup';
 import {
 	showErrorNotification,
 	showSuccessNotification,
 } from '../../../utils/notifications';
 import Store from '../../../store/types';
 import { verifyFromBackpackServer } from '../../../utils/backup/backup';
+import BackupRegisterForm from './RegisterForm';
 
 const BackupSettings = ({ navigation }): ReactElement => {
 	const backupState = useSelector((state: Store) => state.backup);
-	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
 	const [isVerifying, setIsVerifying] = useState<boolean>(false);
-	const [username, setUsername] = useState<string>(backupState.username);
-	const [password, setPassword] = useState<string>('');
 
 	const lastBackup = backupState.lastBackedUp
 		? backupState.lastBackedUp.toLocaleString()
@@ -45,60 +41,7 @@ const BackupSettings = ({ navigation }): ReactElement => {
 			<ScrollView>
 				<Text style={styles.status}>{status}</Text>
 
-				{!backupState.username ? (
-					<>
-						<TextInput
-							textAlignVertical={'center'}
-							underlineColorAndroid="transparent"
-							style={styles.textInput}
-							placeholder="Username"
-							autoCapitalize="none"
-							autoCompleteType="off"
-							autoCorrect={false}
-							onChangeText={setUsername}
-							value={username}
-						/>
-						<TextInput
-							textAlignVertical={'center'}
-							underlineColorAndroid="transparent"
-							style={styles.textInput}
-							placeholder="Password"
-							autoCapitalize="none"
-							autoCompleteType="off"
-							autoCorrect={false}
-							onChangeText={setPassword}
-							value={password}
-							textContentType={'newPassword'}
-							secureTextEntry
-						/>
-
-						<Button
-							text={isSubmitting ? 'Updating...' : 'Update'}
-							disabled={isSubmitting}
-							onPress={async (): Promise<void> => {
-								setIsSubmitting(true);
-								const registrationResult = await registerBackpack({
-									username,
-									password,
-								});
-
-								if (registrationResult.isErr()) {
-									showErrorNotification({
-										title: 'Failed to register',
-										message: registrationResult.error.message,
-									});
-								} else {
-									showSuccessNotification({
-										title: 'Success',
-										message: 'Backup registered',
-									});
-								}
-
-								setIsSubmitting(false);
-							}}
-						/>
-					</>
-				) : null}
+				{!backupState.username ? <BackupRegisterForm /> : null}
 
 				<Button
 					text={isVerifying ? 'Verifying...' : 'Verify backup'}

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,7 +9,7 @@ const { persistReducer } = require('redux-persist');
 //Switch off logging for unit tests and prod env
 const createStoreWithMiddleware = (process.env.JEST_WORKER_ID === undefined &&
 	__DEV__
-	? applyMiddleware(thunk)
+	? applyMiddleware(thunk, logger)
 	: applyMiddleware(thunk))(createStore);
 
 const persistConfig = {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -9,7 +9,7 @@ const { persistReducer } = require('redux-persist');
 //Switch off logging for unit tests and prod env
 const createStoreWithMiddleware = (process.env.JEST_WORKER_ID === undefined &&
 	__DEV__
-	? applyMiddleware(thunk, logger)
+	? applyMiddleware(thunk)
 	: applyMiddleware(thunk))(createStore);
 
 const persistConfig = {

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -89,7 +89,8 @@ export const defaultWalletShape: IDefaultWalletShape = {
 };
 
 export const defaultWalletStoreShape: IWallet = {
-	loading: false,
+	loading: true,
+	walletExists: false,
 	error: false,
 	selectedNetwork: 'bitcoinTestnet',
 	selectedWallet: EWallet.defaultWallet,

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -50,6 +50,7 @@ export interface IKeyDerivationPath {
 
 export interface IWallet {
 	loading: boolean;
+	walletExists: boolean;
 	error: boolean;
 	selectedNetwork: TAvailableNetworks;
 	selectedWallet: string;

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -1,0 +1,97 @@
+import { connectToElectrum, getMnemonicPhrase, refreshWallet } from '../wallet';
+import { createWallet, updateWallet } from '../../store/actions/wallet';
+import { err, ok, Result } from '../result';
+import { InteractionManager } from 'react-native';
+import { getStore } from '../../store/helpers';
+import { backupSetup } from '../../store/actions/backup';
+import { backpackRetrieve, IBackpackAuth } from '../backup/backpack';
+import { restoreFromBackup } from '../backup/backup';
+import { startOmnibolt } from '../omnibolt';
+import { downloadNeutrinoCache } from '../lightning/cachedHeaders';
+import {
+	createLightningWallet,
+	startLnd,
+	unlockLightningWallet,
+} from '../../store/actions/lightning';
+import lnd, { ENetworks as LndNetworks } from 'react-native-lightning';
+
+export const checkWalletExists = async (): Promise<void> => {
+	const getMnemonicPhraseResponse = await getMnemonicPhrase('wallet0');
+	const { data } = getMnemonicPhraseResponse;
+
+	await updateWallet({ walletExists: !!data });
+};
+
+export const restoreWallet = async (
+	auth: IBackpackAuth,
+): Promise<Result<string>> => {
+	const retrieveRes = await backpackRetrieve(auth);
+	if (retrieveRes.isErr()) {
+		return err(retrieveRes.error);
+	}
+
+	const restoreRes = await restoreFromBackup(retrieveRes.value);
+	if (restoreRes.isErr()) {
+		return err(restoreRes.error);
+	}
+
+	return await startWalletServices();
+};
+
+export const createNewWallet = async (): Promise<Result<string>> => {
+	//All seeds will get automatically created
+	return await startWalletServices();
+};
+
+export const startWalletServices = async (): Promise<Result<string>> => {
+	const lndNetwork = LndNetworks.testnet; //TODO use the same network as other wallets
+	const tempPassword = 'shhhhhhhh123'; //TODO use keychain stored password
+
+	try {
+		InteractionManager.runAfterInteractions(async () => {
+			//Create wallet if none exists.
+			let { wallets, selectedNetwork, selectedWallet } = getStore().wallet;
+			const walletKeys = Object.keys(wallets);
+			if (!wallets[walletKeys[0]] || !wallets[walletKeys[0]]?.id) {
+				await createWallet({});
+			}
+
+			await updateWallet({ walletExists: true });
+
+			const electrumResponse = await connectToElectrum({ selectedNetwork });
+			if (electrumResponse.isOk()) {
+				refreshWallet().then();
+			}
+
+			//Create and start omnibolt.
+			startOmnibolt({ selectedWallet }).then();
+
+			downloadNeutrinoCache(lndNetwork)
+				//Start LND no matter the outcome of the download
+				.finally(async () => {
+					await startLnd(lndNetwork);
+
+					// Create or unlock LND wallet
+					const existsRes = await lnd.walletExists(lndNetwork);
+					if (existsRes.isOk() && existsRes.value) {
+						await unlockLightningWallet({
+							password: tempPassword,
+							network: lndNetwork,
+						});
+					} else {
+						await createLightningWallet({
+							password: tempPassword,
+							mnemonic: '',
+							network: lndNetwork,
+						});
+					}
+				});
+
+			backupSetup().then();
+		});
+
+		return ok('Wallet started');
+	} catch (e) {
+		return err(e);
+	}
+};


### PR DESCRIPTION
All the functional onboarding options for backup. Create account, restore a wallet and skip. After skipping you can still go to settings later and register for backups.

Will rather be adding in the lightning backup in my next PR.

When the OnboardingNavigator is swopped for the RootNavigator after the wallet is created there this quick slide of the side menu. Looks strange but still looking into why.

This is hard to test on a real iOS device because it seems the keychain is persisted even if you delete the app and reinstall. We'll have to make some kind of a "Wipe wallet" button for testnet that deletes everything in the keychain as well. For testing on iOS sims you can just go to `Device` -> `Erase All Content and Settings`.

![Simulator Screen Shot - iPhone 11 - 2021-03-31 at 18 12 10](https://user-images.githubusercontent.com/5300488/113176398-b7938400-924c-11eb-81c5-f84912428983.png)

![Simulator Screen Shot - iPhone 11 - 2021-03-31 at 18 12 13](https://user-images.githubusercontent.com/5300488/113176629-ff1a1000-924c-11eb-8889-801f093d0592.png)
