### PR TITLE
Minimum Fee Fix

### DIFF
--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -293,7 +293,10 @@ export const getTotalFee = ({
 				{ [addressType]: outputLength },
 				message,
 			) || fallBackFee;
-		return transactionByteCount * Number(satsPerByte) || fallBackFee;
+		const totalFee = transactionByteCount * Number(satsPerByte);
+		return totalFee > fallBackFee
+			? totalFee
+			: fallBackFee * Number(satsPerByte);
 	} catch {
 		return Number(satsPerByte) * fallBackFee || fallBackFee;
 	}


### PR DESCRIPTION
Updated getTotalFee to ensure the fee is always greater than the fallback fee (250 sats). Otherwise, Electrum may refuse the transaction with such a low fee.