### PR TITLE
Bitcoin Network Selection for LDK Testing

### DIFF
--- a/src/navigation/settings/SettingsNavigator.tsx
+++ b/src/navigation/settings/SettingsNavigator.tsx
@@ -24,6 +24,7 @@ import NetworksSettings from '../../screens/Settings/Networks';
 import AdvancedSettings from '../../screens/Settings/Advanced';
 import AboutSettings from '../../screens/Settings/About';
 import EasterEgg from '../../screens/Settings/EasterEgg';
+import BitcoinNetworkSelection from '../../screens/Settings/Bitcoin/BitcoinNetworkSelection';
 
 const Stack = createNativeStackNavigator();
 
@@ -75,6 +76,10 @@ const SettingsNavigator = (): ReactElement => {
 				<Stack.Screen
 					name="LightningChannelDetails"
 					component={LightningChannelDetails}
+				/>
+				<Stack.Screen
+					name="BitcoinNetworkSelection"
+					component={BitcoinNetworkSelection}
 				/>
 				<Stack.Screen name="LightningNodeInfo" component={LightningNodeInfo} />
 				<Stack.Screen name="ManageSeedPhrase" component={ManageSeedPhrase} />

--- a/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
+++ b/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
@@ -1,0 +1,56 @@
+import React, { memo, ReactElement, useMemo } from 'react';
+import { IListData } from '../../../components/List';
+import SettingsView from '../SettingsView';
+import { useSelector } from 'react-redux';
+import Store from '../../../store/types';
+import { EAvailableNetworks } from '../../../utils/networks';
+import {
+	updateAddressIndexes,
+	updateWallet,
+} from '../../../store/actions/wallet';
+import { getNetworkData } from '../../../utils/helpers';
+import { startWalletServices } from '../../../utils/startup';
+import { getCurrentWallet } from '../../../utils/wallet';
+
+const BitcoinNetworkSelection = (): ReactElement => {
+	const selectedNetwork = useSelector(
+		(state: Store) => state.wallet.selectedNetwork,
+	);
+	const Networks: IListData[] = useMemo(
+		() => [
+			{
+				title: 'Bitcoin Network Selection',
+				data: Object.values(EAvailableNetworks).map((network) => {
+					const networkData = getNetworkData({ selectedNetwork: network });
+					return {
+						title: `${networkData.label}`,
+						value: network === selectedNetwork,
+						type: 'button',
+						onPress: async (): Promise<void> => {
+							// Switch to new network.
+							await updateWallet({ selectedNetwork: network });
+							// Grab the selectedWallet.
+							const { selectedWallet } = getCurrentWallet({ selectedNetwork });
+							// Generate addresses if none exist for the newly selected wallet and network.
+							await updateAddressIndexes({ selectedWallet, selectedNetwork });
+							// Start wallet services with the newly selected network.
+							await startWalletServices({});
+						},
+						hide: false,
+					};
+				}),
+			},
+		],
+		[selectedNetwork],
+	);
+
+	return (
+		<SettingsView
+			title={'Bitcoin Networks'}
+			listData={Networks}
+			showBackNavigation
+		/>
+	);
+};
+
+export default memo(BitcoinNetworkSelection);

--- a/src/screens/Settings/DevSettings/index.tsx
+++ b/src/screens/Settings/DevSettings/index.tsx
@@ -18,7 +18,7 @@ import SettingsView from './../SettingsView';
 import { resetSlashtagsStore } from '../../../store/actions/slashtags';
 import { clearSlashtagsStorage } from '../../../components/SlashtagsProvider';
 
-const SettingsMenu = ({}): ReactElement => {
+const SettingsMenu = ({ navigation }): ReactElement => {
 	const selectedWallet = useSelector(
 		(state: Store) => state.wallet.selectedWallet,
 	);
@@ -34,6 +34,12 @@ const SettingsMenu = ({}): ReactElement => {
 			{
 				title: 'Dev Settings',
 				data: [
+					{
+						title: 'Bitcoin Network Selection',
+						type: 'button',
+						onPress: (): void => navigation.navigate('BitcoinNetworkSelection'),
+						hide: false,
+					},
 					{
 						title: 'Reset Current Wallet Store',
 						type: 'button',

--- a/src/screens/Wallets/SendOnChainTransaction2/AddressAndAmount.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction2/AddressAndAmount.tsx
@@ -126,6 +126,7 @@ const AddressAndAmount = ({ index = 0, navigation }): ReactElement => {
 			});
 			return;
 		}
+		data.replace('bitcoinRegtest:', '');
 		data.replace('bitcoinTestnet:', '');
 		data.replace('bitcoin:', '');
 		const addressIsValid = validate(data);

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -1,5 +1,4 @@
 import { ISettings } from '../types/settings';
-import { arrayTypeItems } from './wallet';
 import { EExchangeRateService } from '../../utils/exchange-rate/types';
 
 export const defaultSettingsShape: ISettings = {
@@ -16,7 +15,19 @@ export const defaultSettingsShape: ISettings = {
 	selectedCurrency: 'USD',
 	exchangeRateService: EExchangeRateService.bitfinex,
 	selectedLanguage: 'english',
-	customElectrumPeers: { ...arrayTypeItems },
+	customElectrumPeers: {
+		bitcoin: [],
+		bitcoinTestnet: [],
+		bitcoinRegtest: [
+			{
+				host: '35.233.47.252',
+				ssl: 18484,
+				tcp: 18483,
+				protocol: 'tcp',
+			},
+		],
+		timestamp: null,
+	},
 	coinSelectAuto: true,
 	coinSelectPreference: 'small',
 	unitPreference: 'asset',

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -23,7 +23,7 @@ export type TBalanceUnit = 'satoshi' | 'BTC' | 'fiat';
 
 export type TBitcoinAbbreviation = 'sats' | 'BTC';
 
-export type TBitcoinLabel = 'Bitcoin' | 'Bitcoin Testnet';
+export type TBitcoinLabel = 'Bitcoin' | 'Bitcoin Testnet' | 'Bitcoin Regtest';
 
 export type TTicker = 'BTC' | 'tBTC';
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -115,6 +115,8 @@ export const getNetworkData = ({
 				return { abbreviation, label: 'Bitcoin', ticker: 'BTC' };
 			case 'bitcoinTestnet':
 				return { abbreviation, label: 'Bitcoin Testnet', ticker: 'tBTC' };
+			case 'bitcoinRegtest':
+				return { abbreviation, label: 'Bitcoin Regtest', ticker: 'tBTC' };
 			default:
 				return { abbreviation, label: 'Bitcoin', ticker: 'BTC' };
 		}

--- a/src/utils/networks.ts
+++ b/src/utils/networks.ts
@@ -1,4 +1,7 @@
-export type TAvailableNetworks = 'bitcoin' | 'bitcoinTestnet';
+export type TAvailableNetworks =
+	| 'bitcoin'
+	| 'bitcoinTestnet'
+	| 'bitcoinRegtest';
 
 export enum EAvailableNetworks {
 	bitcoin = 'bitcoin',


### PR DESCRIPTION
In order to test LDK we'll need to be able to switch between Bitcoin networks. Specifically, `bitcoinRegtest` for LDK. This PR adds a network selection component to the dev settings menu so that we can toggle between networks as needed.

This view can be found by navigating to Settings->Advanced->Dev Settings->Bitcoin Network Selection.

Note: The activity reducer is not wrapped in a wallet and network object so transactions made on one network will still remain visible when toggling to other networks. If we wish to flesh out this network toggle functionality we can wrap the activity state along with other such instances in a wallet and network object in a future PR to hide other network activity in the app. In the meantime, this is solely for testing LDK functionality on bitcoinRegtest.

This PR:
- Creates BitcoinNetworkSelection.tsx component and added it to the DevSettings menu.
- Adds bitcoinRegtest server to customElectrumPeers in shapes/settings.ts.
- Adds Bitcoin Regtest to TBitcoinLabel type in types/wallet.ts.
- Adds bitcoinRegtest to getNetworkData method in utils/helpers.ts.
- Adds bitcoinRegtest to TAvailableNetworks in utils/network.ts.


![Simulator Screen Shot - iPhone 13 - 2022-07-14 at 10 27 29](https://user-images.githubusercontent.com/8532651/179006511-272793bd-867c-4557-bcf3-ce76bdde75b1.png)

