### PR TITLE
fix fractual satoshi

### DIFF
--- a/src/utils/exchange-rate/index.ts
+++ b/src/utils/exchange-rate/index.ts
@@ -69,7 +69,7 @@ export const fiatToBitcoinUnit = ({
 	exchangeRate?: number;
 	currency?: string;
 	bitcoinUnit?: TBitcoinUnit;
-}): number => {
+}): string => {
 	if (!currency) {
 		currency = getStore().settings.selectedCurrency;
 	}
@@ -80,10 +80,13 @@ export const fiatToBitcoinUnit = ({
 		bitcoinUnit = getStore().settings.bitcoinUnit;
 	}
 	bitcoinUnits.setFiat(currency, exchangeRate);
-	return bitcoinUnits(Number(fiatValue), currency)
+
+	const value = bitcoinUnits(Number(fiatValue), currency)
 		.to(bitcoinUnit)
 		.value()
-		.toFixed(8);
+		.toFixed(bitcoinUnit === 'satoshi' ? 0 : 8); // satoshi cannot be a fractional number
+
+	return value;
 };
 
 export const getDisplayValues = ({

--- a/src/utils/seed-suggestions/PatienceDiff.js
+++ b/src/utils/seed-suggestions/PatienceDiff.js
@@ -1,3 +1,4 @@
+/* eslint @typescript-eslint/explicit-function-return-type: 0 */
 // https://raw.githubusercontent.com/jonTrent/PatienceDiff/dev/PatienceDiff.js
 
 export { patienceDiff, patienceDiffPlus };

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -1315,6 +1315,9 @@ export const validateTransaction = (
 					`Output value for ${address} must be greater than or equal to ${baseFee} sats`,
 				);
 			}
+			if (!Number.isInteger(value)) {
+				return err(`Output value for ${address} should be an integer`);
+			}
 		}
 
 		const inputsReduce = reduceValue({


### PR DESCRIPTION
There is a bug in bitkit - you can't create transaction with fiat amount. It will convert fiat to satoshi as float number, not an integer. 
To fix that bug, I'm adding rounding in `fiatToBitcoinUnit` func. 
I think this might lead to some future bugs with rounding, if you will try to switch bitcoin unit to fiat back and forth, but they should be rare. 