### PR TITLE
On-Chain Number Pad

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,7 @@ import React, {
 	useEffect,
 	useCallback,
 } from 'react';
-import { Platform, UIManager, useColorScheme } from 'react-native';
+import { Platform, UIManager } from 'react-native';
 import { useSelector } from 'react-redux';
 import { ThemeProvider } from 'styled-components/native';
 import { SafeAreaProvider } from './styles/components';
@@ -20,7 +20,6 @@ import Toast from 'react-native-toast-message';
 import './utils/translations';
 import OnboardingNavigator from './navigation/onboarding/OnboardingNavigator';
 import { checkWalletExists, startWalletServices } from './utils/startup';
-import { updateSettings } from './store/actions/settings';
 
 if (Platform.OS === 'android') {
 	if (UIManager.setLayoutAnimationEnabledExperimental) {
@@ -31,21 +30,14 @@ if (Platform.OS === 'android') {
 const App = (): ReactElement => {
 	const walletExists = useSelector((state: Store) => state.wallet.walletExists);
 	const theme = useSelector((state: Store) => state.settings.theme);
-	const colorScheme = useColorScheme();
 
 	useEffect(() => {
 		(async (): Promise<void> => {
 			const _walletExists = await checkWalletExists();
-			if (!_walletExists) {
-				//Set theme based on device preference.
-				const userPreference = colorScheme === 'light' ? 'light' : 'dark';
-				updateSettings({ theme: userPreference });
-			}
 			if (_walletExists) {
 				await startWalletServices({});
 			}
 		})();
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	const currentTheme = useMemo(() => {

--- a/src/components/AmountToggle.tsx
+++ b/src/components/AmountToggle.tsx
@@ -1,0 +1,140 @@
+import React, { memo, ReactElement, useCallback, useMemo } from 'react';
+import {
+	Display,
+	Title,
+	View,
+	Pressable,
+	Headline,
+} from '../styles/components';
+import { LayoutAnimation, StyleSheet } from 'react-native';
+import { abbreviateNumber } from '../utils/helpers';
+import useDisplayValues from '../hooks/displayValues';
+import { IDisplayValues } from '../utils/exchange-rate';
+import { toggleView } from '../store/actions/user';
+import { useSelector } from 'react-redux';
+import Store from '../store/types';
+
+const FiatBalance = memo(
+	({
+		displayValues,
+		primary = true,
+	}: {
+		displayValues: IDisplayValues;
+		primary: boolean;
+	}): ReactElement => {
+		LayoutAnimation.easeInEaseOut();
+		const { fiatWhole, fiatDecimal, fiatDecimalValue, fiatTicker } =
+			displayValues;
+		const size = useMemo(() => (primary ? '34px' : '18px'), [primary]);
+		if (fiatWhole.length > 12) {
+			const { newValue, abbreviation } = abbreviateNumber(fiatWhole);
+			return (
+				<View style={styles.row}>
+					<Headline size={size} color={primary ? null : 'gray'}>
+						{newValue}
+					</Headline>
+					<Headline size={size} color="gray">
+						{abbreviation}
+					</Headline>
+				</View>
+			);
+		}
+		return (
+			<View style={styles.row}>
+				<Display size={size} color={primary ? null : 'gray'}>
+					{fiatWhole}
+					{fiatDecimal}
+					{fiatDecimalValue}{' '}
+				</Display>
+				<Title size={size} color="gray">
+					{fiatTicker}
+				</Title>
+			</View>
+		);
+	},
+);
+
+const AssetBalance = memo(
+	({
+		displayValues,
+		primary = true,
+	}: {
+		displayValues: IDisplayValues;
+		primary: boolean;
+	}): ReactElement => {
+		LayoutAnimation.easeInEaseOut();
+		const size = useMemo(() => (primary ? '34px' : '18px'), [primary]);
+		const { bitcoinFormatted, bitcoinTicker } = displayValues;
+		return (
+			<View style={styles.row} size={size}>
+				<Headline size={size} color={primary ? null : 'gray'}>
+					{bitcoinFormatted}
+				</Headline>
+				<Headline size={size} color="gray">
+					{' '}
+					{bitcoinTicker.toLowerCase()}
+				</Headline>
+			</View>
+		);
+	},
+);
+
+/**
+ * Displays the total amount of sats specified and it's corresponding fiat value.
+ */
+const AmountToggle = ({
+	sats = 0,
+	style,
+}: {
+	sats: number;
+	style?: object;
+}): ReactElement => {
+	const primary = useSelector((state: Store) => state.settings.unitPreference);
+	const displayValues = useDisplayValues(sats);
+	const fiatIsPrimary = useMemo(() => primary === 'fiat', [primary]);
+
+	const getBalanceComponents = useCallback(() => {
+		const arr: ReactElement[] = [
+			<FiatBalance displayValues={displayValues} primary={fiatIsPrimary} />,
+			<AssetBalance displayValues={displayValues} primary={!fiatIsPrimary} />,
+		];
+		if (!fiatIsPrimary) {
+			[arr[0], arr[1]] = [arr[1], arr[0]];
+		}
+		return arr;
+	}, [displayValues, fiatIsPrimary]);
+
+	const BalanceComponents = useMemo(() => {
+		return getBalanceComponents().map((Component, i) => (
+			<View color="transparent" key={i}>
+				{Component}
+			</View>
+		));
+	}, [getBalanceComponents]);
+	const onTogglePress = useCallback(() => {
+		toggleView({
+			view: 'numberPad',
+			data: {
+				isOpen: true,
+				snapPoint: 0,
+			},
+		}).then();
+	}, []);
+
+	return (
+		<Pressable onPress={onTogglePress} style={[styles.row, style]}>
+			<View color="transparent">{BalanceComponents}</View>
+		</Pressable>
+	);
+};
+
+const styles = StyleSheet.create({
+	row: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: 'transparent',
+	},
+});
+
+export default memo(AmountToggle);

--- a/src/components/BalanceToggle.tsx
+++ b/src/components/BalanceToggle.tsx
@@ -92,9 +92,11 @@ const AssetBalance = memo(
 const BalanceToggle = ({
 	sats = 0,
 	initialPrimary = 'fiat',
+	style,
 }: {
 	sats: number;
 	initialPrimary?: 'fiat' | 'asset';
+	style?: object;
 }): ReactElement => {
 	const [primary, setPrimary] = useState(initialPrimary);
 	const displayValues = useDisplayValues(sats);
@@ -123,7 +125,7 @@ const BalanceToggle = ({
 	}, [primary]);
 
 	return (
-		<Pressable onPress={onTogglePress} style={styles.row}>
+		<Pressable onPress={onTogglePress} style={[styles.row, style]}>
 			<View color="transparent">{BalanceComponents}</View>
 			<View style={styles.switchIcon}>
 				<SvgXml xml={switchIconXml} width={15.44} height={12.22} />

--- a/src/components/BottomSheetWrapper.tsx
+++ b/src/components/BottomSheetWrapper.tsx
@@ -1,3 +1,20 @@
+/***********************************************************************************
+ * This component wraps the reanimated-bottom-sheet library
+ * to more easily take advantage of it throughout the app.
+ *
+ * Implementation:
+ * <BottomSheetWrapper view="viewName">
+ *   <View>...</View>
+ * </BottomSheetWrapper>
+ *
+ * Usage Throughout App:
+ * toggleView({ view: 'viewName', data: { isOpen: true, snapPoint: 1 }});
+ * toggleView({ view: 'viewName', data: { isOpen: false }});
+ *
+ * Check if a given view is open:
+ * getStore().user.viewController['viewName'].isOpen;
+ ***********************************************************************************/
+
 import React, {
 	memo,
 	ReactElement,
@@ -16,13 +33,14 @@ import { toggleView } from '../store/actions/user';
 import { TViewController } from '../store/types/user';
 import { usePrevious } from '../hooks/helpers';
 
-const snapPoints = ['95%', '65%', 0];
 export interface IModalProps {
 	children: ReactElement;
 	view?: TViewController;
 	onOpen?: () => any;
 	onClose?: () => any;
 	headerColor?: string;
+	displayHeader?: boolean;
+	snapPoints?: any[];
 }
 const BottomSheetWrapper = forwardRef(
 	(
@@ -32,6 +50,8 @@ const BottomSheetWrapper = forwardRef(
 			onOpen = (): null => null,
 			onClose = (): null => null,
 			headerColor = 'onSurface',
+			displayHeader = true,
+			snapPoints = ['95%', '65%', 0],
 		}: IModalProps,
 		ref,
 	): ReactElement => {
@@ -93,7 +113,7 @@ const BottomSheetWrapper = forwardRef(
 				renderContent={(): ReactElement => {
 					return (
 						<View style={styles.container} color={headerColor}>
-							<View style={styles.spacer} />
+							{displayHeader && <View style={styles.spacer} />}
 							{children}
 						</View>
 					);

--- a/src/components/NavigationHeader.tsx
+++ b/src/components/NavigationHeader.tsx
@@ -23,7 +23,7 @@ const BackButton = memo(
 );
 
 const NavigationHeader = ({
-	title = '',
+	title = ' ',
 	displayBackButton = true,
 	onBackPress = (): null => null,
 	navigateBack = true,

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -1,0 +1,119 @@
+import React, { memo, ReactElement } from 'react';
+import { StyleSheet } from 'react-native';
+import { Text, TouchableOpacity, Ionicons, View } from '../styles/components';
+
+const { vibrate } = require('../utils/helpers');
+
+const ACTIVE_OPACITY = 0.2;
+const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
+
+interface NumberPad {
+	onPress: Function;
+	onRemove: Function;
+	onClear: Function;
+	style?: object;
+	children?: ReactElement;
+}
+
+const Button = memo(
+	({ num, onPress }: { num: number; onPress: Function }): ReactElement => {
+		return (
+			<TouchableOpacity
+				onPress={onPress}
+				activeOpacity={ACTIVE_OPACITY}
+				style={styles.buttonContainer}
+				color={'transparent'}>
+				<Text style={styles.button}>{num}</Text>
+			</TouchableOpacity>
+		);
+	},
+);
+
+const NumberPad = ({
+	onPress,
+	onRemove,
+	onClear,
+	style = {},
+	children,
+}: NumberPad): ReactElement => {
+	const handleRemove = (): void => {
+		vibrate({});
+		onRemove();
+	};
+
+	const handleClear = (): void => {
+		vibrate({});
+		onClear();
+	};
+
+	//Handle pin button press.
+	const handlePress = (key: number | string): void => {
+		vibrate({});
+		onPress(key);
+	};
+
+	return (
+		<View color={'background'} style={[styles.container, { ...style }]}>
+			{children}
+			<View style={styles.row}>
+				<Button onPress={(): void => handlePress(digits[0])} num={digits[0]} />
+				<Button onPress={(): void => handlePress(digits[1])} num={digits[1]} />
+				<Button onPress={(): void => handlePress(digits[2])} num={digits[2]} />
+			</View>
+
+			<View style={styles.row}>
+				<Button onPress={(): void => handlePress(digits[3])} num={digits[3]} />
+				<Button onPress={(): void => handlePress(digits[4])} num={digits[4]} />
+				<Button onPress={(): void => handlePress(digits[5])} num={digits[5]} />
+			</View>
+
+			<View style={styles.row}>
+				<Button onPress={(): void => handlePress(digits[6])} num={digits[6]} />
+				<Button onPress={(): void => handlePress(digits[7])} num={digits[7]} />
+				<Button onPress={(): void => handlePress(digits[8])} num={digits[8]} />
+			</View>
+
+			<View style={styles.row}>
+				<TouchableOpacity
+					onPress={handleClear}
+					activeOpacity={ACTIVE_OPACITY}
+					style={styles.buttonContainer}
+					color={'transparent'}>
+					<Text style={styles.button}>C</Text>
+				</TouchableOpacity>
+				<Button onPress={(): void => handlePress(digits[9])} num={digits[9]} />
+				<TouchableOpacity
+					onPress={handleRemove}
+					activeOpacity={ACTIVE_OPACITY}
+					style={styles.buttonContainer}
+					color={'transparent'}>
+					<Ionicons name={'ios-backspace-outline'} size={31} />
+				</TouchableOpacity>
+			</View>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	buttonContainer: {
+		flex: 1,
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	button: {
+		fontSize: 24,
+		justifyContent: 'center',
+		alignItems: 'center',
+		textAlign: 'center',
+	},
+	row: {
+		flex: 1,
+		flexDirection: 'row',
+		justifyContent: 'space-evenly',
+	},
+});
+
+export default memo(NumberPad);

--- a/src/components/SendForm.tsx
+++ b/src/components/SendForm.tsx
@@ -25,9 +25,7 @@ import {
 	adjustFee,
 	getTotalFee,
 	getTransactionOutputValue,
-	sendMax,
 	updateAmount,
-	updateMessage,
 } from '../utils/wallet/transactions';
 import { useBalance, useTransactionDetails } from '../hooks/transaction';
 import Card from './Card';
@@ -38,11 +36,7 @@ import Clipboard from '@react-native-community/clipboard';
 import { showErrorNotification } from '../utils/notifications';
 import { validate } from 'bitcoin-address-validation';
 
-const SendForm = ({
-	index = 0,
-	displayMessage = true,
-	displayFee = true,
-}): ReactElement => {
+const SendForm = ({ index = 0, displayFee = true }): ReactElement => {
 	const selectedWallet = useSelector(
 		(store: Store) => store.wallet.selectedWallet,
 	);
@@ -236,6 +230,7 @@ const SendForm = ({
 							<Text02M>To</Text02M>
 							<TextInput
 								style={styles.textInput}
+								selectTextOnFocus={true}
 								multiline={true}
 								textAlignVertical={'center'}
 								underlineColorAndroid="transparent"
@@ -269,82 +264,26 @@ const SendForm = ({
 			</Card>
 
 			<Card style={styles.card} color={'gray336'}>
-				<>
-					<View style={styles.col1}>
-						<View color="transparent" style={styles.titleContainer}>
-							<Text02M>Amount</Text02M>
-							<TextInput
-								style={styles.textInput}
-								multiline={true}
-								textAlignVertical={'center'}
-								underlineColorAndroid="transparent"
-								placeholderTextColor={colors.gray2}
-								editable={!max}
-								placeholder="Amount (sats)"
-								keyboardType="number-pad"
-								autoCapitalize="none"
-								autoCompleteType="off"
-								autoCorrect={false}
-								onChangeText={(txt): void => {
-									updateAmount({
-										amount: txt,
-										selectedWallet,
-										selectedNetwork,
-										index,
-									});
-								}}
-								value={Number(value) ? value.toString() : ''}
-								onSubmitEditing={(): void => {}}
-							/>
-						</View>
+				<View style={styles.col1}>
+					<View color="transparent" style={styles.titleContainer}>
+						<Text02M>Add Note</Text02M>
+						<TextInput
+							style={styles.textInput}
+							textAlignVertical={'center'}
+							placeholderTextColor={colors.gray2}
+							editable={!max}
+							multiline
+							underlineColorAndroid="transparent"
+							placeholder="This is a transaction note"
+							autoCapitalize="none"
+							autoCompleteType="off"
+							autoCorrect={false}
+							value={message}
+							onSubmitEditing={(): void => {}}
+						/>
 					</View>
-
-					<View color="transparent" style={styles.col2}>
-						<TouchableOpacity
-							style={styles.button}
-							color={max ? 'surface' : 'onSurface'}
-							text="Max"
-							disabled={balance <= 0}
-							onPress={sendMax}>
-							<Text02M>Max</Text02M>
-						</TouchableOpacity>
-					</View>
-				</>
+				</View>
 			</Card>
-
-			{!!displayMessage && (
-				<Card style={styles.card} color={'gray336'}>
-					<>
-						<View style={styles.col1}>
-							<View color="transparent" style={styles.titleContainer}>
-								<Text02M>Add Note</Text02M>
-								<TextInput
-									style={styles.textInput}
-									textAlignVertical={'center'}
-									placeholderTextColor={colors.gray2}
-									editable={!max}
-									multiline
-									underlineColorAndroid="transparent"
-									placeholder="Message (OP_RETURN)"
-									autoCapitalize="none"
-									autoCompleteType="off"
-									autoCorrect={false}
-									onChangeText={(txt): void => {
-										updateMessage({
-											message: txt,
-											selectedWallet,
-											selectedNetwork,
-											index,
-										});
-									}}
-									value={message}
-									onSubmitEditing={(): void => {}}
-								/>
-							</View>
-						</View>
-					</>
-				</Card>
-			)}
 
 			{!!displayFee && (
 				<AdjustValue
@@ -365,7 +304,7 @@ const styles = StyleSheet.create({
 		backgroundColor: 'transparent',
 	},
 	card: {
-		height: 58,
+		minHeight: 62,
 		marginBottom: 8,
 		borderRadius: 20,
 		paddingHorizontal: 16,
@@ -387,12 +326,6 @@ const styles = StyleSheet.create({
 	titleContainer: {
 		flex: 1,
 		marginHorizontal: 12,
-	},
-	button: {
-		paddingVertical: 2,
-		paddingHorizontal: 5,
-		borderRadius: 20,
-		right: -7,
 	},
 });
 

--- a/src/screens/Settings/ManageSeedPhrase.tsx
+++ b/src/screens/Settings/ManageSeedPhrase.tsx
@@ -19,8 +19,7 @@ import Store from '../../store/types';
 import { useSelector } from 'react-redux';
 import { resetSelectedWallet } from '../../store/actions/wallet';
 import SafeAreaView from '../../components/SafeAreaView';
-
-const bip39 = require('bip39');
+import * as bip39 from 'bip39';
 
 const ManageSeedPhrase = (): ReactElement => {
 	const selectedWallet = useSelector(
@@ -33,7 +32,7 @@ const ManageSeedPhrase = (): ReactElement => {
 	const [mnemonic, setMnemonic] = useState('');
 	const [currentMnemonic, setCurrentMnemonic] = useState('');
 	const [loading, setLoading] = useState(false);
-	const [suggestedWords, setSuggestedWords] = useState([]);
+	const [suggestedWords, setSuggestedWords] = useState<string[]>([]);
 
 	const setupComponent = async (): Promise<void> => {
 		const response = await getMnemonicPhrase();

--- a/src/screens/Wallets/SendOnChainTransaction/AmountButtonRow.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/AmountButtonRow.tsx
@@ -1,0 +1,99 @@
+import React, { memo, ReactElement } from 'react';
+import { StyleSheet } from 'react-native';
+import { TouchableOpacity, View } from '../../../styles/components';
+import { useSelector } from 'react-redux';
+import Store from '../../../store/types';
+import { sendMax } from '../../../utils/wallet/transactions';
+import { Text02M } from '../../../styles/components';
+import { getStore } from '../../../store/helpers';
+import { updateSettings } from '../../../store/actions/settings';
+import { SvgXml } from 'react-native-svg';
+import { toggleView } from '../../../store/actions/user';
+import useDisplayValues from '../../../hooks/displayValues';
+import { switchIcon } from '../../../assets/icons/wallet';
+
+const switchIconXml = switchIcon();
+const AmountButtonRow = (): ReactElement => {
+	const selectedWallet = useSelector(
+		(store: Store) => store.wallet.selectedWallet,
+	);
+	const selectedNetwork = useSelector(
+		(store: Store) => store.wallet.selectedNetwork,
+	);
+
+	const balance = useSelector(
+		(store: Store) =>
+			store.wallet.wallets[selectedWallet]?.balance[selectedNetwork],
+	);
+
+	const unitPreference = useSelector(
+		(state: Store) => state.settings.unitPreference,
+	);
+
+	const displayValues = useDisplayValues(balance);
+
+	const max = useSelector(
+		(state: Store) =>
+			state.wallet.wallets[selectedWallet].transaction[selectedNetwork].max,
+	);
+
+	return (
+		<View style={styles.topRow}>
+			<TouchableOpacity
+				style={styles.topRowButtons}
+				color={'onSurface'}
+				disabled={balance <= 0}
+				onPress={sendMax}>
+				<Text02M color={max ? 'orange' : 'white'}>Max</Text02M>
+			</TouchableOpacity>
+
+			<TouchableOpacity
+				color={'onSurface'}
+				style={styles.topRowButtons}
+				onPress={(): void => {
+					const newUnitPreference =
+						getStore().settings?.unitPreference === 'asset' ? 'fiat' : 'asset';
+					updateSettings({ unitPreference: newUnitPreference });
+				}}>
+				<SvgXml xml={switchIconXml} width={16.44} height={13.22} />
+				<Text02M style={styles.middleButtonText} color="orange">
+					{unitPreference === 'asset'
+						? displayValues.fiatTicker
+						: displayValues.bitcoinTicker.toLocaleLowerCase()}
+				</Text02M>
+			</TouchableOpacity>
+
+			<TouchableOpacity
+				style={styles.topRowButtons}
+				color={'onSurface'}
+				onPress={(): void => {
+					toggleView({ view: 'numberPad', data: { isOpen: false } }).then();
+				}}>
+				<Text02M>Done</Text02M>
+			</TouchableOpacity>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	topRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		paddingVertical: 5,
+		paddingHorizontal: 5,
+	},
+	topRowButtons: {
+		paddingVertical: 5,
+		paddingHorizontal: 8,
+		borderRadius: 20,
+		flexDirection: 'row',
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+	middleButtonText: {
+		marginLeft: 8,
+	},
+});
+
+export default memo(AmountButtonRow);

--- a/src/screens/Wallets/SendOnChainTransaction/OnChainNumberPad.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/OnChainNumberPad.tsx
@@ -1,0 +1,145 @@
+import React, { memo, ReactElement, useCallback } from 'react';
+import {
+	getTransactionOutputValue,
+	updateAmount,
+} from '../../../utils/wallet/transactions';
+import AmountButtonRow from './AmountButtonRow';
+import NumberPad from '../../../components/NumberPad';
+import { useSelector } from 'react-redux';
+import Store from '../../../store/types';
+import { defaultOnChainTransactionData } from '../../../store/types/wallet';
+import {
+	fiatToBitcoinUnit,
+	getDisplayValues,
+} from '../../../utils/exchange-rate';
+import { btcToSats } from '../../../utils/helpers';
+
+/**
+ * Handles the number pad logic (add/remove/clear) for on-chain transactions.
+ */
+const OnChainNumberPad = (): ReactElement => {
+	const selectedWallet = useSelector(
+		(store: Store) => store.wallet.selectedWallet,
+	);
+	const selectedNetwork = useSelector(
+		(store: Store) => store.wallet.selectedNetwork,
+	);
+
+	const bitcoinUnit = useSelector((store: Store) => store.settings.bitcoinUnit);
+
+	const unitPreference = useSelector(
+		(store: Store) => store.settings.unitPreference,
+	);
+
+	const currency = useSelector(
+		(store: Store) => store.settings.selectedCurrency,
+	);
+	const exchangeRate = useSelector(
+		(store: Store) => store.wallet.exchangeRates[currency],
+	);
+
+	const transaction = useSelector(
+		(store: Store) =>
+			store.wallet.wallets[selectedWallet]?.transaction[selectedNetwork] ||
+			defaultOnChainTransactionData,
+	);
+
+	/*
+	 * Retrieves total value of all outputs. Excludes change address.
+	 */
+	const getAmountToSend = useCallback((): number => {
+		try {
+			return getTransactionOutputValue({
+				selectedWallet,
+				selectedNetwork,
+			});
+		} catch {
+			return 0;
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [transaction.outputs, selectedNetwork, selectedWallet]);
+
+	// Add, shift and update the current transaction amount based on the provided fiat value or bitcoin unit.
+	const onPress = (key): void => {
+		let amount = '0';
+		if (unitPreference === 'asset') {
+			if (bitcoinUnit === 'BTC') {
+				const displayValue = getDisplayValues({ satoshis: getAmountToSend() });
+				amount = displayValue.bitcoinFormatted;
+				// Add new key and shift decimal place by one.
+				amount = String((Number(`${amount}${key}`) * 10).toFixed(8));
+				amount = String(btcToSats(Number(amount)));
+			} else {
+				amount = String(getAmountToSend());
+				amount = `${amount}${key}`;
+			}
+		} else {
+			const displayValue = getDisplayValues({ satoshis: getAmountToSend() });
+			amount = displayValue.fiatFormatted;
+			// Add new key and shift decimal place by one.
+			amount = String((Number(`${amount}${key}`) * 10).toFixed(2));
+			// Convert new fiat amount to satoshis.
+			amount = String(
+				fiatToBitcoinUnit({
+					fiatValue: amount,
+					bitcoinUnit: 'satoshi',
+					currency,
+					exchangeRate,
+				}),
+			);
+		}
+		updateAmount({
+			amount,
+			selectedWallet,
+			selectedNetwork,
+			index: 0,
+		}).then();
+	};
+
+	// Shift, remove and update the current transaction amount based on the provided fiat value or bitcoin unit.
+	const onRemove = (): void => {
+		let amount = '0';
+		let newAmount = '0';
+		if (unitPreference === 'asset') {
+			amount = String(getAmountToSend());
+			newAmount = amount.substr(0, amount.length - 1);
+		} else {
+			const displayValue = getDisplayValues({ satoshis: getAmountToSend() });
+			amount = displayValue?.fiatFormatted;
+			amount = String(Number(`${amount}`) / 10);
+			newAmount = amount.substr(0, amount.lastIndexOf('.') + 3);
+			const fiatAmount = fiatToBitcoinUnit({
+				fiatValue: newAmount,
+				bitcoinUnit,
+				exchangeRate,
+				currency,
+			});
+			newAmount = String(fiatAmount);
+		}
+		updateAmount({
+			amount: newAmount,
+			selectedWallet,
+			selectedNetwork,
+			index: 0,
+			max: false,
+		}).then();
+	};
+
+	const onClear = (): void => {
+		updateAmount({
+			amount: '0',
+			selectedWallet,
+			selectedNetwork,
+			index: 0,
+			max: false,
+		}).then();
+	};
+
+	return (
+		<NumberPad onPress={onPress} onRemove={onRemove} onClear={onClear}>
+			<AmountButtonRow />
+		</NumberPad>
+	);
+};
+
+export default memo(OnChainNumberPad);

--- a/src/screens/Wallets/SendOnChainTransaction/OutputSummary.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/OutputSummary.tsx
@@ -15,7 +15,7 @@ const OutputSummary = ({
 	return (
 		<View color="transparent">
 			{outputs &&
-				outputs.map(({ address, value }, index) => {
+				outputs.map(({ address = ' ', value }, index) => {
 					if (changeAddress !== address) {
 						return (
 							<View key={`${index}${value}`} color="transparent">

--- a/src/screens/Wallets/SendOnChainTransaction/Summary.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/Summary.tsx
@@ -3,8 +3,8 @@ import { Text, View } from '../../../styles/components';
 import { StyleSheet } from 'react-native';
 
 const Summary = ({
-	leftText = '',
-	rightText = '',
+	leftText = ' ',
+	rightText = ' ',
 }: {
 	leftText: string;
 	rightText: string;

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -15,4 +15,5 @@ export const defaultSettingsShape: ISettings = {
 	selectedLanguage: 'english',
 	customElectrumPeers: { ...arrayTypeItems },
 	coinSelectPreference: 'small',
+	unitPreference: 'asset',
 };

--- a/src/store/types/settings.ts
+++ b/src/store/types/settings.ts
@@ -31,6 +31,7 @@ export interface ISettings {
 	exchangeRateService: EExchangeRateService;
 	selectedLanguage: string;
 	coinSelectPreference: TCoinSelectPreference;
+	unitPreference: 'asset' | 'fiat';
 	[key: string]: any;
 }
 

--- a/src/store/types/user.ts
+++ b/src/store/types/user.ts
@@ -5,7 +5,9 @@ export type TViewController =
 	| 'receive'
 	| 'sendAssetPicker'
 	| 'receiveAssetPicker'
-	| 'coinSelection';
+	| 'coinSelection'
+	| 'feePicker'
+	| 'numberPad';
 
 export type TUserViewController = {
 	[key in TViewController]: IViewControllerData;

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -42,7 +42,7 @@ const colors: IColors = {
 	green: '#75BF72',
 	green2: '#33CE59',
 	yellow: '#FFD200',
-	orange: '#ED8452',
+	orange: '#F75C1A',
 	red: '#E95164',
 	indigo: '#2D5BFF',
 	purple: '#B95CE8',

--- a/src/utils/exchange-rate/index.ts
+++ b/src/utils/exchange-rate/index.ts
@@ -114,6 +114,33 @@ export const defaultDisplayValues: IDisplayValues = {
 	satoshis: 0,
 };
 
+export const fiatToBitcoinUnit = ({
+	fiatValue,
+	exchangeRate,
+	currency,
+	bitcoinUnit,
+}: {
+	fiatValue: string;
+	exchangeRate?: number;
+	currency?: string;
+	bitcoinUnit?: TBitcoinUnit;
+}): number => {
+	if (!currency) {
+		currency = getStore().settings.selectedCurrency;
+	}
+	if (!exchangeRate) {
+		exchangeRate = getStore().wallet.exchangeRates[currency] || 0;
+	}
+	if (!bitcoinUnit) {
+		bitcoinUnit = getStore().settings.bitcoinUnit;
+	}
+	bitcoinUnits.setFiat(currency, exchangeRate);
+	return bitcoinUnits(Number(fiatValue), currency)
+		.to(bitcoinUnit)
+		.value()
+		.toFixed(8);
+};
+
 export const getDisplayValues = ({
 	satoshis,
 	exchangeRate,
@@ -132,8 +159,7 @@ export const getDisplayValues = ({
 			currency = getStore().settings.selectedCurrency;
 		}
 		if (!exchangeRate) {
-			const exchangeRates = getStore().wallet.exchangeRates[currency] || {};
-			exchangeRate = exchangeRates[currency];
+			exchangeRate = getStore().wallet.exchangeRates[currency] || 0;
 		}
 		if (!bitcoinUnit) {
 			bitcoinUnit = getStore().settings.bitcoinUnit;
@@ -179,6 +205,7 @@ export const getDisplayValues = ({
 		const bitcoinFormatted = bitcoinUnits(satoshis, 'satoshi')
 			.to(bitcoinUnit)
 			.value()
+			.toFixed(bitcoinUnit === 'satoshi' ? 0 : 8)
 			.toString();
 
 		let { bitcoinSymbol } = defaultDisplayValues;


### PR DESCRIPTION
This PR:
 - Adds a number pad and it's corresponding conversion logic to the on-chain send flow.
 - Fixes several bugs that caused a crash after the Hermes update.
 - Updated several types, styles & colors throughout the app.
 - Changed all instances of mnemonicToSeedSync to mnemonicToSeed throughout app for better performance.
 - Removed the useColorScheme logic on startup so that app always defaults to dark mode.

![Simulator Screen Shot - iPhone 13 - 2022-01-03 at 10 47 07](https://user-images.githubusercontent.com/8532651/147950803-a12b7c5d-d9f5-4066-8b1e-aefe528e33f2.png)

