### PR TITLE
use changeAddress in CPFP boost transaction

### DIFF
--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -1921,10 +1921,12 @@ export const setupCpfp = async ({
 	if (response.isErr()) {
 		return err(response.error?.message);
 	}
+
 	return sendMax({
 		selectedWallet,
 		selectedNetwork,
 		transaction: response.value,
+		address: response.value.changeAddress,
 	});
 };
 

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -1922,6 +1922,7 @@ export const setupCpfp = async ({
 		return err(response.error?.message);
 	}
 
+	// TODO: This will consolidate all UTXO's. Fix it to only use the UTXO's required according to the user's coin selection preference.
 	return sendMax({
 		selectedWallet,
 		selectedNetwork,


### PR DESCRIPTION
Maybe I'm missing something, but CPFP doesn't work for me. After calling `setupCpfp` new transaction doesn't have outputs.
So I think it is better to set address by passing it to `sendMax`