### PR TITLE
Fix jest mocks config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,8 @@ module.exports = {
 	preset: 'react-native',
 	moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
 	transformIgnorePatterns: ['<roodDir>/__mocks__'],
-	setupFiles: ['<rootDir>/jest.setup.js'],
+	setupFiles: [
+		'<rootDir>/jest.setup.js',
+		'./node_modules/react-native-gesture-handler/jestSetup.js',
+	],
 };

--- a/package.json
+++ b/package.json
@@ -134,17 +134,6 @@
     "rn-nodeify": "^10.3.0",
     "typescript": "^3.9.7"
   },
-  "jest": {
-    "preset": "react-native",
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js",
-      "jsx",
-      "json",
-      "node"
-    ]
-  },
   "react-native": {
     "crypto": "react-native-crypto",
     "_stream_transform": "readable-stream/transform",


### PR DESCRIPTION
Also I removed jest config section from package.json to prevent multiple configurations warning
```

● Multiple configurations found:
    * /Users/limpbrains/s/bitkit/jest.config.js
    * `jest` key in /Users/limpbrains/s/bitkit/package.json

  Implicit config resolution does not allow multiple configuration files.
  Either remove unused config files or select one explicitly with `--config`.

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```