### PR TITLE
Blocktank updates

### DIFF
--- a/__tests__/transactions.ts
+++ b/__tests__/transactions.ts
@@ -25,7 +25,7 @@ describe('On chain transactions', () => {
 
 		await updateWallet({ wallets: { wallet0: walletState } });
 
-		setupOnChainTransaction({});
+		await setupOnChainTransaction({});
 	});
 
 	it('Creates an on chain transaction from the transaction store', async () => {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@react-navigation/native": "^6.0.2",
     "@react-navigation/native-stack": "^6.1.0",
     "@react-navigation/stack": "^6.0.6",
-    "@synonymdev/blocktank-client": "^0.0.3",
+    "@synonymdev/blocktank-client": "^0.0.4",
     "@synonymdev/react-native-lightning": "0.0.34",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "aezeed": "^0.0.4",

--- a/src/screens/Blocktank/OrderService.tsx
+++ b/src/screens/Blocktank/OrderService.tsx
@@ -135,6 +135,9 @@ const Order = (props: Props): ReactElement => {
 		onRefreshOrder().catch();
 	}, [onRefreshOrder]);
 
+	const showPayButton = order && order?.state === 0;
+	const showClaimButton = order && order?.state === 100;
+
 	return (
 		<View style={styles.container}>
 			<NavigationHeader title={description} />
@@ -198,26 +201,11 @@ const Order = (props: Props): ReactElement => {
 					<Divider />
 
 					{orderId ? (
-						<>
-							<Button
-								text={isRefreshing ? 'Refreshing...' : 'Refresh order'}
-								disabled={isRefreshing}
-								onPress={onRefreshOrder}
-							/>
-							{order?.state === 0 ? (
-								<Button
-									text={'Pay'}
-									disabled={isProcessing}
-									onPress={goToPayment}
-								/>
-							) : (
-								<Button
-									text={isProcessing ? 'Claiming...' : 'Claim channel'}
-									disabled={isProcessing}
-									onPress={onClaimChannel}
-								/>
-							)}
-						</>
+						<Button
+							text={isRefreshing ? 'Refreshing...' : 'Refresh order'}
+							disabled={isRefreshing}
+							onPress={onRefreshOrder}
+						/>
 					) : (
 						<Button
 							text={isProcessing ? 'Ordering...' : 'Order'}
@@ -225,6 +213,21 @@ const Order = (props: Props): ReactElement => {
 							onPress={onOrder}
 						/>
 					)}
+
+					{showPayButton ? (
+						<Button
+							text={'Pay'}
+							disabled={isProcessing}
+							onPress={goToPayment}
+						/>
+					) : null}
+					{showClaimButton ? (
+						<Button
+							text={isProcessing ? 'Claiming...' : 'Claim channel'}
+							disabled={isProcessing}
+							onPress={onClaimChannel}
+						/>
+					) : null}
 				</View>
 			</View>
 		</View>

--- a/src/screens/Blocktank/Payment.tsx
+++ b/src/screens/Blocktank/Payment.tsx
@@ -232,8 +232,6 @@ const BlocktankPayment = (props: Props): ReactElement => {
 				</Text>
 			) : null}
 
-			<Text>RBF: {transaction.rbf ? 'TRUE' : 'FALSE'}</Text>
-
 			<FeeSummary amount={order.total_amount} lightning />
 
 			<Button color={'onSurface'} text="Pay" onPress={authCheck} />

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -282,7 +282,7 @@ const Settings = ({ navigation }): ReactElement => {
 						hide: false,
 					},
 					{
-						title: 'Reset Chaintank Store',
+						title: 'Reset Blocktank Store',
 						type: 'button',
 						onPress: async (): Promise<void> => {
 							await resetBlocktankStore();

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -544,6 +544,7 @@ export const setupOnChainTransaction = async ({
 			inputs,
 			changeAddress,
 			fee,
+			rbf: true, //TODO default RBF flag should be determined from user settings
 			outputs: newOutputs,
 		};
 		dispatch({

--- a/src/store/reducers/wallet.ts
+++ b/src/store/reducers/wallet.ts
@@ -202,6 +202,7 @@ const wallet = (state = { ...defaultWalletStoreShape }, action): IWallet => {
 								inputs: action.payload.inputs,
 								outputs: action.payload.outputs,
 								fee: action.payload.fee,
+								rbf: action.payload.rbf,
 							},
 						},
 					},

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -425,11 +425,12 @@ const createPsbtFromTransactionData = async ({
 		outputs = [],
 		changeAddress,
 		fee = ETransactionDefaults.recommendedBaseFee,
+		rbf,
 	} = transactionData;
 	let message = transactionData.message;
 
 	//Get balance of current inputs.
-	const balance = await getTransactionInputValue({
+	const balance = getTransactionInputValue({
 		selectedWallet,
 		selectedNetwork,
 		inputs,
@@ -500,7 +501,7 @@ const createPsbtFromTransactionData = async ({
 	}
 
 	//Set RBF if supported and prompted via rbf in Settings.
-	setReplaceByFee({ psbt, setRbf: true });
+	setReplaceByFee({ psbt, setRbf: !!rbf });
 
 	// Shuffle targets if not run from unit test and add outputs.
 	if (process.env.JEST_WORKER_ID === undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,10 +1471,10 @@
     merge-deep "^3.0.2"
     svgo "^1.2.2"
 
-"@synonymdev/blocktank-client@^0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@synonymdev/blocktank-client/-/blocktank-client-0.0.3.tgz#62b0f3d246220f89951959123995677a970198b6"
-  integrity sha512-1CSgG5SlOjiuYsYgNccYA5GwQud4AqP1YdWApStrHWef4luQuhx2Lucs5Es/sO3w+Ol42GOySpt6MZY596RvxA==
+"@synonymdev/blocktank-client@^0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@synonymdev/blocktank-client/-/blocktank-client-0.0.4.tgz#9e33fd957ee855161f919840021bccad76057773"
+  integrity sha512-3gmqX3Dkg2aO7Pvb/PJ1oMNpGOpJy8cj2Vnj2827ePh5Uz8jhJOuYIK5U01R6Y68ZDZdjAf8317GpVIXM3Ux3A==
 
 "@synonymdev/react-native-lightning@0.0.34":
   version "0.0.34"


### PR DESCRIPTION
- Updated client lib
- Payment view sets and uses the suggested fee. A warning label appears if the user chooses to lower it below recommended fee.
- Setting RBF flag when creating PSBT. Previously defaulted to `true` for every tx
- Defaulting to `true` when calling `setupOnChainTransaction` but we'll set that default from the user settings.