### PR TITLE
fix(settings): menu navigation

### DIFF
--- a/src/screens/Settings/BitcoinUnit/index.tsx
+++ b/src/screens/Settings/BitcoinUnit/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo, ReactElement, useMemo } from 'react';
+import { useNavigation } from '@react-navigation/native';
 
 import { IListData } from '../../../components/List';
 import SettingsView from '../SettingsView';
@@ -9,6 +10,7 @@ import { updateSettings } from '../../../store/actions/settings';
 import { UnitBitcoinIcon, UnitSatoshiIcon } from '../../../styles/components';
 
 const BitcoinUnitSettings = (): ReactElement => {
+	const navigation = useNavigation();
 	const selectedBitcoinUnit = useSelector(
 		(state: Store) => state.settings.bitcoinUnit,
 	);
@@ -36,7 +38,10 @@ const BitcoinUnitSettings = (): ReactElement => {
 					title: `${bitcoinUnit.label} ${bitcoinUnit.labelExample}`,
 					value: bitcoinUnit.unit === selectedBitcoinUnit,
 					type: 'button',
-					onPress: (): any => updateSettings({ bitcoinUnit: bitcoinUnit.unit }),
+					onPress: (): void => {
+						navigation.goBack();
+						updateSettings({ bitcoinUnit: bitcoinUnit.unit });
+					},
 					hide: false,
 					Icon: bitcoinUnit.Icon,
 				})),

--- a/src/screens/Settings/TransactionSpeed/index.tsx
+++ b/src/screens/Settings/TransactionSpeed/index.tsx
@@ -1,4 +1,5 @@
 import React, { memo, ReactElement, useMemo } from 'react';
+import { useNavigation } from '@react-navigation/native';
 
 import { IListData } from '../../../components/List';
 import SettingsView from '../SettingsView';
@@ -14,6 +15,7 @@ import {
 } from '../../../styles/components';
 
 const TransactionSpeedSettings = (): ReactElement => {
+	const navigation = useNavigation();
 	const selectedTransactionSpeed = useSelector(
 		(state: Store) => state.settings.transactionSpeed,
 	);
@@ -57,8 +59,10 @@ const TransactionSpeedSettings = (): ReactElement => {
 					title: `${txSpeed.label}`,
 					value: txSpeed.value === selectedTransactionSpeed,
 					type: 'button',
-					onPress: (): any =>
-						updateSettings({ transactionSpeed: txSpeed.value }),
+					onPress: (): void => {
+						navigation.goBack();
+						updateSettings({ transactionSpeed: txSpeed.value });
+					},
 					hide: false,
 					Icon: txSpeed.Icon,
 					iconColor: txSpeed.iconColor,


### PR DESCRIPTION
## Description

Go back to settings menu after selecting the `bitcoin unit` or `transaction speed`.

## Preview

https://user-images.githubusercontent.com/5798170/186116476-3ce7cec5-2622-42ff-941f-ecc5d2fb7240.mp4


