### PR TITLE
Adds mnemonic phrase derivation scheme

### DIFF
--- a/__tests__/wallet.ts
+++ b/__tests__/wallet.ts
@@ -1,0 +1,22 @@
+import { deriveMnemonicPhrases } from '../src/utils/wallet';
+import { mnemonic } from './utils/dummy-wallet';
+
+describe('Wallet Methods', () => {
+	it('Derive multiple mnemonic phrases for lightning, tokens and slashtags via the on-chain phrase.', async () => {
+		const res = await deriveMnemonicPhrases(mnemonic);
+		if (res.isErr()) {
+			expect(res.error.message).toEqual('');
+			return;
+		}
+		expect(res.value.onchain).toEqual(mnemonic);
+		expect(res.value.lightning).toEqual(
+			'old found shock tenant merit tower foster chase sauce stool book enhance public key whip group retreat member cabin blanket sorry pole gym wink',
+		);
+		expect(res.value.tokens).toEqual(
+			'inspire sick rule wild near rebuild pride tomato shell come drip reduce street steel warrior project radar sister day title spice execute evolve outside',
+		);
+		expect(res.value.slashtags).toEqual(
+			'symbol between rule refuse can salt rack slush lesson excite quality flavor lunar reunion ramp abandon plate narrow bulk machine asset cross violin senior',
+		);
+	});
+});

--- a/ios/bitkit.xcodeproj/xcshareddata/xcschemes/bitkit.xcscheme
+++ b/ios/bitkit.xcodeproj/xcshareddata/xcschemes/bitkit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1330"
+   LastUpgradeVersion = "1340"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -1,11 +1,6 @@
 import RNFS from 'react-native-fs';
 import { err, ok, Result } from '../result';
-import {
-	deriveMnemonicPhrases,
-	getMnemonicPhrase,
-	getSelectedNetwork,
-	getSelectedWallet,
-} from '../wallet';
+import { getSelectedNetwork, getSelectedWallet } from '../wallet';
 import { TAvailableNetworks } from '../networks';
 
 export const defaultNodePubKey =
@@ -44,31 +39,6 @@ export const wipeLndDir = async ({
 		return err(e);
 	}
 	return ok('LND directory wiped');
-};
-
-/**
- * Attempt to deterministically derive lightning seed from on-chain seed.
- * @return {Promise<Result<string[]>>}
- */
-export const getLightningSeed = async (
-	selectedWallet: string,
-): Promise<Result<string>> => {
-	try {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		const mnemonic = await getMnemonicPhrase(selectedWallet);
-		if (mnemonic.isErr()) {
-			return err(mnemonic.error.message);
-		}
-		const lndSeed = await deriveMnemonicPhrases(mnemonic.value);
-		if (lndSeed.isErr()) {
-			return err(lndSeed.error.message);
-		}
-		return ok(lndSeed.value.lightning);
-	} catch (e) {
-		return err(e);
-	}
 };
 
 export const getLightningDirectory = ({

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -1,8 +1,8 @@
 import RNFS from 'react-native-fs';
 import { err, ok, Result } from '../result';
 import {
+	deriveMnemonicPhrases,
 	getMnemonicPhrase,
-	getMnemonicPhraseFromEntropy,
 	getSelectedNetwork,
 	getSelectedWallet,
 } from '../wallet';
@@ -61,8 +61,11 @@ export const getLightningSeed = async (
 		if (mnemonic.isErr()) {
 			return err(mnemonic.error.message);
 		}
-		const lndSeed = getMnemonicPhraseFromEntropy(mnemonic.value);
-		return ok(lndSeed);
+		const lndSeed = await deriveMnemonicPhrases(mnemonic.value);
+		if (lndSeed.isErr()) {
+			return err(lndSeed.error.message);
+		}
+		return ok(lndSeed.value.lightning);
 	} catch (e) {
 		return err(e);
 	}

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -476,9 +476,39 @@ export const getMnemonicPhrase = async (
  * @param {string} str
  * @return {string}
  */
-export const getMnemonicPhraseFromEntropy = (str: Buffer): string => {
+export const generateMnemonicPhraseFromEntropy = (str: string): string => {
+	// @ts-ignore
 	const hash = getSha256(str);
 	return bip39.entropyToMnemonic(hash);
+};
+
+/**
+ * Derive multiple mnemonic phrases by appending a
+ * descriptive string to the original mnemonic.
+ * @param {string} mnemonic
+ */
+export const deriveMnemonicPhrases = async (
+	mnemonic: string,
+): Promise<
+	Result<{
+		onchain: string;
+		lightning: string;
+		tokens: string;
+		slashtags: string;
+	}>
+> => {
+	if (!mnemonic) {
+		return err('Please provide a mnemonic phrase.');
+	}
+	const isValid = validateMnemonic(mnemonic);
+	if (!isValid) {
+		return err('Mnemonic provided is not valid.');
+	}
+	const onchain = mnemonic;
+	const lightning = generateMnemonicPhraseFromEntropy(`${mnemonic}lightning`);
+	const tokens = generateMnemonicPhraseFromEntropy(`${mnemonic}tokens`);
+	const slashtags = generateMnemonicPhraseFromEntropy(`${mnemonic}slashtags`);
+	return ok({ onchain, lightning, tokens, slashtags });
 };
 
 /**


### PR DESCRIPTION
 This PR:
Adds the mnemonic phrase derivation scheme that will allow the wallet to derive the lightning, tokens and slashtags phrases/seeds from a given (on-chain) mnemonic.
- Created `deriveMnemonicPhrases` method in `utils/wallet/index.ts`.
- Renamed `getMnemonicPhraseFromEntropy` to `generateMnemonicPhraseFromEntropy` in `utils/wallet/index.ts`.
- Updated `getLightningSeed` method in `utils/lightning/index.ts`.
- Created `wallet.ts` tests in `__tests__` directory.
- Added seed derivation test to `__tests__/wallet.ts`.