### PR TITLE
Lightning PSBT Funding Fee Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bip21": "^2.0.3",
     "bip32": "^2.0.6",
     "bip39": "^3.0.2",
+    "bitcoin-address-validation": "^2.0.1",
     "bitcoin-units": "^0.3.0",
     "bitcoinjs-lib": "^5.2.0",
     "bitcoinjs-message": "^2.1.1",

--- a/src/screens/Wallets/SendOnChainTransaction/FeeSummary.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/FeeSummary.tsx
@@ -1,0 +1,119 @@
+import { defaultOnChainTransactionData } from '../../../store/types/wallet';
+import React, { memo, ReactElement, useCallback } from 'react';
+import Summary from './Summary';
+import { LayoutAnimation, StyleSheet } from 'react-native';
+import { getTransactionOutputValue } from '../../../utils/wallet/transactions';
+import { useSelector } from 'react-redux';
+import Store from '../../../store/types';
+import { getFiatBalance } from '../../../utils/helpers';
+import { View } from '../../../styles/components';
+
+const FeeSummary = ({
+	amount: _amount = '0',
+	lightning = false,
+}: {
+	amount?: string | number;
+	lightning?: boolean;
+}): ReactElement => {
+	const selectedWallet = useSelector(
+		(store: Store) => store.wallet.selectedWallet,
+	);
+	const selectedNetwork = useSelector(
+		(store: Store) => store.wallet.selectedNetwork,
+	);
+
+	const transaction = useSelector(
+		(store: Store) =>
+			store.wallet.wallets[selectedWallet]?.transaction[selectedNetwork] ||
+			defaultOnChainTransactionData,
+	);
+
+	const selectedCurrency = useSelector(
+		(state: Store) => state.settings.selectedCurrency,
+	);
+
+	const exchangeRate = useSelector((state: Store) => state.wallet.exchangeRate);
+
+	const totalFee = transaction.fee;
+
+	/*
+	 * Retrieves total value of all outputs. Excludes change address.
+	 */
+	const getAmountToSend = useCallback((): number => {
+		try {
+			return getTransactionOutputValue({
+				selectedWallet,
+				selectedNetwork,
+			});
+		} catch {
+			return 0;
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [transaction.outputs, selectedNetwork, selectedWallet]);
+
+	const amount = Number(_amount) || getAmountToSend();
+
+	const getFiatAmount = useCallback((): string => {
+		return getFiatBalance({
+			balance: amount,
+			exchangeRate,
+			selectedCurrency,
+		});
+	}, [amount, exchangeRate, selectedCurrency]);
+	const fiatAmount = getFiatAmount();
+
+	const getFiatTotalFee = useCallback((): string => {
+		return getFiatBalance({
+			balance: totalFee,
+			exchangeRate,
+			selectedCurrency,
+		});
+	}, [totalFee, exchangeRate, selectedCurrency]);
+	const fiatTotalFee = getFiatTotalFee();
+
+	const getTransactionTotal = useCallback((): number => {
+		try {
+			return Number(amount) + Number(totalFee);
+		} catch {
+			return Number(totalFee);
+		}
+	}, [amount, totalFee]);
+
+	const transactionTotal = getTransactionTotal();
+
+	const getFiatTransactionTotal = useCallback((): string => {
+		return getFiatBalance({
+			balance: transactionTotal,
+			exchangeRate,
+			selectedCurrency,
+		});
+	}, [transactionTotal, exchangeRate, selectedCurrency]);
+
+	const fiatTransactionTotal = getFiatTransactionTotal();
+
+	LayoutAnimation.easeInEaseOut();
+	return (
+		<View color="transparent" style={styles.summary}>
+			<Summary
+				leftText={lightning ? 'Transfer' : 'Send:'}
+				rightText={`${amount} sats\n$${fiatAmount}`}
+			/>
+			<Summary
+				leftText={'Fee:'}
+				rightText={`${totalFee} sats\n$${fiatTotalFee}`}
+			/>
+			<Summary
+				leftText={'Total:'}
+				rightText={`${transactionTotal} sats\n$${fiatTransactionTotal}`}
+			/>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	summary: {
+		marginVertical: 20,
+	},
+});
+
+export default memo(FeeSummary);

--- a/src/screens/Wallets/SendOnChainTransaction/FeeSummary.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/FeeSummary.tsx
@@ -1,4 +1,3 @@
-import { defaultOnChainTransactionData } from '../../../store/types/wallet';
 import React, { memo, ReactElement, useCallback } from 'react';
 import Summary from './Summary';
 import { LayoutAnimation, StyleSheet } from 'react-native';
@@ -7,6 +6,7 @@ import { useSelector } from 'react-redux';
 import Store from '../../../store/types';
 import { getFiatBalance } from '../../../utils/helpers';
 import { View } from '../../../styles/components';
+import { useTransactionDetails } from './TransactionHook';
 
 const FeeSummary = ({
 	amount: _amount = '0',
@@ -22,11 +22,7 @@ const FeeSummary = ({
 		(store: Store) => store.wallet.selectedNetwork,
 	);
 
-	const transaction = useSelector(
-		(store: Store) =>
-			store.wallet.wallets[selectedWallet]?.transaction[selectedNetwork] ||
-			defaultOnChainTransactionData,
-	);
+	const transaction = useTransactionDetails();
 
 	const selectedCurrency = useSelector(
 		(state: Store) => state.settings.selectedCurrency,
@@ -34,7 +30,7 @@ const FeeSummary = ({
 
 	const exchangeRate = useSelector((state: Store) => state.wallet.exchangeRate);
 
-	const totalFee = transaction.fee;
+	const totalFee = transaction?.fee || 250;
 
 	/*
 	 * Retrieves total value of all outputs. Excludes change address.

--- a/src/screens/Wallets/SendOnChainTransaction/OutputSummary.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/OutputSummary.tsx
@@ -1,63 +1,44 @@
 import { IOutput } from '../../../store/types/wallet';
 import React, { ReactElement } from 'react';
 import { Text, View } from '../../../styles/components';
-import Summary from './Summary';
 import { StyleSheet } from 'react-native';
 
 const OutputSummary = ({
 	outputs = [],
 	changeAddress = '',
-	sendAmount = 0,
-	fee = 0,
 	lightning = false,
+	children = <></>,
 }: {
 	outputs: IOutput[];
 	changeAddress: string;
-	sendAmount: number;
-	fee: number;
 	lightning?: boolean;
+	children?: ReactElement;
 }): ReactElement => {
 	return (
-		<>
+		<View color="transparent">
 			{outputs &&
 				outputs.map(({ address, value }, index) => {
 					if (changeAddress !== address) {
 						return (
-							<View
-								key={`${index}${value}`}
-								color="transparent"
-								style={styles.summaryContainer}>
-								<View color="transparent" style={styles.summary}>
-									{!lightning && (
-										<>
-											<Text style={styles.addressText}>Address:</Text>
-											<Text style={styles.addressText}>{address}</Text>
-										</>
-									)}
-
-									<Summary
-										leftText={lightning ? 'Transfer:' : 'Send:'}
-										rightText={`${sendAmount} sats`}
-									/>
-									<Summary leftText={'Fee:'} rightText={`${fee} sats`} />
-								</View>
+							<View key={`${index}${value}`} color="transparent">
+								{!lightning && (
+									<>
+										<Text style={styles.addressText}>Address:</Text>
+										<Text style={styles.addressText}>{address}</Text>
+									</>
+								)}
 							</View>
 						);
 					}
 				})}
-		</>
+			{children}
+		</View>
 	);
 };
 
 const styles = StyleSheet.create({
 	addressText: {
 		textAlign: 'center',
-	},
-	summary: {
-		marginVertical: 20,
-	},
-	summaryContainer: {
-		marginVertical: 5,
 	},
 });
 

--- a/src/screens/Wallets/SendOnChainTransaction/OutputSummary.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/OutputSummary.tsx
@@ -6,12 +6,10 @@ import { StyleSheet } from 'react-native';
 const OutputSummary = ({
 	outputs = [],
 	changeAddress = '',
-	lightning = false,
 	children = <></>,
 }: {
 	outputs: IOutput[];
 	changeAddress: string;
-	lightning?: boolean;
 	children?: ReactElement;
 }): ReactElement => {
 	return (
@@ -21,12 +19,8 @@ const OutputSummary = ({
 					if (changeAddress !== address) {
 						return (
 							<View key={`${index}${value}`} color="transparent">
-								{!lightning && (
-									<>
-										<Text style={styles.addressText}>Address:</Text>
-										<Text style={styles.addressText}>{address}</Text>
-									</>
-								)}
+								<Text style={styles.addressText}>Address:</Text>
+								<Text style={styles.addressText}>{address}</Text>
 							</View>
 						);
 					}

--- a/src/screens/Wallets/SendOnChainTransaction/index.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/index.tsx
@@ -34,9 +34,9 @@ import {
 } from '../../../utils/notifications';
 import { defaultOnChainTransactionData } from '../../../store/types/wallet';
 import SendForm from '../../../components/SendForm';
-import { getFiatBalance } from '../../../utils/helpers';
 import Summary from './Summary';
 import OutputSummary from './OutputSummary';
+import FeeSummary from './FeeSummary';
 
 const updateOpacity = ({
 	opacity = new Animated.Value(0),
@@ -90,12 +90,6 @@ const SendOnChainTransaction = ({
 				?.address || ' ',
 	);
 
-	const selectedCurrency = useSelector(
-		(state: Store) => state.settings.selectedCurrency,
-	);
-
-	const exchangeRate = useSelector((state: Store) => state.wallet.exchangeRate);
-
 	useEffect(() => {
 		if (animate) {
 			setTimeout(() => {
@@ -135,24 +129,6 @@ const SendOnChainTransaction = ({
 
 	const amount = getAmountToSend();
 
-	const getFiatAmount = useCallback((): string => {
-		return getFiatBalance({
-			balance: amount,
-			exchangeRate,
-			selectedCurrency,
-		});
-	}, [amount, exchangeRate, selectedCurrency]);
-	const fiatAmount = getFiatAmount();
-
-	const getFiatTotalFee = useCallback((): string => {
-		return getFiatBalance({
-			balance: totalFee,
-			exchangeRate,
-			selectedCurrency,
-		});
-	}, [totalFee, exchangeRate, selectedCurrency]);
-	const fiatTotalFee = getFiatTotalFee();
-
 	const getTransactionTotal = useCallback((): number => {
 		try {
 			return Number(amount) + Number(totalFee);
@@ -162,16 +138,6 @@ const SendOnChainTransaction = ({
 	}, [amount, totalFee]);
 
 	const transactionTotal = getTransactionTotal();
-
-	const getFiatTransactionTotal = useCallback((): string => {
-		return getFiatBalance({
-			balance: transactionTotal,
-			exchangeRate,
-			selectedCurrency,
-		});
-	}, [transactionTotal, exchangeRate, selectedCurrency]);
-
-	const fiatTransactionTotal = getFiatTransactionTotal();
 
 	const _createTransaction = async (): Promise<void> => {
 		try {
@@ -193,12 +159,9 @@ const SendOnChainTransaction = ({
 	if (rawTx) {
 		return (
 			<>
-				<OutputSummary
-					outputs={outputs}
-					changeAddress={changeAddress}
-					sendAmount={getTransactionOutputValue({})}
-					fee={totalFee}
-				/>
+				<OutputSummary outputs={outputs} changeAddress={changeAddress}>
+					<FeeSummary />
+				</OutputSummary>
 				<View color={'transparent'} style={styles.row}>
 					<Summary leftText={'Total:'} rightText={`${transactionTotal} sats`} />
 					<TouchableOpacity
@@ -257,20 +220,7 @@ const SendOnChainTransaction = ({
 			{header && <NavigationHeader title="Send Transaction" />}
 			<AnimatedView color="transparent" style={[styles.container, { opacity }]}>
 				<SendForm />
-				<View color="transparent" style={styles.summary}>
-					<Summary
-						leftText={'Amount:'}
-						rightText={`${amount} sats\n$${fiatAmount}`}
-					/>
-					<Summary
-						leftText={'Fee:'}
-						rightText={`${totalFee} sats\n$${fiatTotalFee}`}
-					/>
-					<Summary
-						leftText={'Total:'}
-						rightText={`${transactionTotal} sats\n$${fiatTransactionTotal}`}
-					/>
-				</View>
+				<FeeSummary />
 				<Button
 					disabled={balance < transactionTotal}
 					color="onSurface"
@@ -297,9 +247,6 @@ const styles = StyleSheet.create({
 	row: {
 		flexDirection: 'row',
 		justifyContent: 'space-evenly',
-	},
-	summary: {
-		marginVertical: 20,
 	},
 	broadcastButton: {
 		width: '40%',

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -156,7 +156,7 @@ export interface IDefaultWalletShape {
 	addressIndex: IWalletItem<IAddressContent>;
 	changeAddresses: IWalletItem<IAddress> | IWalletItem<{}>;
 	changeAddressIndex: IWalletItem<IAddressContent>;
-	utxos: IWalletItem<IUtxo> | IWalletItem<[]>;
+	utxos: IWalletItem<IUtxo[]>;
 	transactions: IWalletItem<IFormattedTransaction> | IWalletItem<{}>;
 	blacklistedUtxos: IWalletItem<[]>;
 	balance: IWalletItem<number>;

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -20,6 +20,35 @@ export type TTicker = 'BTC' | 'tBTC';
 
 export type TTransactionType = 'sent' | 'received';
 
+export type TGetByteCountInput =
+	| 'MULTISIG-P2SH'
+	| 'MULTISIG-P2WSH'
+	| 'MULTISIG-P2SH-P2WSH'
+	| 'P2PKH'
+	| 'P2WPKH'
+	| 'P2SH-P2WPKH'
+	| 'bech32'
+	| 'segwit'
+	| 'legacy'
+	| any; //Unsure how to account for multisig variations (ex. 'MULTISIG-P2SH:2-4')
+
+export type TGetByteCountOutput =
+	| 'P2SH'
+	| 'P2PKH'
+	| 'P2WPKH'
+	| 'P2WSH'
+	| 'bech32'
+	| 'segwit'
+	| 'legacy';
+
+export type TGetByteCountInputs = {
+	[key in TGetByteCountInput]?: number;
+};
+
+export type TGetByteCountOutputs = {
+	[key in TGetByteCountOutput]?: number;
+};
+
 export enum EWallet {
 	selectedNetwork = 'bitcoin',
 	defaultWallet = 'wallet0',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2428,7 +2428,7 @@ base-64@^0.1.0:
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
   integrity sha1-eAqZyE59YAJgNhURxId2E78k9rs=
 
-base-x@^3.0.2:
+base-x@^3.0.2, base-x@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.8.tgz#1e1106c2537f0162e8b52474a557ebb09000018d"
   integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==
@@ -2464,6 +2464,11 @@ bech32@^1.1.2, bech32@^1.1.3, bech32@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
+
+bech32@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
+  integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
 
 big-integer@^1.6.44:
   version "1.6.48"
@@ -2533,6 +2538,15 @@ bip66@^1.1.0, bip66@^1.1.5:
   integrity sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=
   dependencies:
     safe-buffer "^5.0.1"
+
+bitcoin-address-validation@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/bitcoin-address-validation/-/bitcoin-address-validation-2.0.1.tgz#57864114687db11b7884a44224243c59a3f5f1e5"
+  integrity sha512-S3VEoqW4w/92QKKZhmraw84oUXc35i++hOknY9lxy9p10MXdwmhPjTNuKP37dm8YttYr5elUQE3jumc9l/PR5w==
+  dependencies:
+    base-x "^3.0.8"
+    bech32 "^2.0.0"
+    sha.js "^2.4.11"
 
 bitcoin-ops@^1.3.0, bitcoin-ops@^1.4.0:
   version "1.4.1"
@@ -7974,8 +7988,11 @@ react-native-keychain@^6.2.0:
     bint8array "^1.1.1"
 
 "react-native-lightning@git+ssh://git@github.com/synonymdev/react-native-lightning":
-  version "0.0.18"
+  version "0.0.24"
   resolved "git+ssh://git@github.com/synonymdev/react-native-lightning#02a97ae122d05416ffd2aa89f0371df7214d6e3a"
+  dependencies:
+    base64-js "^1.5.1"
+    protobufjs "^6.10.2"
 
 react-native-modal@^11.5.6:
   version "11.6.1"
@@ -8707,7 +8724,7 @@ setprototypeof@1.1.1:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.1.tgz#7e95acb24aa92f5885e0abef5ba131330d4ae683"
   integrity sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==
 
-sha.js@^2.4.0, sha.js@^2.4.8:
+sha.js@^2.4.0, sha.js@^2.4.11, sha.js@^2.4.8:
   version "2.4.11"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
   integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==


### PR DESCRIPTION
This PR adds a way to calculate and adjust the fee when funding a lightning channel via psbt.
More specifically, `fundingLightning` was added as a param to the `getTotalFee` method. Setting `fundingLightning` to true will add an additional bech32 output into its calculation to account for the future output address lnd will return.

![psbt-fee-update](https://user-images.githubusercontent.com/8532651/118735192-e7ebad80-b80d-11eb-982b-cdc1071c2baf.png)
