### PR TITLE
Single Seed Derivation

### DIFF
--- a/src/utils/omnibolt/index.ts
+++ b/src/utils/omnibolt/index.ts
@@ -28,10 +28,10 @@ import {
 } from 'omnibolt-js/lib/types/types';
 import {
 	generateAddresses,
-	generateMnemonic,
 	getCurrentWallet,
 	getKeyDerivationPath,
 	getMnemonicPhrase,
+	getMnemonicPhraseFromEntropy,
 	getPrivateKey,
 	getSelectedNetwork,
 	getSelectedWallet,
@@ -599,7 +599,12 @@ export const createOmniboltId = async ({
 			if (!response.error) {
 				return ok(response.data);
 			}
-			const id = await generateMnemonic();
+			const seedStr = await getMnemonicPhrase(selectedWallet); //Set if wallet is being restored from a backup
+			if (seedStr.isErr()) {
+				return err("On-Chain wallet doesn't exist.");
+			}
+			// Derive the omnibolt login id from the sha256 hash of on-chain wallet's mnemonic.
+			const id = await getMnemonicPhraseFromEntropy(seedStr.value);
 			const keychainResponse = await setKeychainValue({ key, value: id });
 			if (keychainResponse.error) {
 				return err(keychainResponse.data);

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -1,4 +1,8 @@
-import { getMnemonicPhrase, refreshWallet } from '../wallet';
+import {
+	getMnemonicPhrase,
+	getMnemonicPhraseFromEntropy,
+	refreshWallet,
+} from '../wallet';
 import {
 	createWallet,
 	updateExchangeRates,
@@ -19,6 +23,7 @@ import { showErrorNotification } from '../notifications';
 import { refreshServiceList } from '../../store/actions/blocktank';
 import { setupTodos } from '../todos';
 import { connectToElectrum } from '../wallet/electrum';
+import { setupLightningSeed } from '../lightning';
 
 /**
  * Checks if the specified wallet's phrase is saved to storage.
@@ -81,9 +86,19 @@ export const startWalletServices = async ({
 			//Create wallet if none exists.
 			let { wallets, selectedNetwork, selectedWallet } = getStore().wallet;
 
+			const walletExists = await checkWalletExists();
 			const walletKeys = Object.keys(wallets);
-			if (!wallets[walletKeys[0]] || !wallets[walletKeys[0]]?.id) {
-				await createWallet({});
+			if (
+				!walletExists ||
+				!wallets[walletKeys[0]] ||
+				!wallets[walletKeys[0]]?.id
+			) {
+				const lndSeed = await setupLightningSeed();
+				if (lndSeed.isErr()) {
+					return err('Unable to setup lightning seed.');
+				}
+				const mnemonic = getMnemonicPhraseFromEntropy(lndSeed.value.join(' '));
+				await createWallet({ mnemonic });
 			}
 
 			if (onchain) {

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -475,6 +475,25 @@ export const getMnemonicPhrase = async (
 };
 
 /**
+ * Generate a mnemonic phrase using a string as entropy.
+ * @param {string} str
+ * @return {string}
+ */
+export const getMnemonicPhraseFromEntropy = (str: string): string => {
+	const hash = getSha256(str);
+	return bip39.entropyToMnemonic(hash);
+};
+
+/**
+ * Returns sha256 hash of string.
+ * @param {string} str
+ * @return {string}
+ */
+export const getSha256 = (str = ''): string => {
+	return bitcoin.crypto.sha256(str);
+};
+
+/**
  *.Returns any previously stored aezeed passphrase.
  * @async
  * @return {{error: boolean, data: string}}


### PR DESCRIPTION
This PR sets the app up to derive all seeds used for lightning, on-chain & omnibolt wallets from a single seed.

The current derivation is as follows:
Lightning Seed -> On-Chain & Omnibolt Seeds -> Omnibolt Login

The lightning seed is initially derived via `CipherSeed.random()` from the `aezeed` library when creating the wallet.

The on-chain/omnibolt seeds are derived by getting the sha256 hash of the lightning seed and passing it to `bip39.entropyToMnemonic(hash);`.

The omnibolt login phrase is derived by getting the sha256 hash of the on-chain seed and passing it to `bip39.entropyToMnemonic(hash);`.