### PR TITLE
perf(wallet): Reduced Address Generation On-Start

### DIFF
--- a/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
+++ b/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
@@ -10,7 +10,10 @@ import {
 } from '../../../store/actions/wallet';
 import { getNetworkData } from '../../../utils/helpers';
 import { startWalletServices } from '../../../utils/startup';
-import { getCurrentWallet } from '../../../utils/wallet';
+import {
+	getCurrentWallet,
+	getSelectedAddressType,
+} from '../../../utils/wallet';
 
 const BitcoinNetworkSelection = (): ReactElement => {
 	const selectedNetwork = useSelector(
@@ -30,9 +33,19 @@ const BitcoinNetworkSelection = (): ReactElement => {
 							// Switch to new network.
 							await updateWallet({ selectedNetwork: network });
 							// Grab the selectedWallet.
-							const { selectedWallet } = getCurrentWallet({ selectedNetwork });
+							const { selectedWallet } = getCurrentWallet({
+								selectedNetwork: network,
+							});
+							const addressType = getSelectedAddressType({
+								selectedNetwork: network,
+								selectedWallet,
+							});
 							// Generate addresses if none exist for the newly selected wallet and network.
-							await updateAddressIndexes({ selectedWallet, selectedNetwork });
+							await updateAddressIndexes({
+								selectedWallet,
+								selectedNetwork: network,
+								addressType,
+							});
 							// Start wallet services with the newly selected network.
 							await startWalletServices({});
 						},

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -46,6 +46,7 @@ import {
 import { EFeeIds } from '../types/fees';
 import { IHeader } from '../../utils/types/electrum';
 import { toggleView } from './user';
+import { GENERATE_ADDRESS_AMOUNT } from '../../utils/wallet/constants';
 
 const dispatch = getDispatch();
 
@@ -70,8 +71,8 @@ export const updateWallet = (payload): Promise<Result<string>> => {
  */
 export const createWallet = async ({
 	walletName = EWallet.defaultWallet,
-	addressAmount = 1,
-	changeAddressAmount = 1,
+	addressAmount = GENERATE_ADDRESS_AMOUNT,
+	changeAddressAmount = GENERATE_ADDRESS_AMOUNT,
 	mnemonic = '',
 	addressTypes,
 }: ICreateWallet): Promise<Result<string>> => {

--- a/src/utils/wallet/constants.ts
+++ b/src/utils/wallet/constants.ts
@@ -1,0 +1,6 @@
+export const BITKIT_WALLET_SEED_HASH_PREFIX = Buffer.from(
+	'@Bitkit/wallet-uuid',
+);
+
+//How many addresses to generate when more are needed.
+export const GENERATE_ADDRESS_AMOUNT = 2;


### PR DESCRIPTION
This PR reduces the number of addresses generated on-start. Instead of generating 30+ addresses that include all address types, we're only generating 4 `p2wpkh` addresses. As a result, `p2sh` and `p2pkh` addresses will no longer appear in the receive view's address carousel. However, we will be phasing this out in a future PR in favor of a unified qr-code (on-chain+lightning).

Ultimately, this should speed up tests for testers on live devices, Android emulators and simulators until we are ready to implement the [nodejs-mobile](https://github.com/synonymdev/bitkit/tree/nodejs-mobile) update.

This PR:
- Adds `updateAllAddressTypes` param to `refreshWallet` method in `utils/wallet/index.ts`.
- Creates `constants.ts` and set `GENERATE_ADDRESS_AMOUNT` to 2 in `utils/wallet/constants.ts`.
- Passes `addressType` to `updateAddressIndexes` in `BitcoinNetworkSelection.tsx`.