### PR TITLE
Android Fix

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
+      android:usesCleartextTraffic="true"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "29.0.3"
-        minSdkVersion = 21
+        minSdkVersion = 23
         compileSdkVersion = 29
         targetSdkVersion = 29
         ndkVersion = "20.1.5948944"


### PR DESCRIPTION
This PR resolves the crash that occurs when attempting to connect to the testnet omnibolt server on Android devices. 

- Bumped minSdkVersion to 23 in android/build.gradle.
 - Added usesCleartextTraffic to AndroidManifest.xml.