### PR TITLE
fix: remove LayoutAnimation from render of some components

### DIFF
--- a/src/screens/Wallets/SendOnChainTransaction/FeePickerCard.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/FeePickerCard.tsx
@@ -1,5 +1,5 @@
 import React, { memo, ReactElement, useMemo } from 'react';
-import { LayoutAnimation, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import {
 	AntDesign,
 	EvilIcon,
@@ -55,8 +55,6 @@ const FeePickerCard = ({
 	onPress?: Function;
 	isSelected?: boolean;
 }): ReactElement => {
-	LayoutAnimation.easeInEaseOut();
-
 	const totalFeeDisplay = useDisplayValues(sats);
 
 	const _description = useMemo(() => {

--- a/src/screens/Wallets/index.tsx
+++ b/src/screens/Wallets/index.tsx
@@ -1,6 +1,6 @@
 import React, { memo, ReactElement, useState } from 'react';
 import { useSelector } from 'react-redux';
-import { LayoutAnimation, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
 import {
 	View,
@@ -38,8 +38,6 @@ const Wallets = ({ navigation }): ReactElement => {
 	const navigateToProfile = (): void => {
 		navigation.navigate('Profile');
 	};
-
-	LayoutAnimation.easeInEaseOut();
 
 	const onRefresh = async (): Promise<void> => {
 		setRefreshing(true);


### PR DESCRIPTION
Looks like using LayoutAnimation may lead to some errors on Android. 
I didn't remove all of them, only ones that made errors while switching denomination. 

closes #234