### PR TITLE
Default To Regtest

### DIFF
--- a/__tests__/transactions.ts
+++ b/__tests__/transactions.ts
@@ -9,6 +9,7 @@ import { TAvailableNetworks } from '../src/utils/networks';
 import { mnemonic, walletState } from './utils/dummy-wallet';
 import { createTransaction } from '../src/utils/wallet/transactions';
 
+const selectedNetwork: TAvailableNetworks = 'bitcoinTestnet';
 describe('On chain transactions', () => {
 	beforeAll(async () => {
 		//Seed wallet data including utxo and transaction data
@@ -16,15 +17,15 @@ describe('On chain transactions', () => {
 			mnemonic,
 			addressAmount: 5,
 			changeAddressAmount: 5,
+			selectedNetwork,
 		});
 
 		await updateWallet({ wallets: { wallet0: walletState } });
 
-		await setupOnChainTransaction({});
+		await setupOnChainTransaction({ selectedNetwork });
 	});
 
 	it('Creates an on chain transaction from the transaction store', async () => {
-		const selectedNetwork: TAvailableNetworks = 'bitcoinTestnet';
 		const selectedWallet = getSelectedWallet();
 
 		await updateOnChainTransaction({

--- a/src/screens/Settings/SettingsView.tsx
+++ b/src/screens/Settings/SettingsView.tsx
@@ -31,7 +31,7 @@ const SettingsView = ({
 	childrenPosition?: 'top' | 'bottom';
 }): ReactElement => {
 	return (
-		<View style={[ fullHeight ? styles.fullHeight : null ]} color="black">
+		<View style={[fullHeight ? styles.fullHeight : null]} color="black">
 			<SafeAreaInsets type="top" />
 			<NavigationHeader title={title} displayBackButton={showBackNavigation} />
 
@@ -63,7 +63,7 @@ const styles = StyleSheet.create({
 	},
 	fullHeight: {
 		flex: 1,
-	}
+	},
 });
 
 export default memo(SettingsView);

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -167,7 +167,7 @@ export const defaultWalletStoreShape: IWallet = {
 	loading: true,
 	walletExists: false,
 	error: false,
-	selectedNetwork: 'bitcoinTestnet',
+	selectedNetwork: 'bitcoinRegtest',
 	selectedWallet: EWallet.defaultWallet,
 	addressTypes: { ...addressTypes },
 	exchangeRates: {},

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -15,6 +15,7 @@ import { connectToElectrum, subscribeToHeader } from '../wallet/electrum';
 import { updateOnchainFeeEstimates } from '../../store/actions/fees';
 import { setupLdk } from '../lightning';
 import lm from '@synonymdev/react-native-ldk';
+import { ICustomElectrumPeer } from '../../store/types/settings';
 
 /**
  * Checks if the specified wallet's phrase is saved to storage.
@@ -106,7 +107,19 @@ export const startWalletServices = async ({
 			// We need to start Electrum if either onchain or lightning is true.
 			if (onchain || lightning) {
 				// Connect to Electrum
-				const electrumResponse = await connectToElectrum({ selectedNetwork });
+				let customPeers: ICustomElectrumPeer[] | undefined;
+				/*customPeers = [
+					{
+						host: '192.168.50.35',
+						ssl: 50001,
+						tcp: 50001,
+						protocol: 'tcp',
+					},
+				];*/
+				const electrumResponse = await connectToElectrum({
+					selectedNetwork,
+					customPeers,
+				});
 				if (electrumResponse.isOk()) {
 					let onReceive = (): void => {};
 					// TODO: Remove regtest condition once LDK is enabled for mainnet and testnet.


### PR DESCRIPTION
Bitkit will now default to regtest when starting for the first time.

In regtest, Bitkit will connect to [this](https://github.com/synonymdev/bitkit/blob/08d7b67a46f939265dab7efdad6a86a7027f5161/src/store/shapes/settings.ts#L21) Synonym Electrum server unless specified otherwise. To override this Electrum server for testing purposes you can inject your own by uncommenting and updating the `customPeers` variable [here](https://github.com/synonymdev/bitkit/blob/08d7b67a46f939265dab7efdad6a86a7027f5161/src/utils/startup/index.ts#L111).

This PR:
- Switches the default `selectedNetwork` from "bitcoinTestnet" to "bitcoinRegtest".