### PR TITLE
feat: improve fiat render

### DIFF
--- a/__mocks__/rn-qr-generator.ts
+++ b/__mocks__/rn-qr-generator.ts
@@ -1,0 +1,3 @@
+export default {
+    detect: jest.fn(),
+};

--- a/__tests__/fiat.ts
+++ b/__tests__/fiat.ts
@@ -33,18 +33,48 @@ describe('Pulls latest fiat exchange rates and checks the wallet store for valid
 
 	it('Formats all display values in USD formatted with correct locale', async () => {
 		//Testing the react hook
-		const { fiatFormatted, fiatSymbol, bitcoinFormatted, bitcoinSymbol } =
-			getDisplayValues({
-				satoshis: 1010101,
-				exchangeRate: 100000,
-				currency: 'USD',
-				bitcoinUnit: 'BTC',
-				locale: 'en-US',
-			});
+		const dv = getDisplayValues({
+			satoshis: 1010101,
+			exchangeRate: 100000,
+			currency: 'USD',
+			bitcoinUnit: 'BTC',
+			locale: 'en-US',
+		});
 
-		expect(fiatFormatted).toBe('1,010.10');
-		expect(fiatSymbol).toBe('$');
-		expect(bitcoinFormatted).toBe('0.01010101');
-		expect(bitcoinSymbol).toBe('₿');
+		expect(dv.fiatFormatted).toBe('1,010.10');
+		expect(dv.fiatWhole).toBe('1,010');
+		expect(dv.fiatDecimal).toBe('.');
+		expect(dv.fiatDecimalValue).toBe('10');
+		expect(dv.fiatSymbol).toBe('$');
+		expect(dv.fiatTicker).toBe('USD');
+		expect(dv.fiatValue).toBe(1010.1);
+		expect(dv.bitcoinFormatted).toBe('0.01010101');
+		expect(dv.bitcoinSymbol).toBe('₿');
+		expect(dv.bitcoinTicker).toBe('BTC');
+		expect(dv.satoshis).toBe(1010101);
+	});
+
+	it('Formats all display values in RUB formatted with correct locale', async () => {
+		//Testing the react hook
+		const dv = getDisplayValues({
+			satoshis: 1010101,
+			exchangeRate: 100000,
+			currency: 'RUB',
+			currencySymbol: '₽',
+			bitcoinUnit: 'satoshi',
+			locale: 'en-US',
+		});
+
+		expect(dv.fiatFormatted).toBe('1,010.10');
+		expect(dv.fiatWhole).toBe('1,010');
+		expect(dv.fiatDecimal).toBe('.');
+		expect(dv.fiatDecimalValue).toBe('10');
+		expect(dv.fiatSymbol).toBe('₽');
+		expect(dv.fiatTicker).toBe('RUB');
+		expect(dv.fiatValue).toBe(1010.1);
+		expect(dv.bitcoinFormatted).toBe('1 010 101');
+		expect(dv.bitcoinSymbol).toBe('⚡');
+		expect(dv.bitcoinTicker).toBe('sats');
+		expect(dv.satoshis).toBe(1010101);
 	});
 });

--- a/src/utils/exchange-rate/index.ts
+++ b/src/utils/exchange-rate/index.ts
@@ -107,11 +107,12 @@ export const getDisplayValues = ({
 				currencyFormat = 'USD';
 			}
 
+			fiatFormatted = '';
+
 			const fiatFormattedIntl = new Intl.NumberFormat(locale, {
 				style: 'currency',
 				currency: currencyFormat,
 			});
-			fiatFormatted = fiatFormattedIntl.format(fiatValue);
 
 			fiatFormattedIntl.formatToParts(fiatValue).forEach((part) => {
 				if (part.type === 'currency') {
@@ -123,11 +124,13 @@ export const getDisplayValues = ({
 				} else if (part.type === 'decimal') {
 					fiatDecimal = part.value;
 				}
+
+				if (part.type !== 'currency') {
+					fiatFormatted = `${fiatFormatted}${part.value}`;
+				}
 			});
 
-			fiatFormatted = isNaN(fiatValue)
-				? '-'
-				: fiatFormatted.replace(fiatSymbol, '');
+			fiatFormatted = fiatFormatted.trim();
 		}
 
 		let bitcoinFormatted = bitcoinUnits(satoshis, 'satoshi')


### PR DESCRIPTION
Currently we format numbers in en-US locale. 
russian rubbles in en-US shown as "RUB10.00"
canadian dollars shown as "CA10.00"

this breaks our formatting code and as a result we show "₽ RUB10.00" instead of "₽10.00"
this PR fixes it. Also it adds jest mocks for `rn-qr-generator`
