### PR TITLE
Omnibolt Force Close

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import '../shim';
 import 'intl';
 import 'intl/locale-data/jsonp/en';
-import React, { memo, ReactElement, useEffect } from 'react';
+import React, { memo, ReactElement, useMemo, useEffect } from 'react';
 import { Platform, StyleSheet, UIManager } from 'react-native';
 import { useSelector } from 'react-redux';
 import { ThemeProvider } from 'styled-components/native';
@@ -13,7 +13,6 @@ import Toast from 'react-native-toast-message';
 import './utils/translations';
 import OnboardingNavigator from './navigation/onboarding/OnboardingNavigator';
 import { checkWalletExists, startWalletServices } from './utils/startup';
-import { getStore } from './store/helpers';
 
 if (Platform.OS === 'android') {
 	if (UIManager.setLayoutAnimationEnabledExperimental) {
@@ -22,21 +21,24 @@ if (Platform.OS === 'android') {
 }
 
 const App = (): ReactElement => {
-	const { walletExists } = useSelector((state: Store) => state.wallet);
+	const walletExists = useSelector((state: Store) => state.wallet.walletExists);
+	const theme = useSelector((state: Store) => state.settings.theme);
 
 	useEffect(() => {
 		(async (): Promise<void> => {
-			await checkWalletExists();
-
-			if (getStore().wallet.walletExists) {
-				await startWalletServices();
+			const _walletExists = await checkWalletExists();
+			if (_walletExists) {
+				await startWalletServices({});
 			}
 		})();
 	}, []);
 
-	const settings = useSelector((state: Store) => state.settings);
+	const currentTheme = useMemo(() => {
+		return themes[theme];
+	}, [theme]);
+
 	return (
-		<ThemeProvider theme={themes[settings.theme]}>
+		<ThemeProvider theme={currentTheme}>
 			<StatusBar />
 			<SafeAreaView style={styles.container}>
 				{walletExists ? <RootNavigator /> : <OnboardingNavigator />}

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -1,26 +1,13 @@
 import React, { PropsWithChildren, ReactElement } from 'react';
-import { StyleSheet, View } from 'react-native';
-import { useSelector } from 'react-redux';
-import Store from '../store/types';
-import themes from '../styles/themes';
+import { StyleSheet } from 'react-native';
+import { View } from '../styles/components';
 
 interface Props extends PropsWithChildren<any> {
 	style?: {};
 }
 
 const Divider = ({ style }: Props = { style: {} }): ReactElement => {
-	const settings = useSelector((state: Store) => state.settings);
-	const theme = themes[settings.theme];
-
-	return (
-		<View
-			style={[
-				styles.line,
-				{ backgroundColor: theme.colors.onBackground },
-				style,
-			]}
-		/>
-	);
+	return <View color={'onBackground'} style={[styles.line, style]} />;
 };
 
 const styles = StyleSheet.create({

--- a/src/screens/Onboarding/RestoreAccount.tsx
+++ b/src/screens/Onboarding/RestoreAccount.tsx
@@ -38,7 +38,7 @@ const OnboardingRestoreAccountScreen = (): ReactElement => {
 								message: 'Wallet is being restored',
 							});
 
-							await startWalletServices();
+							await startWalletServices({});
 
 							setIsRestoring(false);
 						}}

--- a/src/screens/Onboarding/RestoreFromFile.tsx
+++ b/src/screens/Onboarding/RestoreFromFile.tsx
@@ -44,7 +44,7 @@ const OnboardingRestoreFromFileScreen = ({ navigation }): ReactElement => {
 			message: 'Wallet is being restored',
 		});
 
-		await startWalletServices();
+		await startWalletServices({});
 	};
 
 	const openFiles = async (): Promise<void> => {

--- a/src/screens/Settings/ExchangeRate/index.tsx
+++ b/src/screens/Settings/ExchangeRate/index.tsx
@@ -1,5 +1,4 @@
 import React, { memo, ReactElement } from 'react';
-import RadioButtonRN from 'radio-buttons-react-native';
 import { ScrollView, StyleSheet } from 'react-native';
 import { useSelector } from 'react-redux';
 import {
@@ -7,9 +6,9 @@ import {
 	Text,
 	TouchableOpacity,
 	View,
+	RadioButtonRN,
 } from '../../../styles/components';
 import Store from '../../../store/types';
-import themes from '../../../styles/themes';
 import {
 	EExchangeRateService,
 	supportedExchangeTickers,
@@ -21,16 +20,19 @@ import { TBitcoinUnit } from '../../../store/types/wallet';
 import { RadioButtonItem } from '../../../store/types/settings';
 
 const ExchangeRateSettings = ({ navigation }): ReactElement => {
-	const settings = useSelector((state: Store) => state.settings);
-	const itemStyle = { color: themes[settings.theme].colors.text };
-	const activeColor = themes[settings.theme].colors.onBackground;
+	const selectedExchangeRateService = useSelector(
+		(state: Store) => state.settings.exchangeRateService,
+	);
+	const selectedCurrency = useSelector(
+		(state: Store) => state.settings.selectedCurrency,
+	);
+	const selectedBitcoinUnit = useSelector(
+		(state: Store) => state.settings.bitcoinUnit,
+	);
 
 	const exchangeRateProviders = Object.keys(EExchangeRateService).filter(
 		(key) => isNaN(Number(EExchangeRateService[key])),
 	);
-	const selectedExchangeRateService = settings.exchangeRateService;
-	const selectedCurrency = settings.selectedCurrency;
-	const selectedBitcoinUnit = settings.bitcoinUnit;
 	const bitcoinUnits: TBitcoinUnit[] = ['BTC', 'satoshi'];
 
 	const onSetExchangeRateService = (provider: EExchangeRateService): void => {
@@ -92,12 +94,6 @@ const ExchangeRateSettings = ({ navigation }): ReactElement => {
 		}
 	});
 
-	const radioButtonProps = {
-		box: false,
-		textStyle: itemStyle,
-		activeColor,
-	};
-
 	return (
 		<View style={styles.container}>
 			<TouchableOpacity
@@ -116,7 +112,6 @@ const ExchangeRateSettings = ({ navigation }): ReactElement => {
 			<ScrollView>
 				<Text style={styles.titleText}>Exchange rate provider</Text>
 				<RadioButtonRN
-					{...radioButtonProps}
 					data={services}
 					selectedBtn={(e): void => onSetExchangeRateService(e.value)}
 					initial={initialServiceIndex}
@@ -124,7 +119,6 @@ const ExchangeRateSettings = ({ navigation }): ReactElement => {
 
 				<Text style={styles.titleText}>Display currency</Text>
 				<RadioButtonRN
-					{...radioButtonProps}
 					data={tickers}
 					selectedBtn={(e): void => {
 						if (e) {
@@ -137,7 +131,6 @@ const ExchangeRateSettings = ({ navigation }): ReactElement => {
 				<Text style={styles.titleText}>Bitcoin display unit</Text>
 
 				<RadioButtonRN
-					{...radioButtonProps}
 					data={units}
 					selectedBtn={(e): void => onSetBitcoinUnit(e.value)}
 					initial={initialUnitIndex}

--- a/src/screens/Settings/ExchangeRate/index.tsx
+++ b/src/screens/Settings/ExchangeRate/index.tsx
@@ -18,8 +18,7 @@ import { updateSettings } from '../../../store/actions/settings';
 import useDisplayValues from '../../../utils/exchange-rate/useDisplayValues';
 import { updateExchangeRates } from '../../../store/actions/wallet';
 import { TBitcoinUnit } from '../../../store/types/wallet';
-
-type RadioButtonItem = { label: string; value: string };
+import { RadioButtonItem } from '../../../store/types/settings';
 
 const ExchangeRateSettings = ({ navigation }): ReactElement => {
 	const settings = useSelector((state: Store) => state.settings);

--- a/src/store/actions/settings.ts
+++ b/src/store/actions/settings.ts
@@ -7,6 +7,7 @@ import { deleteOmniboltId } from '../../utils/omnibolt';
 import { wipeAuthDetails } from '../../utils/backup/backpack';
 import { wipeLndDir } from '../../utils/lightning';
 import { removePin } from '../../utils/settings';
+import { resetActivityStore } from './activity';
 
 const dispatch = getDispatch();
 
@@ -52,6 +53,7 @@ export const wipeWallet = async ({
 			wipeAuthDetails(),
 			resetKeychainValue({ key: 'lndMnemonic' }),
 			wipeLndDir(),
+			resetActivityStore(),
 		]);
 		dispatch({
 			type: actions.WIPE_WALLET,

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -13,4 +13,5 @@ export const defaultSettingsShape: ISettings = {
 	exchangeRateService: EExchangeRateService.bitfinex,
 	selectedLanguage: 'english',
 	customElectrumPeers: { ...arrayTypeItems },
+	coinSelectPreference: 'small',
 };

--- a/src/store/types/settings.ts
+++ b/src/store/types/settings.ts
@@ -3,6 +3,7 @@ import { EExchangeRateService } from '../../utils/exchange-rate';
 
 type TTheme = 'dark' | 'light' | 'blue';
 type TProtocol = 'ssl' | 'tcp';
+export type TCoinSelectPreference = 'small' | 'large' | 'consolidate';
 
 export interface ICustomElectrumPeer {
 	host: string;
@@ -22,5 +23,8 @@ export interface ISettings {
 	selectedCurrency: string;
 	exchangeRateService: EExchangeRateService;
 	selectedLanguage: string;
+	coinSelectPreference: TCoinSelectPreference;
 	[key: string]: any;
 }
+
+export type RadioButtonItem = { label: string; value: string };

--- a/src/styles/components.ts
+++ b/src/styles/components.ts
@@ -6,6 +6,7 @@ import _Ionicons from 'react-native-vector-icons/Ionicons';
 import _MaterialIcons from 'react-native-vector-icons/MaterialIcons';
 import Animated from 'react-native-reanimated';
 import colors from './colors';
+import _RadioButtonRN from 'radio-buttons-react-native';
 
 export const SafeAreaView = styled.SafeAreaView`
 	flex: 1;
@@ -50,8 +51,11 @@ export const ScrollView = styled.ScrollView`
 	background-color: ${(props): string => props.theme.colors.background};
 `;
 
-export const TextInput = styled.TextInput.attrs(() => ({
+export const TextInput = styled.TextInput.attrs((props) => ({
 	selectionColor: colors.orange,
+	placeholderTextColor: props?.placeholderTextColor
+		? props.placeholderTextColor
+		: 'gray',
 }))`
 	background-color: ${(props): string =>
 		props.backgroundColor
@@ -89,6 +93,16 @@ export const Text = styled.Text`
 			? props.theme.fonts[props.font].fontWeight
 			: props.theme.fonts.medium.fontWeight};
 `;
+
+export const RadioButtonRN = styled(_RadioButtonRN).attrs((props) => ({
+	box: props?.box ? props.box : false,
+	textStyle: props?.textStyle
+		? props.textStyle
+		: { color: props.theme.colors.text },
+	activeColor: props?.activeColor
+		? props.activeColor
+		: props.theme.colors.onBackground,
+}))``;
 
 export const Feather = styled(_Feather).attrs((props) => ({
 	color: props.color

--- a/src/utils/omnibolt/index.ts
+++ b/src/utils/omnibolt/index.ts
@@ -74,7 +74,7 @@ import { IMyChannelsData } from '../../store/shapes/omnibolt';
 import { showSuccessNotification } from '../notifications';
 import { ISendSignedHex100362Response } from 'omnibolt-js/src/types';
 
-const obdapi = new ObdApi();
+const obdapi = new ObdApi({});
 
 /**
  * Connect to a specified omnibolt server.

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -934,11 +934,13 @@ export const updateFee = ({
 /**
  * Returns a block explorer URL for a specific transaction
  * @param {string} id
+ * @param {'tx' | 'address'} type
  * @param {TAvailableNetworks} selectedNetwork
  * @param {'blockstream' | 'mempool'} [service]
  */
 export const getBlockExplorerLink = (
 	id: string,
+	type: 'tx' | 'address' = 'tx',
 	selectedNetwork: TAvailableNetworks | undefined = undefined,
 	service: 'blockstream' | 'mempool' = 'mempool',
 ): string => {
@@ -948,15 +950,15 @@ export const getBlockExplorerLink = (
 	switch (service) {
 		case 'blockstream':
 			if (selectedNetwork === 'bitcoinTestnet') {
-				return `https://blockstream.info/testnet/tx/${id}`;
+				return `https://blockstream.info/testnet/${type}/${id}`;
 			} else {
-				return `https://blockstream.info/tx/${id}`;
+				return `https://blockstream.info/${type}/${id}`;
 			}
 		case 'mempool':
 			if (selectedNetwork === 'bitcoinTestnet') {
-				return `https://mempool.space/testnet/tx/${id}`;
+				return `https://mempool.space/testnet/${type}/${id}`;
 			} else {
-				return `https://mempool.space/tx/${id}`;
+				return `https://mempool.space/${type}/${id}`;
 			}
 	}
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -7205,7 +7205,7 @@ object.values@^1.1.0, object.values@^1.1.3:
 
 "omnibolt-js@git+ssh://git@github.com/synonymdev/omnibolt-js":
   version "1.0.0"
-  resolved "git+ssh://git@github.com/synonymdev/omnibolt-js#fe6eebbb75fc023fe90fe97493a67268c2beb208"
+  resolved "git+ssh://git@github.com/synonymdev/omnibolt-js#6eb3b4843e04181c340e564164c4db26a6e47467"
   dependencies:
     babel "^6.23.0"
     bip32 "^2.0.6"


### PR DESCRIPTION
This PR adds the ability to force close an omnibolt channel.

![Simulator Screen Shot - iPhone 12 - 2021-07-07 at 16 14 03](https://user-images.githubusercontent.com/8532651/124822892-88249f80-df3e-11eb-8cf4-c173eda340cb.png)

The obd node doesn't recognize that the channel is closed until the transaction has 2 confirmations. To get around this in the future we will want to monitor the funding address for transactions indicating a pending close and/or simply save some local channel state when force closing.