### PR TITLE
Android Fix for react-native-ldk

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -263,6 +263,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
+    implementation files("../../node_modules/@synonymdev/react-native-ldk/android/libs/LDK-release.aar")
 
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+"  // From node_modules

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 buildscript {
     ext {
         buildToolsVersion = "31.0.0"
-        minSdkVersion = 21
+        minSdkVersion = 24
         compileSdkVersion = 31
         targetSdkVersion = 31
 


### PR DESCRIPTION
This PR:
- Adds `LDK-release.aar` to dependencies in `android/app/build.gradle`.
- Updated `minSdkVersion` to `24` in `android/build.gradle`.
- This fixes #215 