### PR TITLE
Fix: Settings glow effect

### DIFF
--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -214,15 +214,11 @@ const List = ({
 				// eslint-disable-next-line react-hooks/exhaustive-deps
 			}, [])}
 			stickySectionHeadersEnabled={false}
-			contentContainerStyle={styles.contentContainerStyle}
 		/>
 	);
 };
 
 const styles = StyleSheet.create({
-	contentContainerStyle: {
-		paddingBottom: 55,
-	},
 	row: {
 		height: 55,
 	},

--- a/src/screens/Settings/SettingsView.tsx
+++ b/src/screens/Settings/SettingsView.tsx
@@ -19,17 +19,19 @@ const SettingsView = ({
 	title,
 	listData,
 	showBackNavigation = true,
+	fullHeight = true,
 	children,
 	childrenPosition = 'top',
 }: {
 	title: string;
 	listData?: IListData[];
 	showBackNavigation: boolean;
+	fullHeight?: boolean;
 	children?: ReactElement | ReactElement[] | undefined;
 	childrenPosition?: 'top' | 'bottom';
 }): ReactElement => {
 	return (
-		<View style={styles.container} color="black">
+		<View style={[ fullHeight ? styles.fullHeight : null ]} color="black">
 			<SafeAreaInsets type="top" />
 			<NavigationHeader title={title} displayBackButton={showBackNavigation} />
 
@@ -48,22 +50,20 @@ const SettingsView = ({
 					{children}
 				</View>
 			) : null}
-			<SafeAreaInsets type="bottom" />
 		</View>
 	);
 };
 
 const styles = StyleSheet.create({
-	container: {
-		flex: 1,
-	},
 	listContent: {
 		paddingHorizontal: 16,
-		flex: 1,
 	},
 	childrenContent: {
 		flex: 1,
 	},
+	fullHeight: {
+		flex: 1,
+	}
 });
 
 export default memo(SettingsView);

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -78,7 +78,6 @@ const styles = StyleSheet.create({
 		backgroundColor: '#000',
 	},
 	imageContainer: {
-		zIndex: -1,
 		alignItems: 'center',
 		justifyContent: 'center',
 		flexGrow: 1,

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -82,6 +82,7 @@ const styles = StyleSheet.create({
 		justifyContent: 'center',
 		flexGrow: 1,
 		width: '100%',
+		pointerEvents: 'none'
 	},
 	image: {
 		width: 150,

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -58,6 +58,7 @@ const SettingsMenu = ({ navigation }): ReactElement => {
 				title={'Settings'}
 				listData={SettingsListData}
 				showBackNavigation={true}
+				fullHeight={false}
 			/>
 			<View style={styles.imageContainer}>
 				<Glow color="brand" size={500} style={styles.glow} />
@@ -80,7 +81,7 @@ const styles = StyleSheet.create({
 		zIndex: -1,
 		alignItems: 'center',
 		justifyContent: 'center',
-		height: 210,
+		flexGrow: 1,
 		width: '100%',
 	},
 	image: {

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -60,7 +60,7 @@ const SettingsMenu = ({ navigation }): ReactElement => {
 				showBackNavigation={true}
 				fullHeight={false}
 			/>
-			<View style={styles.imageContainer}>
+			<View style={styles.imageContainer} pointerEvents="none">
 				<Glow color="brand" size={500} style={styles.glow} />
 				<Image
 					style={styles.image}
@@ -82,7 +82,6 @@ const styles = StyleSheet.create({
 		justifyContent: 'center',
 		flexGrow: 1,
 		width: '100%',
-		pointerEvents: 'none'
 	},
 	image: {
 		width: 150,


### PR DESCRIPTION
Changes:
- update List component styles to fix glow effect

Notes:
Removed `paddingBottom` from generic List component which is also used in `LightningChannels` component, which seems to currently be unused. Not sure if that's breaking the styles there.

| Before         | After     | 
|--------------|-----------|
| ![Simulator Screen Shot - iPhone 13 - 2022-08-01 at 17 06 09](https://user-images.githubusercontent.com/8538369/182185224-d29bea5c-e10c-43bb-921e-138257758737.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-01 at 16 36 47](https://user-images.githubusercontent.com/8538369/182185208-0db7886f-760f-489d-92eb-dc9ca0251502.png)      |



