### PR TITLE
feat: reduce exchange rate services to Blocktank

### DIFF
--- a/__tests__/fiat.ts
+++ b/__tests__/fiat.ts
@@ -24,6 +24,7 @@ describe('Pulls latest fiat exchange rates and checks the wallet store for valid
 
 		//All tickers have the correct format 
 		tickers.forEach((ticker) => {
+			expect(typeof exchangeRates[ticker].currencySymbol).toBe('string');
 			expect(typeof exchangeRates[ticker].quoteName).toBe('string');
 			expect(typeof exchangeRates[ticker].rate).toBe('number');
 			expect(exchangeRates[ticker].rate).toBeGreaterThan(1);

--- a/__tests__/fiat.ts
+++ b/__tests__/fiat.ts
@@ -1,18 +1,13 @@
 import { getStore } from '../src/store/helpers';
 import { updateExchangeRates } from '../src/store/actions/wallet';
 import { getDisplayValues } from '../src/utils/exchange-rate';
-import {
-	EExchangeRateService,
-	supportedExchangeTickers,
-} from '../src/utils/exchange-rate/types';
-import { updateSettings } from '../src/store/actions/settings';
 
 global.fetch = require('node-fetch');
 
 describe('Pulls latest fiat exchange rates and checks the wallet store for valid conversions', () => {
 	jest.setTimeout(10000);
 
-	it('Bitfinex rates with default selected currency', async () => {
+	it('Blocktank FX rates with default selected currency', async () => {
 		const res = await updateExchangeRates();
 
 		expect(res.isOk()).toEqual(true);
@@ -25,43 +20,13 @@ describe('Pulls latest fiat exchange rates and checks the wallet store for valid
 		const tickers = Object.keys(exchangeRates);
 
 		//We have some available tickers
-		expect(tickers.length).toBe(
-			supportedExchangeTickers[EExchangeRateService.bitfinex].length,
-		);
+		expect(tickers.length).toBeGreaterThan(0);
 
-		//Every ticker stored needs to be a valid number
+		//All tickers have the correct format 
 		tickers.forEach((ticker) => {
-			expect(typeof exchangeRates[ticker]).toBe('number');
-			expect(exchangeRates[ticker]).toBeGreaterThan(1);
-		});
-	});
-
-	it('Crypto Compare rates with new selected currency', async () => {
-		updateSettings({
-			exchangeRateService: 'cryptoCompare',
-			selectedCurrency: 'EUR',
-		});
-
-		const res = await updateExchangeRates();
-
-		expect(res.isOk()).toEqual(true);
-		if (res.isErr()) {
-			return;
-		}
-
-		const { exchangeRates } = getStore().wallet;
-
-		const tickers = Object.keys(exchangeRates);
-
-		//We have some available tickers
-		expect(tickers.length).toBe(
-			supportedExchangeTickers[EExchangeRateService.cryptoCompare].length,
-		);
-
-		//Every ticker stored needs to be a valid number
-		tickers.forEach((ticker) => {
-			expect(typeof exchangeRates[ticker]).toBe('number');
-			expect(exchangeRates[ticker]).toBeGreaterThan(1);
+			expect(typeof exchangeRates[ticker].quoteName).toBe('string');
+			expect(typeof exchangeRates[ticker].rate).toBe('number');
+			expect(exchangeRates[ticker].rate).toBeGreaterThan(1);
 		});
 	});
 

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,12 +1,18 @@
 import React, { ReactElement, memo } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { TextInput, MagnifyingGlassIcon } from '../styles/components';
 
-const SearchInput = ({ style, children, ...props }): ReactElement => {
+type SearchInputProps = {
+	style?: StyleProp<ViewStyle>;
+	children?: ReactElement;
+	[x: string]: any;
+};
+
+const SearchInput = ({ style, children, ...props }: SearchInputProps) => {
 	const rootStyle = StyleSheet.compose(style, styles.root);
 
 	return (
-		<View style={rootStyle}>
+		<View style={style ? rootStyle : null}>
 			<MagnifyingGlassIcon style={styles.icon} />
 			<TextInput style={styles.input} placeholder="Search" {...props} />
 			{children && <View style={styles.tags}>{children}</View>}

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -9,10 +9,8 @@ type SearchInputProps = {
 };
 
 const SearchInput = ({ style, children, ...props }: SearchInputProps) => {
-	const rootStyle = StyleSheet.compose(style, styles.root);
-
 	return (
-		<View style={style ? rootStyle : null}>
+		<View style={[styles.root, style]}>
 			<MagnifyingGlassIcon style={styles.icon} />
 			<TextInput style={styles.input} placeholder="Search" {...props} />
 			{children && <View style={styles.tags}>{children}</View>}

--- a/src/hooks/displayValues.ts
+++ b/src/hooks/displayValues.ts
@@ -28,7 +28,7 @@ export default function useDisplayValues(
 			return defaultDisplayValues;
 		}
 
-		const exchangeRate = exchangeRates[selectedCurrency];
+		const exchangeRate = exchangeRates[selectedCurrency].rate;
 
 		return getDisplayValues({
 			satoshis: sats,

--- a/src/screens/Settings/Currencies/index.tsx
+++ b/src/screens/Settings/Currencies/index.tsx
@@ -52,6 +52,7 @@ const Currencies = (): ReactElement => {
 			title={'Local currency'}
 			listData={CurrencyListData}
 			showBackNavigation
+			showSearch
 		/>
 	);
 };

--- a/src/screens/Settings/Currencies/index.tsx
+++ b/src/screens/Settings/Currencies/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo, ReactElement, useMemo } from 'react';
+import { useNavigation } from '@react-navigation/native';
 
 import { IListData } from '../../../components/List';
 import SettingsView from '../SettingsView';
@@ -8,6 +9,8 @@ import { mostUsedExchangeTickers } from '../../../utils/exchange-rate/types';
 import { updateSettings } from '../../../store/actions/settings';
 
 const Currencies = (): ReactElement => {
+	const navigation = useNavigation();
+
 	const exchangeRates = useSelector(
 		(state: Store) => state.wallet.exchangeRates,
 	);
@@ -28,7 +31,10 @@ const Currencies = (): ReactElement => {
 					title: `${ticker} (${exchangeRates[ticker].currencySymbol})`,
 					value: selectedCurrency === ticker,
 					type: 'button',
-					onPress: (): void => onSetCurrency(ticker),
+					onPress: (): void => {
+						navigation.goBack();
+						onSetCurrency(ticker);
+					},
 					hide: false,
 				})),
 			},
@@ -38,7 +44,10 @@ const Currencies = (): ReactElement => {
 					title: ticker,
 					value: selectedCurrency === ticker,
 					type: 'button',
-					onPress: (): void => onSetCurrency(ticker),
+					onPress: (): void => {
+						navigation.goBack();
+						onSetCurrency(ticker);
+					},
 					hide: false,
 				})),
 			},

--- a/src/screens/Settings/Currencies/index.tsx
+++ b/src/screens/Settings/Currencies/index.tsx
@@ -25,7 +25,7 @@ const Currencies = (): ReactElement => {
 			{
 				title: 'Most Used',
 				data: mostUsedExchangeTickers.map((ticker) => ({
-					title: ticker,
+					title: `${ticker} (${exchangeRates[ticker].currencySymbol})`,
 					value: selectedCurrency === ticker,
 					type: 'button',
 					onPress: (): void => onSetCurrency(ticker),
@@ -33,9 +33,9 @@ const Currencies = (): ReactElement => {
 				})),
 			},
 			{
-				title: 'All',
+				title: 'Other Currencies',
 				data: Object.keys(exchangeRates).map((ticker) => ({
-					title: `${ticker} — ${exchangeRates[ticker].quoteName}`,
+					title: ticker,
 					value: selectedCurrency === ticker,
 					type: 'button',
 					onPress: (): void => onSetCurrency(ticker),
@@ -49,7 +49,7 @@ const Currencies = (): ReactElement => {
 
 	return (
 		<SettingsView
-			title={'Currencies'}
+			title={'Local currency'}
 			listData={CurrencyListData}
 			showBackNavigation
 		/>

--- a/src/screens/Settings/Currencies/index.tsx
+++ b/src/screens/Settings/Currencies/index.tsx
@@ -1,25 +1,15 @@
-import React, { memo, ReactElement, useCallback, useMemo } from 'react';
+import React, { memo, ReactElement, useMemo } from 'react';
 
 import { IListData } from '../../../components/List';
 import SettingsView from '../SettingsView';
 import { useSelector } from 'react-redux';
 import Store from '../../../store/types';
-import {
-	EExchangeRateService,
-	exchangeRateServices,
-	mostUsedExchangeTickers,
-	supportedExchangeTickers,
-} from '../../../utils/exchange-rate/types';
+import { mostUsedExchangeTickers } from '../../../utils/exchange-rate/types';
 import { updateSettings } from '../../../store/actions/settings';
-import { updateExchangeRates } from '../../../store/actions/wallet';
 
 const Currencies = (): ReactElement => {
-	const exchangeRateServicesKeys = Object.keys(EExchangeRateService).filter(
-		(key) => isNaN(Number(EExchangeRateService[key])),
-	);
-
-	const selectedExchangeRateService = useSelector(
-		(state: Store) => state.settings.exchangeRateService,
+	const exchangeRates = useSelector(
+		(state: Store) => state.wallet.exchangeRates,
 	);
 
 	const selectedCurrency = useSelector(
@@ -30,65 +20,31 @@ const Currencies = (): ReactElement => {
 		updateSettings({ selectedCurrency: currency });
 	};
 
-	const onSetExchangeRateService = useCallback(
-		(provider: EExchangeRateService): void => {
-			updateSettings({
-				exchangeRateService: provider,
-				selectedCurrency:
-					supportedExchangeTickers[EExchangeRateService[provider]][0],
-			});
-
-			setTimeout(() => {
-				updateExchangeRates().then();
-			}, 250);
-		},
-		[],
-	);
-
 	const CurrencyListData: IListData[] = useMemo(
 		() => [
 			{
-				title: 'Exchange rate service',
-				data: exchangeRateServicesKeys.map((service) => ({
-					title: exchangeRateServices[service],
-					value: service === selectedExchangeRateService,
+				title: 'Most Used',
+				data: mostUsedExchangeTickers.map((ticker) => ({
+					title: ticker,
+					value: selectedCurrency === ticker,
 					type: 'button',
-					onPress: (): void =>
-						onSetExchangeRateService(EExchangeRateService[service]),
+					onPress: (): void => onSetCurrency(ticker),
 					hide: false,
 				})),
 			},
 			{
-				title: 'Most Used',
-				data: mostUsedExchangeTickers[selectedExchangeRateService].map(
-					(ticker) => ({
-						title: ticker,
-						value: selectedCurrency === ticker,
-						type: 'button',
-						onPress: (): void => onSetCurrency(ticker),
-						hide: false,
-					}),
-				),
-			},
-			{
 				title: 'All',
-				data: supportedExchangeTickers[selectedExchangeRateService].map(
-					(ticker) => ({
-						title: ticker,
-						value: selectedCurrency === ticker,
-						type: 'button',
-						onPress: (): void => onSetCurrency(ticker),
-						hide: false,
-					}),
-				),
+				data: Object.keys(exchangeRates).map((ticker) => ({
+					title: `${ticker} — ${exchangeRates[ticker].quoteName}`,
+					value: selectedCurrency === ticker,
+					type: 'button',
+					onPress: (): void => onSetCurrency(ticker),
+					hide: false,
+				})),
 			},
 		],
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[
-			selectedExchangeRateService,
-			onSetExchangeRateService,
-			exchangeRateServicesKeys,
-		],
+		[selectedCurrency],
 	);
 
 	return (

--- a/src/screens/Settings/General/index.tsx
+++ b/src/screens/Settings/General/index.tsx
@@ -97,7 +97,12 @@ const General = ({ navigation }): ReactElement => {
 			},
 		],
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[showSuggestions, selectedBitcoinUnit, selectedTransactionSpeed],
+		[
+			showSuggestions,
+			selectedCurrency,
+			selectedBitcoinUnit,
+			selectedTransactionSpeed,
+		],
 	);
 
 	return (

--- a/src/screens/Settings/SettingsView.tsx
+++ b/src/screens/Settings/SettingsView.tsx
@@ -1,9 +1,9 @@
-import React, { memo, ReactElement } from 'react';
+import React, { memo, ReactElement, useState } from 'react';
 import { StyleSheet } from 'react-native';
+
 import { View } from '../../styles/components';
-
+import SearchInput from '../../components/SearchInput';
 import List, { IListData } from '../../components/List';
-
 import NavigationHeader from '../../components/NavigationHeader';
 import SafeAreaInsets from '../../components/SafeAreaInsets';
 
@@ -19,6 +19,7 @@ const SettingsView = ({
 	title,
 	listData,
 	showBackNavigation = true,
+	showSearch = false,
 	fullHeight = true,
 	children,
 	childrenPosition = 'top',
@@ -26,14 +27,34 @@ const SettingsView = ({
 	title: string;
 	listData?: IListData[];
 	showBackNavigation: boolean;
+	showSearch?: boolean;
 	fullHeight?: boolean;
 	children?: ReactElement | ReactElement[] | undefined;
 	childrenPosition?: 'top' | 'bottom';
 }): ReactElement => {
+	const [search, setSearch] = useState('');
+	const filteredListData = listData?.map((section) => {
+		const filteredSectionData = section.data.filter((item) => {
+			return item.title.toLowerCase().includes(search.toLowerCase());
+		});
+
+		const filteredSection = filteredSectionData.length > 0 ? section : null
+
+		return { ...filteredSection, data: filteredSectionData };
+	}) ?? [];
+
 	return (
 		<View style={[fullHeight ? styles.fullHeight : null]} color="black">
 			<SafeAreaInsets type="top" />
 			<NavigationHeader title={title} displayBackButton={showBackNavigation} />
+
+			{showSearch ? (
+				<SearchInput
+					style={styles.searchInput}
+					value={search}
+					onChangeText={setSearch}
+				/>
+			) : null}
 
 			{children && childrenPosition === 'top' ? (
 				<View color="black">{children}</View>
@@ -41,7 +62,7 @@ const SettingsView = ({
 
 			{listData ? (
 				<View style={styles.listContent} color="black">
-					<List data={listData} />
+					<List data={filteredListData} />
 				</View>
 			) : null}
 
@@ -55,6 +76,9 @@ const SettingsView = ({
 };
 
 const styles = StyleSheet.create({
+	searchInput: {
+		marginHorizontal: 16,
+	},
 	listContent: {
 		paddingHorizontal: 16,
 	},

--- a/src/screens/Wallets/SendOnChainTransaction/CoinSelection.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/CoinSelection.tsx
@@ -122,7 +122,7 @@ const CoinSelection = (): ReactElement => {
 	const exchangeRates = useSelector(
 		(state: Store) => state.wallet.exchangeRates,
 	);
-	const exchangeRate = exchangeRates[selectedCurrency];
+	const exchangeRate = exchangeRates[selectedCurrency].rate;
 
 	const getBtcValueText = (displayValue: IDisplayValues): string =>
 		`${

--- a/src/screens/Wallets/SendOnChainTransaction/OnChainNumberPad.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/OnChainNumberPad.tsx
@@ -39,7 +39,7 @@ const OnChainNumberPad = (): ReactElement => {
 		(store: Store) => store.settings.selectedCurrency,
 	);
 	const exchangeRate = useSelector(
-		(store: Store) => store.wallet.exchangeRates[currency],
+		(store: Store) => store.wallet.exchangeRates[currency].rate,
 	);
 
 	const transaction = useSelector(

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -1,5 +1,4 @@
 import { ISettings } from '../types/settings';
-import { EExchangeRateService } from '../../utils/exchange-rate/types';
 
 export const defaultSettingsShape: ISettings = {
 	loading: false,
@@ -13,7 +12,6 @@ export const defaultSettingsShape: ISettings = {
 	bitcoinUnit: 'satoshi', //BTC, mBTC, μBTC or satoshi
 	balanceUnit: 'satoshi', //BTC, mBTC, μBTC or satoshi
 	selectedCurrency: 'USD',
-	exchangeRateService: EExchangeRateService.bitfinex,
 	selectedLanguage: 'english',
 	customElectrumPeers: {
 		bitcoin: [],

--- a/src/store/types/settings.ts
+++ b/src/store/types/settings.ts
@@ -1,5 +1,4 @@
 import { IWalletItem, TBitcoinUnit, TBalanceUnit } from './wallet';
-import { EExchangeRateService } from '../../utils/exchange-rate/types';
 
 type TTheme = 'dark' | 'light' | 'blue';
 export type TProtocol = 'ssl' | 'tcp' | string;
@@ -33,7 +32,6 @@ export interface ISettings {
 	balanceUnit: TBalanceUnit;
 	customElectrumPeers: IWalletItem<ICustomElectrumPeer[]> | IWalletItem<[]>;
 	selectedCurrency: string;
-	exchangeRateService: EExchangeRateService;
 	selectedLanguage: string;
 	coinSelectAuto: boolean;
 	coinSelectPreference: TCoinSelectPreference;

--- a/src/utils/exchange-rate/index.ts
+++ b/src/utils/exchange-rate/index.ts
@@ -1,26 +1,31 @@
 import { default as bitcoinUnits } from 'bitcoin-units';
-import { ok, Result } from '../result';
+import { ok, err, Result } from '../result';
 import { getStore } from '../../store/helpers';
 import { TBitcoinUnit } from '../../store/types/wallet';
 import { defaultDisplayValues, IDisplayValues, IExchangeRates } from './types';
 
 export const getExchangeRates = async (): Promise<Result<IExchangeRates>> => {
-	// TODO: pull this out into .env
-	const response = await fetch('http://35.233.47.252:443/fx/rates/btc');
-	const { tickers } = await response.json();
+	try {
+		// TODO: pull this out into .env
+		const response = await fetch('http://35.233.47.252:443/fx/rates/btc');
+		const { tickers } = await response.json();
 
-	const rates: IExchangeRates = tickers.reduce((acc, ticker) => {
-		return {
-			...acc,
-			[ticker.quote]: {
-				currencySymbol: ticker.currencySymbol,
-				quoteName: ticker.quoteName,
-				rate: Math.round(Number(ticker.lastPrice) * 100) / 100,
-			},
-		};
-	}, {});
+		const rates: IExchangeRates = tickers.reduce((acc, ticker) => {
+			return {
+				...acc,
+				[ticker.quote]: {
+					currencySymbol: ticker.currencySymbol,
+					quoteName: ticker.quoteName,
+					rate: Math.round(Number(ticker.lastPrice) * 100) / 100,
+				},
+			};
+		}, {});
 
-	return ok(rates);
+		return ok(rates);
+	} catch (e) {
+		console.error(e);
+		return err(e);
+	}
 };
 
 export const fiatToBitcoinUnit = ({

--- a/src/utils/exchange-rate/index.ts
+++ b/src/utils/exchange-rate/index.ts
@@ -13,6 +13,7 @@ export const getExchangeRates = async (): Promise<Result<IExchangeRates>> => {
 		return {
 			...acc,
 			[ticker.quote]: {
+				currencySymbol: ticker.currencySymbol,
 				quoteName: ticker.quoteName,
 				rate: Math.round(Number(ticker.lastPrice) * 100) / 100,
 			},

--- a/src/utils/exchange-rate/index.ts
+++ b/src/utils/exchange-rate/index.ts
@@ -2,61 +2,24 @@ import { default as bitcoinUnits } from 'bitcoin-units';
 import { ok, Result } from '../result';
 import { getStore } from '../../store/helpers';
 import { TBitcoinUnit } from '../../store/types/wallet';
-import {
-	defaultDisplayValues,
-	EExchangeRateService,
-	IDisplayValues,
-	IExchangeRates,
-	supportedExchangeTickers,
-} from './types';
+import { defaultDisplayValues, IDisplayValues, IExchangeRates } from './types';
 
 export const getExchangeRates = async (): Promise<Result<IExchangeRates>> => {
-	let { exchangeRateService } = getStore().settings;
+	// TODO: pull this out into .env
+	const response = await fetch('http://35.233.47.252:443/fx/rates/btc');
+	const { tickers } = await response.json();
 
-	const service = exchangeRateService
-		? EExchangeRateService[exchangeRateService]
-		: EExchangeRateService.bitfinex;
-
-	switch (service) {
-		case EExchangeRateService.cryptoCompare: {
-			return getCryptoCompareRates();
-		}
-		case EExchangeRateService.bitfinex:
-		default: {
-			return getBitfinexRates();
-		}
-	}
-};
-
-const getBitfinexRates = async (): Promise<Result<IExchangeRates>> => {
-	const rates: IExchangeRates = {};
-
-	const response = await fetch(
-		`https://api-pub.bitfinex.com/v2/tickers?symbols=${supportedExchangeTickers[
-			EExchangeRateService.bitfinex
-		]
-			.map((c) => `tBTC${c}`)
-			.join(',')}`,
-	);
-
-	const jsonResponse = (await response.json()) as Array<Array<string>>;
-	jsonResponse.forEach((a) => {
-		rates[a[0].replace('tBTC', '')] = Math.round(Number(a[1]) * 100) / 100;
-	});
+	const rates: IExchangeRates = tickers.reduce((acc, ticker) => {
+		return {
+			...acc,
+			[ticker.quote]: {
+				quoteName: ticker.quoteName,
+				rate: Math.round(Number(ticker.lastPrice) * 100) / 100,
+			},
+		};
+	}, {});
 
 	return ok(rates);
-};
-
-const getCryptoCompareRates = async (): Promise<Result<IExchangeRates>> => {
-	const response = await fetch(
-		`https://min-api.cryptocompare.com/data/price?fsym=BTC&tsyms=${supportedExchangeTickers[
-			EExchangeRateService.cryptoCompare
-		]
-			.map((c) => `${c}`)
-			.join(',')}`,
-	);
-
-	return ok((await response.json()) as IExchangeRates);
 };
 
 export const fiatToBitcoinUnit = ({
@@ -74,7 +37,7 @@ export const fiatToBitcoinUnit = ({
 		currency = getStore().settings.selectedCurrency;
 	}
 	if (!exchangeRate) {
-		exchangeRate = getStore().wallet.exchangeRates[currency] || 0;
+		exchangeRate = getStore().wallet.exchangeRates[currency].rate || 0;
 	}
 	if (!bitcoinUnit) {
 		bitcoinUnit = getStore().settings.bitcoinUnit;
@@ -107,7 +70,7 @@ export const getDisplayValues = ({
 			currency = getStore().settings.selectedCurrency;
 		}
 		if (!exchangeRate) {
-			exchangeRate = getStore().wallet.exchangeRates[currency] || 0;
+			exchangeRate = getStore().wallet.exchangeRates[currency].rate || 0;
 		}
 		if (!bitcoinUnit) {
 			bitcoinUnit = getStore().settings.bitcoinUnit;

--- a/src/utils/exchange-rate/types.ts
+++ b/src/utils/exchange-rate/types.ts
@@ -1,38 +1,11 @@
-export enum EExchangeRateService {
-	bitfinex = 'bitfinex',
-	cryptoCompare = 'cryptoCompare',
-}
-
-export const exchangeRateServices = {
-	[EExchangeRateService.bitfinex]: 'Bitfinex',
-	[EExchangeRateService.cryptoCompare]: 'Crypto Compare',
-};
-
-export const supportedExchangeTickers = {
-	[EExchangeRateService.bitfinex]: ['USD', 'EUR', 'JPY', 'GBP'],
-	[EExchangeRateService.cryptoCompare]: [
-		'USD',
-		'EUR',
-		'JPY',
-		'GBP',
-		'ZAR',
-		'CAD',
-		'CNY',
-	],
-};
-
-export const mostUsedExchangeTickers = {
-	[EExchangeRateService.bitfinex]: ['USD', 'EUR', 'GBP'],
-	[EExchangeRateService.cryptoCompare]: ['USD', 'EUR', 'GBP'],
-};
+export const mostUsedExchangeTickers = ['USD', 'EUR', 'GBP'];
 
 export interface IExchangeRates {
-	[key: string]: number;
+	[key: string]: {
+		quoteName: string
+		rate: number
+	};
 }
-
-export type IExchangeTickers = {
-	[key in EExchangeRateService]: string[];
-};
 
 export interface IDisplayValues {
 	fiatFormatted: string;

--- a/src/utils/exchange-rate/types.ts
+++ b/src/utils/exchange-rate/types.ts
@@ -1,9 +1,10 @@
-export const mostUsedExchangeTickers = ['USD', 'EUR', 'GBP'];
+export const mostUsedExchangeTickers = ['USD', 'GBP', 'CAD', 'CNY', 'EUR'];
 
 export interface IExchangeRates {
 	[key: string]: {
-		quoteName: string
-		rate: number
+		currencySymbol: string;
+		quoteName: string;
+		rate: number;
 	};
 }
 


### PR DESCRIPTION
Blocked by https://github.com/synonymdev/blocktank-fx-service/pull/3

### Changes:
- use [Blocktank FX exchange rate service API](https://github.com/synonymdev/blocktank-fx-service)
- remove exchange rate service selection
- add SettingsView search filter, enable for Currencies screen
- navigate the user back on choice

### Notes:
Currency symbols should appear once linked PR is merged 

### Screenshots:
<img src="https://user-images.githubusercontent.com/8538369/182670129-a9b035ce-6888-4fc4-90f4-c49053093f8f.png" width="200" />
