### PR TITLE
feat(lightning): Blocktank Purchase Testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@reduxjs/toolkit": "^1.8.4",
     "@sentry/react-native": "^4.2.2",
     "@shopify/react-native-skia": "^0.1.137",
-    "@synonymdev/blocktank-client": "^0.0.4",
+    "@synonymdev/blocktank-client": "0.0.47",
     "@synonymdev/react-native-ldk": "0.0.51",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",

--- a/src/screens/Blocktank/OrderService.tsx
+++ b/src/screens/Blocktank/OrderService.tsx
@@ -100,7 +100,7 @@ const Order = (props: Props): ReactElement => {
 
 		setIsProcessing(true);
 
-		const { tag, uri, k1, callback } = order.lnurl;
+		const { tag, uri, k1, callback } = order.lnurl_decoded;
 		const res = await claimChannel({ tag, uri, k1, callback, domain: '' });
 		if (res.isErr()) {
 			showErrorNotification({

--- a/src/store/actions/blocktank.ts
+++ b/src/store/actions/blocktank.ts
@@ -1,70 +1,229 @@
 import actions from './actions';
 import { err, ok, Result } from '@synonymdev/result';
-import { getDispatch } from '../helpers';
-import bt, {
+import { getDispatch, getStore } from '../helpers';
+import {
 	IBuyChannelRequest,
 	IBuyChannelResponse,
+	IFinalizeChannelResponse,
 } from '@synonymdev/blocktank-client';
+import * as blocktank from '../../utils/blocktank';
+import { setupOnChainTransaction, updateOnChainTransaction } from './wallet';
+import {
+	getBalance,
+	getSelectedNetwork,
+	getSelectedWallet,
+} from '../../utils/wallet';
+import { EAvailableNetworks, TAvailableNetworks } from '../../utils/networks';
+import { sleep } from '../../utils/helpers';
+import {
+	broadcastTransaction,
+	createTransaction,
+	updateFee,
+} from '../../utils/wallet/transactions';
+import { getNodeId } from '../../utils/lightning';
 
 const dispatch = getDispatch();
 
-export const refreshServiceList = (): Promise<Result<string>> => {
-	return new Promise(async (resolve) => {
-		try {
-			const res = await bt.getInfo();
-
-			dispatch({
-				type: actions.UPDATE_BLOCKTANK_SERVICE_LIST,
-				payload: res.services,
-			});
-
-			resolve(ok('Product list updated'));
-		} catch (error) {
-			resolve(err(error));
+/**
+ * Refreshes available services from BLocktank.
+ * @returns {Promise<Result<string>>}
+ */
+export const refreshServiceList = async (): Promise<Result<string>> => {
+	try {
+		const services = await blocktank.getAvailableServices();
+		if (services.isErr()) {
+			return err(services.error.message);
 		}
-	});
+
+		dispatch({
+			type: actions.UPDATE_BLOCKTANK_SERVICE_LIST,
+			payload: services.value,
+		});
+
+		return ok('Product list updated');
+	} catch (e) {
+		return err(e);
+	}
 };
 
-export const buyChannel = (
+/**
+ * Attempts to buy a channel from BLocktank and updates the saved order id information.
+ * @param {IBuyChannelRequest} req
+ * @returns {Promise<Result<IBuyChannelResponse>>}
+ */
+export const buyChannel = async (
 	req: IBuyChannelRequest,
 ): Promise<Result<IBuyChannelResponse>> => {
-	return new Promise(async (resolve) => {
-		try {
-			const res = await bt.buyChannel(req);
-
-			//Fetches and updates the user's order list
-			await refreshOrder(res.order_id);
-
-			resolve(ok(res));
-		} catch (error) {
-			return resolve(err(error));
+	try {
+		const res = await blocktank.buyChannel(req);
+		if (res.isErr()) {
+			return err(res.error.message);
 		}
-	});
+
+		if (res.value?.order_id) {
+			//Fetches and updates the user's order list
+			await refreshOrder(res.value.order_id);
+		} else {
+			return err('Unable to find order id.');
+		}
+
+		return ok(res.value);
+	} catch (error) {
+		return err(error);
+	}
 };
 
-export const refreshOrder = (orderId: string): Promise<Result<string>> => {
-	return new Promise(async (resolve) => {
-		try {
-			const res = await bt.getOrder(orderId);
-
-			dispatch({
-				type: actions.UPDATE_BLOCKTANK_ORDER,
-				payload: res,
-			});
-
-			resolve(ok('Order updated'));
-		} catch (error) {
-			return resolve(err(error));
+/**
+ * Refreshes a given orderId.
+ * @param {string} orderId
+ * @returns {Promise<Result<string>>}
+ */
+export const refreshOrder = async (
+	orderId: string,
+): Promise<Result<string>> => {
+	try {
+		const res = await blocktank.getOrder(orderId);
+		if (res.isErr()) {
+			return err(res.error.message);
 		}
-	});
+
+		dispatch({
+			type: actions.UPDATE_BLOCKTANK_ORDER,
+			payload: res.value,
+		});
+
+		return ok('Order updated');
+	} catch (error) {
+		return err(error);
+	}
 };
 
 /*
  * This resets the activity store to defaultActivityShape
+ * @returns {Result<string>}
  */
 export const resetBlocktankStore = (): Result<string> => {
 	dispatch({
 		type: actions.RESET_BLOCKTANK_STORE,
 	});
 	return ok('');
+};
+
+// TODO: This is for DEV testing purposes on regtest only. Remove upon release.
+/**
+ * Attempts to auto-buy a channel from Blocktank while on regtest.
+ * @param {TAvailableNetworks} [selectedNetwork]
+ * @param {string} [selectedWallet]
+ * @param {number} [inboundLiquidity]
+ * @param {number} [outboundLiquidity]
+ * @param {number} [channelExpiry]
+ * @returns {Promise<Result<IFinalizeChannelResponse>>}
+ */
+export const autoBuyChannel = async ({
+	selectedNetwork,
+	selectedWallet,
+	inboundLiquidity = 100000, //Inbound liquidity. How much will be on Blocktank.
+	outboundLiquidity = 0, //Outbound liquidity. How much will get pushed to the app
+	channelExpiry = 12,
+}: {
+	selectedNetwork?: TAvailableNetworks;
+	selectedWallet?: string;
+	inboundLiquidity?: number;
+	outboundLiquidity?: number;
+	channelExpiry?: number;
+}): Promise<Result<IFinalizeChannelResponse>> => {
+	if (!selectedNetwork) {
+		selectedNetwork = getSelectedNetwork();
+	}
+	if (!selectedWallet) {
+		selectedWallet = getSelectedWallet();
+	}
+	if (selectedNetwork !== EAvailableNetworks.bitcoinRegtest) {
+		return err('This method is only allowed on regtest.');
+	}
+	const nodeId = await getNodeId();
+	console.log('Nodeid', nodeId);
+	if (nodeId.isErr()) {
+		return err(nodeId.error.message);
+	}
+
+	const { satoshis } = getBalance({ onchain: true, selectedNetwork });
+	if (!satoshis || satoshis < 2000) {
+		return err('Please send at least 2000 satoshis to your wallet.');
+	}
+	const product_id = getStore().blocktank.serviceList[0].product_id;
+	console.log('Product ID:', product_id);
+	/*const remote_balance =
+		getStore().blocktank.serviceList[0].min_channel_size * 4;
+	const local_balance =
+		getStore().blocktank.serviceList[0].min_channel_size * 4;*/
+	const buyChannelData = {
+		product_id,
+		remote_balance: outboundLiquidity,
+		local_balance: inboundLiquidity,
+		channel_expiry: channelExpiry,
+	};
+	const buyChannelResponse = await buyChannel(buyChannelData);
+	console.log('buyChannelResponse:', buyChannelResponse);
+	if (buyChannelResponse.isErr()) {
+		return err(buyChannelResponse.error.message);
+	}
+	await setupOnChainTransaction({ rbf: false });
+	await updateOnChainTransaction({
+		transaction: {
+			outputs: [
+				{
+					value: buyChannelResponse.value.price,
+					index: 0,
+					address: buyChannelResponse.value.btc_address,
+				},
+			],
+		},
+	});
+	await updateFee({ satsPerByte: 4, selectedNetwork });
+	console.log('Creating Transaction...');
+	const rawTx = await createTransaction({ selectedNetwork });
+	console.log('rawTx:', rawTx);
+	if (rawTx.isErr()) {
+		return err(rawTx.error.message);
+	}
+	console.log('Broadcastion Transaction...');
+	const broadcastResponse = await broadcastTransaction({
+		rawTx: rawTx.value.hex,
+		selectedNetwork,
+	});
+	console.log('broadcastResponse: ', broadcastResponse);
+	if (broadcastResponse.isErr()) {
+		return err(broadcastResponse.error.message);
+	}
+	let paymentReceived = false;
+	let i = 1;
+	while (!paymentReceived && i <= 60) {
+		const orderStatus = await blocktank.getOrder(
+			buyChannelResponse.value.order_id,
+		);
+		console.log(`orderStatus check (${i}/60): `, orderStatus);
+		if (orderStatus.isErr()) {
+			return err(orderStatus.error.message);
+		}
+		if (orderStatus.value.state === 100) {
+			paymentReceived = true;
+		}
+		await sleep(5000);
+		i++;
+	}
+	if (!paymentReceived) {
+		console.log('Payment not received.');
+		return err('Payment not received.');
+	}
+	const params = {
+		order_id: buyChannelResponse.value.order_id,
+		node_uri: nodeId.value,
+		private: true,
+	};
+	console.log('finalizeChannelParams', params);
+
+	const finalizeResponse = await blocktank.finalizeChannel(params);
+	console.log('finalizeResponse', finalizeResponse);
+	return finalizeResponse;
 };

--- a/src/store/reducers/blocktank.ts
+++ b/src/store/reducers/blocktank.ts
@@ -12,7 +12,7 @@ const blocktank = (
 			return {
 				...state,
 				serviceList: action.payload,
-				serviceListLastUpdated: new Date(),
+				serviceListLastUpdated: new Date().getTime(),
 			};
 		case actions.UPDATE_BLOCKTANK_ORDER:
 			//Find existing order and update it if it exists, else append to list

--- a/src/store/types/blocktank.ts
+++ b/src/store/types/blocktank.ts
@@ -2,6 +2,6 @@ import { IGetOrderResponse, IService } from '@synonymdev/blocktank-client';
 
 export interface IBlocktank {
 	serviceList: IService[];
-	serviceListLastUpdated?: Date;
+	serviceListLastUpdated?: number;
 	orders: IGetOrderResponse[];
 }

--- a/src/utils/blocktank/index.ts
+++ b/src/utils/blocktank/index.ts
@@ -1,0 +1,126 @@
+import bt, {
+	IBuyChannelRequest,
+	IBuyChannelResponse,
+	IFinalizeChannelResponse,
+	IGetOrderResponse,
+	IService,
+} from '@synonymdev/blocktank-client';
+import { TAvailableNetworks } from '../networks';
+import { err, ok, Result } from '@synonymdev/result';
+import { IFinalizeChannelRequest } from '@synonymdev/blocktank-client/dist/types';
+
+/**
+ * Sets the selectedNetwork for Blocktank.
+ * @param {TAvailableNetworks} selectedNetwork
+ * @returns {void}
+ */
+export const setupBlocktank = (selectedNetwork: TAvailableNetworks): void => {
+	if (selectedNetwork === 'bitcoinTestnet') {
+		return;
+	} else if (selectedNetwork === 'bitcoinRegtest') {
+		bt.setNetwork('regtest');
+	} else {
+		bt.setNetwork('mainnet');
+	}
+};
+
+/**
+ * @returns {Promise<Result<IService[]>>}
+ */
+export const getAvailableServices = async (): Promise<Result<IService[]>> => {
+	try {
+		// Get all node info and available services
+		const info = await bt.getInfo();
+		if (
+			info?.services &&
+			Array.isArray(info.services) &&
+			info.services.length > 0
+		) {
+			return ok(info.services);
+		}
+		return err('Unable to provide services from Blocktank at this time.');
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * @param {IBuyChannelRequest} data
+ * @returns {Promise<Result<IBuyChannelResponse>>}
+ */
+export const buyChannel = async (
+	data: IBuyChannelRequest,
+): Promise<Result<IBuyChannelResponse>> => {
+	try {
+		const buyRes = await bt.buyChannel(data);
+		return ok(buyRes);
+	} catch (e) {
+		console.log(e);
+		return err(e);
+	}
+};
+
+/**
+ * @param {string} orderId
+ * @returns {Promise<Result<IGetOrderResponse>>}
+ */
+export const getOrder = async (
+	orderId: string,
+): Promise<Result<IGetOrderResponse>> => {
+	try {
+		const orderState = await bt.getOrder(orderId);
+		return ok(orderState);
+	} catch (e) {
+		return err(e);
+	}
+};
+
+/**
+ * @param {IFinalizeChannelRequest} params
+ * @returns {Promise<Result<IFinalizeChannelResponse>>}
+ */
+export const finalizeChannel = async (
+	params: IFinalizeChannelRequest,
+): Promise<Result<IFinalizeChannelResponse>> => {
+	try {
+		const finalizeChannelResponse = await bt.finalizeChannel(params);
+		if (finalizeChannelResponse) {
+			return ok(finalizeChannelResponse);
+		}
+		return err('Unable to finalize the Blocktank channel.');
+	} catch (e) {
+		console.log(e);
+		return err(e);
+	}
+};
+
+/**
+ * @param code
+ * @returns {string}
+ */
+export const getStateMessage = (code: number): string => {
+	switch (code) {
+		case 0:
+			return 'Awaiting payment';
+		case 100:
+			return 'Paid';
+		case 150:
+			return 'Payment refunded';
+		case 200:
+			return 'Queued for opening';
+		case 300:
+			return 'Channel opening';
+		case 350:
+			return 'Channel closing';
+		case 400:
+			return 'Given up';
+		case 410:
+			return 'Order expired';
+		case 450:
+			return 'Channel closed';
+		case 500:
+			return 'Channel open';
+	}
+
+	return `Unknown code: ${code}`;
+};

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -40,7 +40,7 @@ export const peers = [
 		pubKey:
 			'02f61609212fd33845cb9688a3f8fec2a9355992ed8e3578d06bcb4a9b0ed6d1b1',
 		address: '35.233.47.252',
-		port: 9735,
+		port: 9400,
 	},
 	{
 		pubKey:
@@ -131,6 +131,12 @@ export const setupLdk = async ({
 		if (lmStart.isErr()) {
 			return err(lmStart.error.message);
 		}
+
+		await ldk.updateFees({
+			highPriority: 1250,
+			normal: 1250,
+			background: 1250,
+		});
 
 		const nodeIdRes = await ldk.nodeId();
 		if (nodeIdRes.isErr()) {
@@ -467,9 +473,7 @@ export const createLightningInvoice = ldk.createPaymentRequest;
  * @param {string} invoice
  * @returns {Promise<Result<string>>}
  */
-export const payLightningInvoice = async (
-	invoice: string,
-): Promise<Result<string>> => {
+export const payLightningInvoice = async (invoice): Promise<Result<string>> => {
 	try {
 		return await ldk.pay({ paymentRequest: invoice });
 	} catch (e) {

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -15,6 +15,7 @@ import { connectToElectrum, subscribeToHeader } from '../wallet/electrum';
 import { updateOnchainFeeEstimates } from '../../store/actions/fees';
 import { setupLdk } from '../lightning';
 import { ICustomElectrumPeer } from '../../store/types/settings';
+import { setupBlocktank } from '../blocktank';
 
 /**
  * Checks if the specified wallet's phrase is saved to storage.
@@ -158,7 +159,10 @@ export const startWalletServices = async ({
 			setupTodos();
 
 			await updateExchangeRates();
-			await refreshServiceList();
+			if (lightning) {
+				await setupBlocktank(selectedNetwork);
+				await refreshServiceList();
+			}
 			//backupServiceStart().then();
 		});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,10 +2017,13 @@
     deepmerge "^4.2.2"
     svgo "^2.5.0"
 
-"@synonymdev/blocktank-client@^0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@synonymdev/blocktank-client/-/blocktank-client-0.0.4.tgz#9e33fd957ee855161f919840021bccad76057773"
-  integrity sha512-3gmqX3Dkg2aO7Pvb/PJ1oMNpGOpJy8cj2Vnj2827ePh5Uz8jhJOuYIK5U01R6Y68ZDZdjAf8317GpVIXM3Ux3A==
+"@synonymdev/blocktank-client@0.0.47":
+  version "0.0.47"
+  resolved "https://registry.yarnpkg.com/@synonymdev/blocktank-client/-/blocktank-client-0.0.47.tgz#8e72ffad096553e8eecce1903487ae2363afb192"
+  integrity sha512-G3L8wmuTW3VBW0DlyQtUJMBxIVO4xolEZgSf6uGaHOxoREtGvlT+IWVY7Hs1+Smm9DYZmcHqfDQ5zWykqrBXIQ==
+  dependencies:
+    cross-fetch "^3.1.4"
+    node-fetch "3.1.1"
 
 "@synonymdev/react-native-ldk@0.0.51":
   version "0.0.51"
@@ -4108,7 +4111,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.0.4:
+cross-fetch@^3.0.4, cross-fetch@^3.1.4:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -4216,6 +4219,11 @@ dargs@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
+
+data-uri-to-buffer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz#b5db46aea50f6176428ac05b73be39a57701a64b"
+  integrity sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==
 
 data-urls@^2.0.0:
   version "2.0.0"
@@ -5166,6 +5174,14 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fetch-blob@^3.1.2, fetch-blob@^3.1.3:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
+  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
+  dependencies:
+    node-domexception "^1.0.0"
+    web-streams-polyfill "^3.0.3"
+
 figures@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
@@ -5312,6 +5328,13 @@ form-data@^3.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+formdata-polyfill@^4.0.10:
+  version "4.0.10"
+  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
+  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
+  dependencies:
+    fetch-blob "^3.1.2"
 
 fragment-cache@^0.2.1:
   version "0.2.1"
@@ -8141,12 +8164,26 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
+node-domexception@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
+  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
+
 node-fetch@2.6.7, node-fetch@^2.0.0-alpha.8, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-fetch@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.1.1.tgz#d0d9607e455b3087e3092b821b5b1f1ebf4c2147"
+  integrity sha512-SMk+vKgU77PYotRdWzqZGTZeuFKlsJ0hu4KPviQKkfY+N3vn2MIzr0rvpnYpR8MtB3IEuhlEcuOLbGvLRlA+yg==
+  dependencies:
+    data-uri-to-buffer "^4.0.0"
+    fetch-blob "^3.1.3"
+    formdata-polyfill "^4.0.10"
 
 node-gyp-build@^4.2.0, node-gyp-build@^4.2.3, node-gyp-build@^4.3.0:
   version "4.4.0"
@@ -11292,6 +11329,11 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+web-streams-polyfill@^3.0.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
This PR:
- Adds a basic auto-buy button to the Channels component in order to test opening regtest channels with Blocktank.
  - Requires at least `2000` regtest sats for testing at the moment.
  - Zero-conf channels do not seem to work on regtest at the moment. Once the app pays for the channel and begins to check the order status, ensure that a block is mined to continue.
- Updates `@synonymdev/blocktank-client` to `0.0.47`.
- Separated blocktank methods between `actions/blocktank` & `utils/blocktank`.