### PR TITLE
fix: HomeScreen Swipe Gestures

### DIFF
--- a/src/navigation/root/RootNavigator.tsx
+++ b/src/navigation/root/RootNavigator.tsx
@@ -1,9 +1,12 @@
 import React, { ReactElement, useCallback, useMemo } from 'react';
-import { TransitionPresets } from '@react-navigation/stack';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { useSelector } from 'react-redux';
+import {
+	createStackNavigator,
+	TransitionPresets,
+} from '@react-navigation/stack';
+
 import TabNavigator from '../tabs/TabNavigator';
 import Biometrics from '../../components/Biometrics';
-import { useSelector } from 'react-redux';
 import Store from '../../store/types';
 import AuthCheck from '../../components/AuthCheck';
 import Blocktank from '../../screens/Blocktank';
@@ -35,7 +38,7 @@ import Contacts from '../../screens/Contacts/Contacts';
 import Contact from '../../screens/Contacts/Contact';
 import ContactEdit from '../../screens/Contacts/ContactEdit';
 
-const Stack = createNativeStackNavigator();
+const Stack = createStackNavigator();
 
 const navOptions = {
 	headerShown: false,
@@ -100,7 +103,11 @@ const RootNavigator = (): ReactElement => {
 					<Stack.Screen name="WalletsDetail" component={WalletsDetail} />
 					<Stack.Screen name="LightningRoot" component={LightningNavigator} />
 					<Stack.Screen name="Settings" component={SettingsNavigator} />
-					<Stack.Screen name="Profile" component={Profile} />
+					<Stack.Screen
+						name="Profile"
+						component={Profile}
+						options={{ gestureDirection: 'horizontal-inverted' }}
+					/>
 					<Stack.Screen name="ProfileEdit" component={ProfileEdit} />
 					<Stack.Screen name="Contacts" component={Contacts} />
 					<Stack.Screen name="ContactEdit" component={ContactEdit} />

--- a/src/screens/Wallets/index.tsx
+++ b/src/screens/Wallets/index.tsx
@@ -20,13 +20,16 @@ const Wallets = ({ navigation }): ReactElement => {
 	const empty = useNoTransactions();
 	const { satoshis } = useBalance({ onchain: true, lightning: true });
 
-	const onSwipeLeft = (): void => {
-		//Swiping left, navigate to the scanner/camera.
+	const toggleHideBalance = (): void => {
+		updateSettings({ hideBalance: !hideBalance });
+	};
+
+	const navigateToScanner = (): void => {
 		navigation.navigate('Scanner');
 	};
 
-	const onSwipeRight = (): void => {
-		updateSettings({ hideBalance: !hideBalance });
+	const navigateToProfile = (): void => {
+		navigation.navigate('Profile');
 	};
 
 	LayoutAnimation.easeInEaseOut();
@@ -34,21 +37,26 @@ const Wallets = ({ navigation }): ReactElement => {
 	return (
 		<SafeAreaView>
 			<Header />
-			<ScrollView
-				contentContainerStyle={!empty && styles.scrollview}
-				disableScrollViewPanResponder={true}
-				showsVerticalScrollIndicator={false}>
-				<DetectSwipe onSwipeLeft={onSwipeLeft} onSwipeRight={onSwipeRight}>
-					<View>
-						<BalanceHeader />
-					</View>
-				</DetectSwipe>
-				{empty ? (
-					<EmptyWallet />
-				) : (
-					<>
-						<TodoCarousel />
-						<DetectSwipe onSwipeLeft={onSwipeLeft} onSwipeRight={onSwipeRight}>
+			<DetectSwipe
+				onSwipeLeft={navigateToScanner}
+				onSwipeRight={navigateToProfile}>
+				<ScrollView
+					contentContainerStyle={!empty && styles.scrollview}
+					disableScrollViewPanResponder={true}
+					showsVerticalScrollIndicator={false}>
+					<DetectSwipe
+						onSwipeLeft={toggleHideBalance}
+						onSwipeRight={toggleHideBalance}>
+						<View>
+							<BalanceHeader />
+						</View>
+					</DetectSwipe>
+
+					{empty ? (
+						<EmptyWallet />
+					) : (
+						<>
+							<TodoCarousel />
 							<View style={styles.content}>
 								<Subtitle style={styles.assetsTitle}>Assets</Subtitle>
 								<AssetCard
@@ -56,20 +64,20 @@ const Wallets = ({ navigation }): ReactElement => {
 									ticker={'BTC'}
 									satoshis={satoshis}
 									icon={<BitcoinCircleIcon />}
-									onPress={(): void =>
+									onPress={(): void => {
 										navigation.navigate('WalletsDetail', {
 											assetType: 'bitcoin',
-										})
-									}
+										});
+									}}
 								/>
 							</View>
-						</DetectSwipe>
-						<View style={styles.content}>
-							<ActivityListShort />
-						</View>
-					</>
-				)}
-			</ScrollView>
+							<View style={styles.content}>
+								<ActivityListShort />
+							</View>
+						</>
+					)}
+				</ScrollView>
+			</DetectSwipe>
 		</SafeAreaView>
 	);
 };


### PR DESCRIPTION
Task: https://app.asana.com/0/1189635884316057/1202701602165762/f

### Changes:
- "swipe to hide balance" now only on total balance (left & right swipe)
- "swipe to Scanner" everywhere below carousel (left swipe)
- "swipe to Profile" everywhere below carousel (right swipe)
- changed RootNavigator to be a non-native StackNavigator to be able to pass custom animation, Profile slides in from left side

### Notes
The android version also has the slideIn animation now for the Root navigator. Is it worth giving up performance of the native StackNavigator for the custom slide-in animation?

### Preview

https://user-images.githubusercontent.com/8538369/183481446-c0dcd8fc-0286-4187-889b-e61592be4c44.mp4

