### PR TITLE
Fix Redux state typo.

### DIFF
--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -12,7 +12,7 @@ export const defaultSettingsShape: ISettings = {
 	rbf: true,
 	theme: 'dark',
 	bitcoinUnit: 'satoshi', //BTC, mBTC, μBTC or satoshi
-	balaceUnit: 'satoshi', //BTC, mBTC, μBTC or satoshi
+	balanceUnit: 'satoshi', //BTC, mBTC, μBTC or satoshi
 	selectedCurrency: 'USD',
 	exchangeRateService: EExchangeRateService.bitfinex,
 	selectedLanguage: 'english',

--- a/src/store/types/settings.ts
+++ b/src/store/types/settings.ts
@@ -28,7 +28,7 @@ export interface ISettings {
 	rbf: boolean;
 	theme: TTheme;
 	bitcoinUnit: TBitcoinUnit;
-	balaceUnit: TBalanceUnit;
+	balanceUnit: TBalanceUnit;
 	customElectrumPeers: IWalletItem<ICustomElectrumPeer[]> | IWalletItem<[]>;
 	selectedCurrency: string;
 	exchangeRateService: EExchangeRateService;


### PR DESCRIPTION
## Description

Fix redux state typo: `balaceUnit` to `balanceUnit`.