### PR TITLE
Close Omnibolt Channel

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -573,7 +573,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: 7b423f9e248eae65987838148c36eec1dbfe0b53
-  FBReactNativeSpec: 48fe9617a70000d48cde537d939824365b283ac7
+  FBReactNativeSpec: 559fb0b2054a6400fd94f3361b459519015929ce
   Flipper: d3da1aa199aad94455ae725e9f3aa43f3ec17021
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c

--- a/src/components/AssetCard.tsx
+++ b/src/components/AssetCard.tsx
@@ -106,7 +106,7 @@ const styles = StyleSheet.create({
 		alignItems: 'flex-start',
 	},
 	col2: {
-		flex: 2,
+		flex: 2.2,
 	},
 	fiatLabelContainer: {
 		flex: 1,

--- a/src/screens/Wallets/OmniboltCard.tsx
+++ b/src/screens/Wallets/OmniboltCard.tsx
@@ -60,7 +60,22 @@ const OmniboltCard = (): ReactElement => {
 
 	const channelCount = useCallback((): number => {
 		try {
-			return Object.keys(channels)?.length || 0;
+			return (
+				Object.keys(channels)?.filter((channel) => {
+					return channels[channel].curr_state !== 21;
+				}).length || 0
+			);
+		} catch (e) {
+			return 0;
+		}
+	}, [channels]);
+	const closedChannelCount = useCallback((): number => {
+		try {
+			return (
+				Object.keys(channels)?.filter((channel) => {
+					return channels[channel].curr_state === 21;
+				}).length || 0
+			);
 		} catch (e) {
 			return 0;
 		}
@@ -76,20 +91,12 @@ const OmniboltCard = (): ReactElement => {
 	return (
 		<AssetCard
 			title="Omnibolt"
-			assetBalanceLabel={`Channels: ${channelCount()}\nTemp Channels ${tempChannelCount()}`}
+			assetBalanceLabel={`Channels: ${channelCount()}\nTemp: ${tempChannelCount()}\nClosed: ${closedChannelCount()}`}
 			fiatBalanceLabel={''}
 			asset="omnibolt"
 			onPress={toggleCard}>
 			{shouldDisplayButtons() && (
 				<>
-					{Object.keys(channels).map((channelId, i) => (
-						<View
-							key={`${channelId}${i}`}
-							color={'transparent'}
-							style={styles.sendAssetContainer}>
-							<OmniboltChannelCard channelId={channelId} />
-						</View>
-					))}
 					<View color="transparent" style={styles.buttonRow}>
 						<Button
 							color="onSurface"
@@ -107,6 +114,14 @@ const OmniboltCard = (): ReactElement => {
 					{displayReceive && (
 						<QR data={connectId} displayText={false} header={false} />
 					)}
+					{Object.keys(channels).map((channelId, i) => (
+						<View
+							key={`${channelId}${i}`}
+							color={'transparent'}
+							style={styles.sendAssetContainer}>
+							<OmniboltChannelCard channelId={channelId} />
+						</View>
+					))}
 				</>
 			)}
 		</AssetCard>

--- a/src/utils/omnibolt/index.ts
+++ b/src/utils/omnibolt/index.ts
@@ -55,9 +55,22 @@ import {
 } from '../../store/types/omnibolt';
 import { networks, TAvailableNetworks } from '../networks';
 import {
+	AcceptChannelInfo,
+	addHTLCInfo,
+	AtomicSwapAccepted,
+	AtomicSwapRequest,
+	CloseHtlcTxInfo,
+	CloseHtlcTxInfoSigned,
 	CommitmentTx,
 	CommitmentTxSigned,
+	ForwardRInfo,
+	HTLCFindPathInfo,
+	HtlcSignedInfo,
+	InvoiceInfo,
 	IssueFixedAmountInfo,
+	IssueManagedAmoutInfo,
+	OmniSendGrant,
+	OmniSendRevoke,
 	OpenChannelInfo,
 	SignedInfo100360,
 	SignedInfo100361,
@@ -65,6 +78,7 @@ import {
 	SignedInfo100363,
 	SignedInfo100364,
 	SignedInfo101035,
+	SignRInfo,
 } from 'omnibolt-js/lib/types/pojo';
 import { IAddressContent } from '../../store/types/wallet';
 import { resumeFromCheckpoints } from './checkpoints';
@@ -2123,4 +2137,595 @@ export const onChannelCloseAttempt = (data: any): void => {
 	} catch (e) {
 		console.log(e);
 	}
+};
+
+/**
+ * MsgType_HTLC_CreatedRAndHInfoList_N4001
+ * @return {Promise<Result<any>>}
+ */
+export const getAddHTLCRandHInfoList = async (): Promise<Result<any>> => {
+	try {
+		return await obdapi.getAddHTLCRandHInfoList();
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_HTLC_SignedRAndHInfoList_N4101
+ * @return {Promise<Result<any>>}
+ */
+export const getHtlcSignedRandHInfoList = async (): Promise<Result<any>> => {
+	try {
+		return await obdapi.getHtlcSignedRandHInfoList();
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_HTLC_GetRFromLCommitTx_N4103
+ * @param {string} channel_id
+ * @return {Promise<Result<any>>}
+ */
+export const getRFromCommitmentTx = async (
+	channel_id,
+): Promise<Result<any>> => {
+	try {
+		if (!channel_id) {
+			return err('No channel id provided.');
+		}
+		return await obdapi.getRFromCommitmentTx(channel_id);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_HTLC_GetPathInfoByH_N4104
+ * @param {string} h
+ * @return {Promise<Result<any>>}
+ */
+export const getPathInfoByH = async (h): Promise<Result<any>> => {
+	try {
+		if (!h) {
+			return err('Empty h.');
+		}
+		return await obdapi.getPathInfoByH(h);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_HTLC_GetRInfoByHOfOwner_N4105
+ * @param {string} h
+ * @return {Promise<Result<any>>}
+ */
+export const getRByHOfReceiver = async (h): Promise<Result<any>> => {
+	try {
+		if (!h) {
+			return err('Empty h.');
+		}
+		return await obdapi.getRByHOfReceiver(h);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_CommitmentTx_LatestCommitmentTxByChanId_3203
+ * @param {string} channel_id
+ * @return {Promise<Result<any>>}
+ */
+export const getLatestCommitmentTransaction = async (
+	channel_id,
+): Promise<Result<any>> => {
+	try {
+		if (!channel_id) {
+			return err('No channel id provided.');
+		}
+		return await obdapi.getLatestCommitmentTransaction(channel_id);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_CommitmentTx_LatestCommitmentTxByChanId_3203
+ * @param {string} channel_id
+ * @return {Promise<Result<any>>}
+ */
+export const getItemsByChannelId = async (channel_id): Promise<Result<any>> => {
+	try {
+		if (!channel_id) {
+			return err('No channel id provided.');
+		}
+		return await obdapi.getItemsByChannelId(channel_id);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_GetMiniBtcFundAmount_2006
+ * @return {Promise<Result<any>>}
+ */
+export const getAmountOfRechargeBTC = async (): Promise<Result<any>> => {
+	try {
+		return await obdapi.getAmountOfRechargeBTC();
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_GetChannelInfoByChannelId_3154
+ * @param {string} channel_id
+ * @return {Promise<Result<any>>}
+ */
+export const getChannelDetailFromChannelID = async (
+	channel_id,
+): Promise<Result<any>> => {
+	try {
+		if (!channel_id) {
+			return err('No channel id provided.');
+		}
+		return await obdapi.getChannelDetailFromChannelID(channel_id);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_GetChannelInfoByDbId_3155
+ * @param {string} id
+ * @return {Promise<Result<any>>}
+ */
+export const getChannelDetailFromDatabaseID = async (
+	id,
+): Promise<Result<any>> => {
+	try {
+		if (!id) {
+			return err('No id provided.');
+		}
+		return await obdapi.getChannelDetailFromDatabaseID(id);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_CommitmentTx_AllBRByChanId_3208
+ * @param {string} channel_id
+ * @return {Promise<Result<any>>}
+ */
+export const getAllBreachRemedyTransactions = async (
+	channel_id,
+): Promise<Result<any>> => {
+	try {
+		if (!channel_id) {
+			return err('No channel id provided.');
+		}
+		return await obdapi.getAllBreachRemedyTransactions(channel_id);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_CommitmentTx_ItemsByChanId_3200
+ * @param {string} channel_id
+ * @return {Promise<Result<any>>}
+ */
+export const getAllCommitmentTx = async (channel_id): Promise<Result<any>> => {
+	try {
+		if (!channel_id) {
+			return err('No channel id provided.');
+		}
+		return await obdapi.getAllCommitmentTx(channel_id);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_CommitmentTx_LatestRDByChanId_3204
+ * @param {string} channel_id
+ * @return {Promise<Result<any>>}
+ */
+export const getLatestRevockableDeliveryTransaction = async (
+	channel_id,
+): Promise<Result<any>> => {
+	try {
+		if (!channel_id) {
+			return err('No channel id provided.');
+		}
+		return await obdapi.getLatestRevockableDeliveryTransaction(channel_id);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_CommitmentTx_LatestRDByChanId_3204
+ * @param {string} channel_id
+ * @return {Promise<Result<any>>}
+ */
+export const getLatestBreachRemedyTransaction = async (
+	channel_id,
+): Promise<Result<any>> => {
+	try {
+		if (!channel_id) {
+			return err('No channel id provided.');
+		}
+		return await obdapi.getLatestBreachRemedyTransaction(channel_id);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_CommitmentTx_SendSomeCommitmentById_3206
+ * @param {string} id
+ * @return {Promise<Result<any>>}
+ */
+export const sendSomeCommitmentById = async (id): Promise<Result<any>> => {
+	try {
+		if (!id) {
+			return err('No id provided.');
+		}
+		return await obdapi.sendSomeCommitmentById(id);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_CommitmentTx_AllRDByChanId_3207
+ * @param {string} channel_id
+ * @return {Promise<Result<any>>}
+ */
+export const getAllRevockableDeliveryTransactions = async (
+	channel_id,
+): Promise<Result<any>> => {
+	try {
+		if (!channel_id) {
+			return err('No channel id provided.');
+		}
+		return await obdapi.getAllRevockableDeliveryTransactions(channel_id);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_Atomic_SendSwap_80
+ * @param recipient_node_peer_id string
+ * @param recipient_user_peer_id string
+ * @param info AtomicSwapRequest
+ */
+export const atomicSwap = async ({
+	recipient_node_peer_id = '',
+	recipient_user_peer_id = '',
+	info,
+}: {
+	recipient_node_peer_id: string;
+	recipient_user_peer_id: string;
+	info: AtomicSwapRequest;
+}): Promise<unknown> => {
+	return await obdapi.atomicSwap(
+		recipient_node_peer_id,
+		recipient_user_peer_id,
+		info,
+	);
+};
+
+/**
+ * MsgType_Atomic_SendSwapAccept_81
+ * @param recipient_node_peer_id string
+ * @param recipient_user_peer_id string
+ * @param info AtomicSwapAccepted
+ */
+export const atomicSwapAccepted = async ({
+	recipient_node_peer_id = '',
+	recipient_user_peer_id = '',
+	info,
+}: {
+	recipient_node_peer_id: string;
+	recipient_user_peer_id: string;
+	info: AtomicSwapAccepted;
+}): Promise<Result<any>> => {
+	return await obdapi.atomicSwapAccepted(
+		recipient_node_peer_id,
+		recipient_user_peer_id,
+		info,
+	);
+};
+
+/**
+ * MsgType_CheckChannelAddessExist_3156
+ * @param recipient_node_peer_id string
+ * @param recipient_user_peer_id string
+ * @param info AcceptChannelInfo
+ */
+export const checkChannelAddessExist = async ({
+	recipient_node_peer_id = '',
+	recipient_user_peer_id = '',
+	info,
+}: {
+	recipient_node_peer_id: string;
+	recipient_user_peer_id: string;
+	info: AcceptChannelInfo;
+}): Promise<unknown> => {
+	if (!info) {
+		return err('No info provided.');
+	}
+	return await obdapi.checkChannelAddessExist(
+		recipient_node_peer_id,
+		recipient_user_peer_id,
+		info,
+	);
+};
+
+/**
+ * MsgType_HTLC_Invoice_402
+ * @param {InvoiceInfo} info
+ * @return {Promise<Result<any>>}
+ */
+export const addInvoice = async (info: InvoiceInfo): Promise<Result<any>> => {
+	try {
+		if (!info) {
+			return err('No invoice info provided.');
+		}
+		return await obdapi.addInvoice(info);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_HTLC_Invoice_402
+ * @param {HTLCFindPathInfo} info
+ * @return {Promise<Result<any>>}
+ */
+export const HTLCFindPath = async (
+	info: HTLCFindPathInfo,
+): Promise<unknown> => {
+	try {
+		if (!info) {
+			return err('No info provided.');
+		}
+		return await obdapi.HTLCFindPath(info);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * MsgType_HTLC_SendAddHTLC_40
+ * @param recipient_node_peer_id string
+ * @param recipient_user_peer_id string
+ * @param info addHTLCInfo
+ */
+export const addHTLC = async ({
+	recipient_node_peer_id = '',
+	recipient_user_peer_id = '',
+	info,
+}: {
+	recipient_node_peer_id: string;
+	recipient_user_peer_id: string;
+	info: addHTLCInfo;
+}): Promise<unknown> => {
+	if (!info) {
+		return err('No info provided.');
+	}
+	return await obdapi.addHTLC(
+		recipient_node_peer_id,
+		recipient_user_peer_id,
+		info,
+	);
+};
+
+/**
+ * MsgType_HTLC_SendAddHTLCSigned_41
+ * @param recipient_node_peer_id string
+ * @param recipient_user_peer_id string
+ * @param info HtlcSignedInfo
+ */
+export const htlcSigned = async ({
+	recipient_node_peer_id = '',
+	recipient_user_peer_id = '',
+	info,
+}: {
+	recipient_node_peer_id: string;
+	recipient_user_peer_id: string;
+	info: HtlcSignedInfo;
+}): Promise<unknown> => {
+	if (!info) {
+		return err('No info provided.');
+	}
+	return await obdapi.htlcSigned(
+		recipient_node_peer_id,
+		recipient_user_peer_id,
+		info,
+	);
+};
+
+/**
+ * MsgType_HTLC_SendVerifyR_45
+ * @param recipient_node_peer_id string
+ * @param recipient_user_peer_id string
+ * @param info ForwardRInfo
+ */
+export const forwardR = async ({
+	recipient_node_peer_id = '',
+	recipient_user_peer_id = '',
+	info,
+}: {
+	recipient_node_peer_id: string;
+	recipient_user_peer_id: string;
+	info: ForwardRInfo;
+}): Promise<unknown> => {
+	if (!info) {
+		return err('No info provided.');
+	}
+	return await obdapi.forwardR(
+		recipient_node_peer_id,
+		recipient_user_peer_id,
+		info,
+	);
+};
+
+/**
+ * MsgType_HTLC_SendSignVerifyR_46
+ * @param recipient_node_peer_id string
+ * @param recipient_user_peer_id string
+ * @param info SignRInfo
+ */
+export const signR = async ({
+	recipient_node_peer_id = '',
+	recipient_user_peer_id = '',
+	info,
+}: {
+	recipient_node_peer_id: string;
+	recipient_user_peer_id: string;
+	info: SignRInfo;
+}): Promise<unknown> => {
+	if (!info) {
+		return err('No info provided.');
+	}
+	return await obdapi.signR(
+		recipient_node_peer_id,
+		recipient_user_peer_id,
+		info,
+	);
+};
+
+/**
+ * MsgType_HTLC_SendRequestCloseCurrTx_49
+ * @param recipient_node_peer_id string
+ * @param recipient_user_peer_id string
+ * @param info CloseHtlcTxInfo
+ */
+export const closeHTLC = async ({
+	recipient_node_peer_id = '',
+	recipient_user_peer_id = '',
+	info,
+}: {
+	recipient_node_peer_id: string;
+	recipient_user_peer_id: string;
+	info: CloseHtlcTxInfo;
+}): Promise<unknown> => {
+	if (!info) {
+		return err('No info provided.');
+	}
+	return await obdapi.closeHTLC(
+		recipient_node_peer_id,
+		recipient_user_peer_id,
+		info,
+	);
+};
+
+/**
+ * MsgType_HTLC_SendCloseSigned_50
+ * @param recipient_node_peer_id string
+ * @param recipient_user_peer_id string
+ * @param info CloseHtlcTxInfoSigned
+ */
+export const closeHTLCSigned = async ({
+	recipient_node_peer_id = '',
+	recipient_user_peer_id = '',
+	info,
+}: {
+	recipient_node_peer_id: string;
+	recipient_user_peer_id: string;
+	info: CloseHtlcTxInfoSigned;
+}): Promise<unknown> => {
+	if (!info) {
+		return err('No info provided.');
+	}
+	return await obdapi.closeHTLCSigned(
+		recipient_node_peer_id,
+		recipient_user_peer_id,
+		info,
+	);
+};
+
+/**
+ * MsgType_Core_Omni_CreateNewTokenFixed_2113
+ * @param info IssueFixedAmountInfo
+ */
+export const issueFixedAmount = async ({
+	info,
+}: {
+	recipient_node_peer_id: string;
+	recipient_user_peer_id: string;
+	info: IssueFixedAmountInfo;
+}): Promise<unknown> => {
+	if (!info) {
+		return err('No info provided.');
+	}
+	return await obdapi.issueFixedAmount(info);
+};
+
+/**
+ * MsgType_Core_Omni_CreateNewTokenManaged_2114
+ * @param info IssueManagedAmoutInfo
+ */
+export const issueManagedAmout = async ({
+	info,
+}: {
+	info: IssueManagedAmoutInfo;
+}): Promise<unknown> => {
+	if (!info) {
+		return err('No info provided.');
+	}
+	return await obdapi.issueManagedAmout(info);
+};
+
+/**
+ * MsgType_Core_Omni_GrantNewUnitsOfManagedToken_2115
+ * @param info OmniSendGrant
+ */
+export const sendGrant = async ({
+	info,
+}: {
+	info: OmniSendGrant;
+}): Promise<unknown> => {
+	if (!info) {
+		return err('No info provided.');
+	}
+	return await obdapi.sendGrant(info);
+};
+
+/**
+ * MsgType_Core_Omni_RevokeUnitsOfManagedToken_2116
+ * @param info OmniSendRevoke
+ */
+export const sendRevoke = async ({
+	info,
+}: {
+	info: OmniSendRevoke;
+}): Promise<unknown> => {
+	if (!info) {
+		return err('No info provided.');
+	}
+	return await obdapi.sendRevoke(info);
+};
+
+/**
+ * MsgType_Core_Omni_Getbalance_2112
+ * @param address string
+ * @param callback function
+ */
+export const getAllBalancesForAddress = async ({
+	address,
+}: {
+	address: string;
+}): Promise<unknown> => {
+	if (!address) {
+		return err('No address provided.');
+	}
+	return await obdapi.getAllBalancesForAddress(address);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7200,7 +7200,7 @@ object.values@^1.1.0, object.values@^1.1.3:
 
 "omnibolt-js@git+ssh://git@github.com/synonymdev/omnibolt-js":
   version "1.0.0"
-  resolved "git+ssh://git@github.com/synonymdev/omnibolt-js#fc5bc04d7f6f890425885fe465fddaad4df0a292"
+  resolved "git+ssh://git@github.com/synonymdev/omnibolt-js#5760a360cde4ded0c1a1d7fdef2db56969c28e53"
   dependencies:
     babel "^6.23.0"
 


### PR DESCRIPTION
This PR:
 - Adds the ability to close an omnibolt channel via the omnibolt channel card.
 - Adds several omnibolt methods for future use when opening channels and transferring assets via omnibolt from the app.