### PR TITLE
LND backup

### DIFF
--- a/__mocks__/react-native-lightning.ts
+++ b/__mocks__/react-native-lightning.ts
@@ -18,6 +18,10 @@ class LND {
 			return err(e);
 		}
 	}
+
+	async exportAllChannelBackups(): Promise<Result<string, Error>> {
+		return ok("fake-static-channel-backup")
+	}
 }
 
 import LndConf from 'react-native-lightning/src/lnd.conf';

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -204,7 +204,6 @@ PODS:
     - React-Core
   - react-native-lightning (0.0.18):
     - React
-    - SwiftProtobuf (~> 1.0)
   - react-native-netinfo (5.9.10):
     - React-Core
   - react-native-randombytes (3.6.0):
@@ -493,7 +492,7 @@ SPEC CHECKSUMS:
   react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
   react-native-camera: eb89d59d50a3fc124b067134b688bccbff0ee841
   react-native-libsodium: 605739edeee166bfa4c57c51609a2096973c85f3
-  react-native-lightning: 26ccad7c6ac90dff433fb3f49c88cdc75174b67e
+  react-native-lightning: 66297f5f3c4c3ecc984818886bb2cf74dce421dd
   react-native-netinfo: 30fb89fa913c342be82a887b56e96be6d71201dd
   react-native-randombytes: b6677f7d495c27e9ee0dbd77ebc97b3c59173729
   react-native-safe-area-context: b6e0e284002381d2ff29fa4fff42b4d8282e3c94

--- a/postinstall.js
+++ b/postinstall.js
@@ -22,7 +22,6 @@ function buildRnLightning() {
 		'yarn install\n' +
 		'yarn protobuf\n' +
 		'cd ../../\n' +
-		'cp node_modules/react-native-lightning/dist/rpc.js node_modules/react-native-lightning/src\n' +
 		'sed -i -e "s/dist\\/index.js/src\\/index.ts/g" node_modules/react-native-lightning/package.json\n' +
 		'sed -i -e "s/\\"types\\": \\".\\/dist\\/index.d.ts\\",//g" node_modules/react-native-lightning/package.json\n'
 	)

--- a/src/screens/Settings/Backup/index.tsx
+++ b/src/screens/Settings/Backup/index.tsx
@@ -71,7 +71,10 @@ const BackupSettings = ({ navigation }): ReactElement => {
 					disabled={isBackingUp}
 					onPress={async (): Promise<void> => {
 						setIsBackingUp(true);
-						const backupRes = await performFullBackup();
+						const backupRes = await performFullBackup({
+							retries: 0,
+							retryTimeout: 0,
+						});
 						if (backupRes.isErr()) {
 							showErrorNotification({
 								title: 'Backup Failed',

--- a/src/screens/Settings/Backup/index.tsx
+++ b/src/screens/Settings/Backup/index.tsx
@@ -13,12 +13,13 @@ import {
 	showSuccessNotification,
 } from '../../../utils/notifications';
 import Store from '../../../store/types';
-import { verifyFromBackpackServer } from '../../../utils/backup/backup';
 import BackupRegisterForm from './RegisterForm';
+import { backupSetup, performFullBackup } from '../../../store/actions/backup';
 
 const BackupSettings = ({ navigation }): ReactElement => {
 	const backupState = useSelector((state: Store) => state.backup);
 	const [isVerifying, setIsVerifying] = useState<boolean>(false);
+	const [isBackingUp, setIsBackingUp] = useState<boolean>(false);
 
 	const lastBackup = backupState.lastBackedUp
 		? backupState.lastBackedUp.toLocaleString()
@@ -48,7 +49,7 @@ const BackupSettings = ({ navigation }): ReactElement => {
 					disabled={isVerifying}
 					onPress={async (): Promise<void> => {
 						setIsVerifying(true);
-						const verifyResult = await verifyFromBackpackServer();
+						const verifyResult = await backupSetup();
 						if (verifyResult.isErr()) {
 							showErrorNotification({
 								title: 'Failed to verify backup',
@@ -62,6 +63,28 @@ const BackupSettings = ({ navigation }): ReactElement => {
 						}
 
 						setIsVerifying(false);
+					}}
+				/>
+
+				<Button
+					text={isBackingUp ? 'Backing up...' : 'Backup now'}
+					disabled={isBackingUp}
+					onPress={async (): Promise<void> => {
+						setIsBackingUp(true);
+						const backupRes = await performFullBackup();
+						if (backupRes.isErr()) {
+							showErrorNotification({
+								title: 'Backup Failed',
+								message: backupRes.error.message,
+							});
+						} else {
+							showSuccessNotification({
+								title: 'Success',
+								message: 'Full backup complete',
+							});
+						}
+
+						setIsBackingUp(false);
 					}}
 				/>
 			</ScrollView>

--- a/src/store/actions/backup.ts
+++ b/src/store/actions/backup.ts
@@ -89,7 +89,7 @@ export const performFullBackup = async ({
 				performFullBackup({ retries: retries - 1, retryTimeout }).then();
 			}, retryTimeout);
 		}
-		return err('backupRes.error');
+		return err(backupRes.error);
 	}
 
 	await dispatch({

--- a/src/store/actions/backup.ts
+++ b/src/store/actions/backup.ts
@@ -75,10 +75,21 @@ export const backupSetup = async (): Promise<Result<string>> => {
  * Triggers a full remote backup
  * @return {Promise<Err<unknown> | Ok<string>>}
  */
-export const performFullBackup = async (): Promise<Result<string>> => {
+export const performFullBackup = async ({
+	retries,
+	retryTimeout,
+}: {
+	retries: number;
+	retryTimeout: number;
+}): Promise<Result<string>> => {
 	const backupRes = await backupToBackpackServer();
 	if (backupRes.isErr()) {
-		return err(backupRes.error);
+		if (retries > 1) {
+			setTimeout(() => {
+				performFullBackup({ retries: retries - 1, retryTimeout }).then();
+			}, retryTimeout);
+		}
+		return err('backupRes.error');
 	}
 
 	await dispatch({

--- a/src/store/actions/backup.ts
+++ b/src/store/actions/backup.ts
@@ -53,17 +53,9 @@ export const backupSetup = async (): Promise<Result<string>> => {
 	});
 
 	const verifyBackupRes = await verifyFromBackpackServer();
-	if (verifyBackupRes.isErr()) {
-		await dispatch({
-			type: actions.BACKUP_UPDATE,
-			payload: state,
-		});
-
-		//Schedule backup if we receive any sort of error
-		performFullBackup().then();
-	} else {
-		state.backpackSynced = true;
-		//TODO get timestamp from server backup
+	state.backpackSynced = verifyBackupRes.isOk();
+	if (verifyBackupRes.isOk()) {
+		state.lastBackedUp = verifyBackupRes.value;
 	}
 
 	//If they've registered we'll have the username
@@ -71,6 +63,10 @@ export const backupSetup = async (): Promise<Result<string>> => {
 		type: actions.BACKUP_UPDATE,
 		payload: state,
 	});
+
+	if (verifyBackupRes.isErr()) {
+		return err(`Backup not verified. ${verifyBackupRes.error.message}.`);
+	}
 
 	return ok('Backup setup');
 };

--- a/src/store/actions/lightning.ts
+++ b/src/store/actions/lightning.ts
@@ -19,6 +19,7 @@ import {
 import { updateLightingActivityList } from './activity';
 import { getKeychainValue, setKeychainValue } from '../../utils/helpers';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { performFullBackup } from './backup';
 
 const dispatch = getDispatch();
 
@@ -56,6 +57,14 @@ export const startLnd = (network: LndNetworks): Promise<Result<string>> => {
 				payload: state,
 			});
 		});
+
+		//Any channel opening/closing triggers a new static channel state backup
+		lnd.subscribeToBackups(
+			() => {
+				performFullBackup({ retries: 3, retryTimeout: 1000 });
+			},
+			() => {},
+		);
 
 		refreshLightningTransactions().then();
 		resolve(ok('LND started'));

--- a/src/store/actions/settings.ts
+++ b/src/store/actions/settings.ts
@@ -48,6 +48,7 @@ export const wipeWallet = async ({
 			resetKeychainValue({ key: `${selectedWallet}passphrase` }),
 			deleteOmniboltId({ selectedWallet }),
 			wipeAuthDetails(),
+			resetKeychainValue({ key: 'lndMnemonic' }),
 			wipeLndDir(),
 		]);
 		dispatch({

--- a/src/store/types/lightning.ts
+++ b/src/store/types/lightning.ts
@@ -25,6 +25,7 @@ export interface ICreateLightningWallet {
 	mnemonic: string;
 	password: string;
 	network: LndNetworks;
+	multiChanBackup?: string;
 }
 
 export interface IUnlockLightningWallet {

--- a/src/store/types/lightning.ts
+++ b/src/store/types/lightning.ts
@@ -22,13 +22,9 @@ export interface ICachedNeutrinoDBDownloadState {
 }
 
 export interface ICreateLightningWallet {
-	mnemonic: string;
-	password: string;
 	network: LndNetworks;
-	multiChanBackup?: string;
 }
 
 export interface IUnlockLightningWallet {
-	password: string;
 	network: LndNetworks;
 }

--- a/src/utils/backup/backup.ts
+++ b/src/utils/backup/backup.ts
@@ -7,6 +7,7 @@ import { backpackRetrieve, backpackStore } from './backpack';
 import { bytesToHexString } from '../converters';
 import { createWallet } from '../../store/actions/wallet';
 import lnd from 'react-native-lightning';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 export const createBackup = async (): Promise<Result<Uint8Array>> => {
 	try {
@@ -118,7 +119,11 @@ export const restoreFromBackup = async (
 			});
 		}
 
-		//TODO restore LND channels
+		//Cache static channel state backup for funds to be swept when creating LND wallet
+		const multiChanBackup = backup.lnd?.multiChanBackup;
+		if (multiChanBackup) {
+			await AsyncStorage.setItem('multiChanBackupRestore', multiChanBackup);
+		}
 
 		//TODO restore Omni
 

--- a/src/utils/backup/backup.ts
+++ b/src/utils/backup/backup.ts
@@ -4,7 +4,6 @@ import { getStore } from '../../store/helpers';
 import { getKeychainValue } from '../helpers';
 import { IDefaultWalletShape, TAddressType } from '../../store/types/wallet';
 import { backpackRetrieve, backpackStore } from './backpack';
-import { bytesToHexString } from '../converters';
 import { createWallet } from '../../store/actions/wallet';
 import lnd from 'react-native-lightning';
 import AsyncStorage from '@react-native-async-storage/async-storage';

--- a/src/utils/backup/protos/scheme.proto
+++ b/src/utils/backup/protos/scheme.proto
@@ -8,6 +8,8 @@ message Backup {
   repeated Wallet wallets = 1;
 
   LND lnd = 2;
+
+  int64 timestampUtc = 3;
 }
 
 message Wallet {
@@ -25,7 +27,6 @@ message Wallet {
 
   KeyDerivationPath keyDerivationPath = 4;
 
-
   enum AddressType {
     bech32 = 0;
     segwit = 1;
@@ -38,6 +39,7 @@ message Wallet {
 }
 
 message LND {
-  repeated string channel_state = 1; //TODO
+  string seed = 1;
+  string multiChanBackup = 2;
 }
 

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -88,7 +88,7 @@ export const startWalletServices = async (): Promise<Result<string>> => {
 					title: 'Failed to verify remote backup. Retrying...',
 					message: res.error.message,
 				});
-				performFullBackup().then();
+				performFullBackup({ retries: 3, retryTimeout: 2000 }).then();
 			}
 		});
 

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -46,7 +46,6 @@ export const createNewWallet = async (): Promise<Result<string>> => {
 
 export const startWalletServices = async (): Promise<Result<string>> => {
 	const lndNetwork = LndNetworks.testnet; //TODO use the same network as other wallets
-	const tempPassword = 'shhhhhhhh123'; //TODO use keychain stored password
 
 	try {
 		InteractionManager.runAfterInteractions(async () => {
@@ -74,15 +73,11 @@ export const startWalletServices = async (): Promise<Result<string>> => {
 					const existsRes = await lnd.walletExists(lndNetwork);
 					if (existsRes.isOk() && existsRes.value) {
 						await unlockLightningWallet({
-							password: tempPassword,
 							network: lndNetwork,
 						});
 					} else {
 						await createLightningWallet({
-							password: tempPassword,
-							mnemonic: '',
 							network: lndNetwork,
-							multiChanBackup: undefined, //TODO get this from backup
 						});
 					}
 				});

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -80,16 +80,16 @@ export const startWalletServices = async (): Promise<Result<string>> => {
 							network: lndNetwork,
 						});
 					}
-				});
 
-			const res = await backupSetup();
-			if (res.isErr()) {
-				showErrorNotification({
-					title: 'Failed to verify remote backup. Retrying...',
-					message: res.error.message,
+					const res = await backupSetup();
+					if (res.isErr()) {
+						showErrorNotification({
+							title: 'Failed to verify remote backup. Retrying...',
+							message: res.error.message,
+						});
+						performFullBackup({ retries: 3, retryTimeout: 2000 }).then();
+					}
 				});
-				performFullBackup({ retries: 3, retryTimeout: 2000 }).then();
-			}
 		});
 
 		return ok('Wallet started');

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -3,7 +3,7 @@ import { createWallet, updateWallet } from '../../store/actions/wallet';
 import { err, ok, Result } from '../result';
 import { InteractionManager } from 'react-native';
 import { getStore } from '../../store/helpers';
-import { backupSetup } from '../../store/actions/backup';
+import { backupSetup, performFullBackup } from '../../store/actions/backup';
 import { backpackRetrieve, IBackpackAuth } from '../backup/backpack';
 import { restoreFromBackup } from '../backup/backup';
 import { startOmnibolt } from '../omnibolt';
@@ -14,6 +14,7 @@ import {
 	unlockLightningWallet,
 } from '../../store/actions/lightning';
 import lnd, { ENetworks as LndNetworks } from 'react-native-lightning';
+import { showErrorNotification } from '../notifications';
 
 export const checkWalletExists = async (): Promise<void> => {
 	const getMnemonicPhraseResponse = await getMnemonicPhrase('wallet0');
@@ -81,11 +82,19 @@ export const startWalletServices = async (): Promise<Result<string>> => {
 							password: tempPassword,
 							mnemonic: '',
 							network: lndNetwork,
+							multiChanBackup: undefined, //TODO get this from backup
 						});
 					}
 				});
 
-			backupSetup().then();
+			const res = await backupSetup();
+			if (res.isErr()) {
+				showErrorNotification({
+					title: 'Failed to verify remote backup. Retrying...',
+					message: res.error.message,
+				});
+				performFullBackup().then();
+			}
 		});
 
 		return ok('Wallet started');

--- a/yarn.lock
+++ b/yarn.lock
@@ -7971,7 +7971,7 @@ react-native-keychain@^6.2.0:
 
 "react-native-lightning@git+ssh://git@github.com/synonymdev/react-native-lightning":
   version "0.0.18"
-  resolved "git+ssh://git@github.com/synonymdev/react-native-lightning#9f517c036b67adf290c9ee820306e62fa5ec51c9"
+  resolved "git+ssh://git@github.com/synonymdev/react-native-lightning#149044590431fb71a884d1b16fe7bdedc6d2768f"
 
 react-native-modal@^11.5.6:
   version "11.6.1"


### PR DESCRIPTION
- Backs up LND seed and channel state. We have to backup the seed as it's used to decrypt the static channel backups when recreating the wallet.
- LND channel restore.
- Auto retry backups on failure with retry limit
- Subscribes to channel backup updates from LND which triggers a full backup each time.

Still seems like the occasional bug causing a crash when restoring from a backup. I'll setup a regtest network to run it through a bunch of times to see how I can reproduced as testing is taking a bit long on testnet.

This actually just sweeps the funds from the channel as it's force closed by the remote peer. This is the suggested way according to the docs but if we actually wanted to restore the channel and continue using it then the full `channels.db` needs to be backed up consistently which has it's risks.