### PR TITLE
feat(wallet): Generate New Addresses

### DIFF
--- a/src/screens/Wallets/Receive/index.tsx
+++ b/src/screens/Wallets/Receive/index.tsx
@@ -132,7 +132,6 @@ const Receive = ({ navigation }): ReactElement => {
 
 	useEffect(() => {
 		setInvoiceDetails().then();
-		getLightningInvoice().then();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [amount, message, selectedNetwork, selectedWallet]);
 

--- a/src/screens/Wallets/Receive/index.tsx
+++ b/src/screens/Wallets/Receive/index.tsx
@@ -6,9 +6,15 @@ import React, {
 	useEffect,
 	useRef,
 	MutableRefObject,
+	useCallback,
 } from 'react';
 import { useSelector } from 'react-redux';
-import { StyleSheet, useWindowDimensions, View } from 'react-native';
+import {
+	ActivityIndicator,
+	StyleSheet,
+	useWindowDimensions,
+	View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import QRCode from 'react-native-qrcode-svg';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
@@ -25,12 +31,14 @@ import {
 import Store from '../../../store/types';
 import { resetInvoice } from '../../../store/actions/receive';
 import { updateMetaIncTxTags } from '../../../store/actions/metadata';
-import { getReceiveAddress, getNewReceiveAddress } from '../../../utils/wallet';
+import { getReceiveAddress } from '../../../utils/wallet';
 import { getUnifiedUri } from '../../../utils/receive';
 import { createLightningInvoice } from '../../../utils/lightning';
 import NavigationHeader from '../../../components/NavigationHeader';
 import Button from '../../../components/Button';
 import Tooltip from '../../../components/Tooltip';
+import { generateNewReceiveAddress } from '../../../store/actions/wallet';
+import { showErrorNotification } from '../../../utils/notifications';
 
 const bitcoinLogo = require('../../../assets/bitcoin-logo.png');
 
@@ -40,9 +48,75 @@ const Receive = ({ navigation }): ReactElement => {
 	const { amount, message, tags } = useSelector(
 		(store: Store) => store.receive,
 	);
+	const receiveNavigationIsOpen = useSelector(
+		(store: Store) => store.user.viewController.receiveNavigation.isOpen,
+	);
+	const selectedWallet = useSelector(
+		(store: Store) => store.wallet.selectedWallet,
+	);
+	const selectedNetwork = useSelector(
+		(store: Store) => store.wallet.selectedNetwork,
+	);
+	const [loading, setLoading] = useState(true);
 	const [showCopy, setShowCopy] = useState(false);
+	const [receiveAddress, setReceiveAddress] = useState('');
 	const [lightningInvoice, setLightningInvoice] = useState('');
 	const qrRef = useRef<object>(null);
+
+	const getLightningInvoice = useCallback(async (): Promise<void> => {
+		if (!receiveNavigationIsOpen) {
+			return;
+		}
+		const response = await createLightningInvoice({
+			amountSats: amount,
+			description: message,
+			expiryDeltaSeconds: 180,
+		});
+
+		if (response.isErr()) {
+			showErrorNotification({
+				title: 'Unable to generate lightning invoice.',
+				message: response.error.message,
+			});
+			return;
+		}
+
+		if (response.isOk()) {
+			setLightningInvoice(response.value.to_str);
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [amount, message]);
+
+	const getAddress = useCallback(async (): Promise<void> => {
+		if (!receiveNavigationIsOpen) {
+			return;
+		}
+		if (amount > 0) {
+			console.info('getting fresh address');
+			const response = await generateNewReceiveAddress({
+				selectedNetwork,
+				selectedWallet,
+			});
+			if (response.isOk()) {
+				console.info(`generated fresh address ${response.value.address}`);
+				setReceiveAddress(response.value.address);
+			}
+		} else {
+			const response = getReceiveAddress({});
+			if (response.isOk()) {
+				console.info(`reusing address ${response.value}`);
+				setReceiveAddress(response.value);
+			}
+		}
+	}, [amount, receiveNavigationIsOpen, selectedNetwork, selectedWallet]);
+
+	const setInvoiceDetails = useCallback(async (): Promise<void> => {
+		if (!loading) {
+			setLoading(true);
+		}
+		await Promise.all([getLightningInvoice(), getAddress()]);
+		setLoading(false);
+	}, [getAddress, getLightningInvoice, loading]);
 
 	const buttonContainer = useMemo(
 		() => ({
@@ -56,40 +130,11 @@ const Receive = ({ navigation }): ReactElement => {
 		resetInvoice();
 	}, []);
 
-	const receiveAddress = useMemo(() => {
-		if (amount > 0) {
-			console.info('getting fresh address');
-			const response = getNewReceiveAddress({});
-
-			if (response.isOk()) {
-				return response.value;
-			}
-		} else {
-			const response = getReceiveAddress({});
-
-			if (response.isOk()) {
-				console.info(`reusing address ${response.value}`);
-				return response.value;
-			}
-		}
-	}, [amount]);
-
 	useEffect(() => {
-		const getLightningInvoice = async (): Promise<void> => {
-			const response = await createLightningInvoice({
-				amountSats: amount,
-				description: message,
-				expiryDeltaSeconds: 180,
-			});
-
-			// TODO: add error handling
-
-			if (response.isOk()) {
-				setLightningInvoice(response.value.to_str);
-			}
-		};
-		getLightningInvoice();
-	}, [amount, message]);
+		setInvoiceDetails().then();
+		getLightningInvoice().then();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [amount, message, selectedNetwork, selectedWallet]);
 
 	useEffect(() => {
 		if (tags.length !== 0 && receiveAddress) {
@@ -97,19 +142,15 @@ const Receive = ({ navigation }): ReactElement => {
 		}
 	}, [receiveAddress, lightningInvoice, tags]);
 
-	// Getting receive address shouldn't take long, so we don't show a spinner
-	// TODO: add error handling
-	if (!receiveAddress) {
-		return <></>;
-	}
-
-	const uri = getUnifiedUri({
-		bitcoin: receiveAddress,
-		amount,
-		label: message,
-		message,
-		lightning: lightningInvoice,
-	});
+	const uri = useMemo((): string => {
+		return getUnifiedUri({
+			bitcoin: receiveAddress,
+			amount,
+			label: message,
+			message,
+			lightning: lightningInvoice,
+		});
+	}, [amount, lightningInvoice, message, receiveAddress]);
 
 	const handleCopy = (): void => {
 		setShowCopy(() => true);
@@ -132,9 +173,18 @@ const Receive = ({ navigation }): ReactElement => {
 		}
 	};
 
-	const qrMaxHeight = dimensions.height / 2.5;
-	const qrMaxWidth = dimensions.width - 16 * 4;
-	const qrSize = Math.min(qrMaxWidth, qrMaxHeight);
+	const qrMaxHeight = useMemo(
+		() => dimensions.height / 2.5,
+		[dimensions?.height],
+	);
+	const qrMaxWidth = useMemo(
+		() => dimensions.width - 16 * 4,
+		[dimensions?.width],
+	);
+	const qrSize = useMemo(
+		() => Math.min(qrMaxWidth, qrMaxHeight),
+		[qrMaxHeight, qrMaxWidth],
+	);
 
 	return (
 		<ThemedView color="onSurface" style={styles.container}>
@@ -144,29 +194,37 @@ const Receive = ({ navigation }): ReactElement => {
 				size="sm"
 			/>
 			<View style={styles.qrCodeContainer}>
-				<TouchableOpacity
-					color="white"
-					activeOpacity={1}
-					onPress={handleCopy}
-					style={styles.qrCode}>
-					<QRCode
-						logo={bitcoinLogo}
-						logoSize={70}
-						logoBackgroundColor="white"
-						logoBorderRadius={100}
-						logoMargin={11}
-						value={uri}
-						size={qrSize}
-						getRef={(c): void => {
-							if (!c || !qrRef) {
-								return;
-							}
-							c.toDataURL(
-								(data) => ((qrRef as MutableRefObject<object>).current = data),
-							);
-						}}
-					/>
-				</TouchableOpacity>
+				{loading && (
+					<View style={[styles.loading, { height: qrSize, width: qrSize }]}>
+						<ActivityIndicator color="white" />
+					</View>
+				)}
+				{!loading && (
+					<TouchableOpacity
+						color="white"
+						activeOpacity={1}
+						onPress={handleCopy}
+						style={styles.qrCode}>
+						<QRCode
+							logo={bitcoinLogo}
+							logoSize={70}
+							logoBackgroundColor="white"
+							logoBorderRadius={100}
+							logoMargin={11}
+							value={uri}
+							size={qrSize}
+							getRef={(c): void => {
+								if (!c || !qrRef) {
+									return;
+								}
+								c.toDataURL(
+									(data) =>
+										((qrRef as MutableRefObject<object>).current = data),
+								);
+							}}
+						/>
+					</TouchableOpacity>
+				)}
 
 				{showCopy && (
 					<AnimatedView
@@ -232,6 +290,10 @@ const styles = StyleSheet.create({
 		flex: 1,
 		justifyContent: 'flex-end',
 		minHeight: 100,
+	},
+	loading: {
+		justifyContent: 'center',
+		alignItems: 'center',
 	},
 });
 

--- a/src/store/reducers/wallet.ts
+++ b/src/store/reducers/wallet.ts
@@ -47,7 +47,11 @@ const wallet = (state = { ...defaultWalletStoreShape }, action): IWallet => {
 							...state.wallets[selectedWallet].addressIndex,
 							[selectedNetwork]: {
 								...state.wallets[selectedWallet].addressIndex[selectedNetwork],
-								[addressType]: action.payload.addressIndex,
+								[addressType]:
+									action.payload?.addressIndex ??
+									state.wallets[selectedWallet].addressIndex[selectedNetwork][
+										addressType
+									],
 							},
 						},
 						changeAddressIndex: {
@@ -56,7 +60,37 @@ const wallet = (state = { ...defaultWalletStoreShape }, action): IWallet => {
 								...state.wallets[selectedWallet].changeAddressIndex[
 									selectedNetwork
 								],
-								[addressType]: action.payload.changeAddressIndex,
+								[addressType]:
+									action.payload?.changeAddressIndex ??
+									state.wallets[selectedWallet].changeAddressIndex[
+										selectedNetwork
+									][addressType],
+							},
+						},
+						lastUsedAddressIndex: {
+							...state.wallets[selectedWallet].lastUsedAddressIndex,
+							[selectedNetwork]: {
+								...state.wallets[selectedWallet].lastUsedAddressIndex[
+									selectedNetwork
+								],
+								[addressType]:
+									action.payload?.lastUsedAddressIndex ??
+									state.wallets[selectedWallet].lastUsedAddressIndex[
+										selectedNetwork
+									][addressType],
+							},
+						},
+						lastUsedChangeAddressIndex: {
+							...state.wallets[selectedWallet].lastUsedChangeAddressIndex,
+							[selectedNetwork]: {
+								...state.wallets[selectedWallet].lastUsedChangeAddressIndex[
+									selectedNetwork
+								],
+								[addressType]:
+									action.payload?.lastUsedChangeAddressIndex ??
+									state.wallets[selectedWallet].lastUsedChangeAddressIndex[
+										selectedNetwork
+									][addressType],
 							},
 						},
 					},

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -3,12 +3,12 @@ import {
 	IDefaultWalletShape,
 	EWallet,
 	IWallet,
-	IAddressContent,
 	IOnChainTransactionData,
 	defaultOnChainTransactionData,
 	IKeyDerivationPath,
 	IAddressType,
 	TAssetNetwork,
+	IAddress,
 } from '../types/wallet';
 import { IHeader } from '../../utils/types/electrum';
 
@@ -67,7 +67,7 @@ export const stringTypeItems: IWalletItem<string> = {
 };
 
 export const addressContent = {
-	index: 0,
+	index: -1,
 	path: '',
 	address: '',
 	scriptHash: '',
@@ -86,36 +86,13 @@ export type IAddressTypeContent<T> = {
 	[key: string]: T;
 };
 
-export const addressIndex: IWalletItem<IAddressTypeContent<IAddressContent>> = {
-	bitcoin: getAddressTypeContent({ ...addressContent }),
-	bitcoinTestnet: getAddressTypeContent({ ...addressContent }),
-	bitcoinRegtest: getAddressTypeContent({ ...addressContent }),
-	timestamp: null,
-};
-
-export const changeAddressIndex: IWalletItem<
-	IAddressTypeContent<IAddressContent>
-> = {
-	bitcoin: getAddressTypeContent(addressContent),
-	bitcoinTestnet: getAddressTypeContent(addressContent),
-	bitcoinRegtest: getAddressTypeContent(addressContent),
-	timestamp: null,
-};
-
-export const addresses: IWalletItem<IAddressTypeContent<IAddressContent>> = {
-	bitcoin: getAddressTypeContent({}),
-	bitcoinTestnet: getAddressTypeContent({}),
-	bitcoinRegtest: getAddressTypeContent({}),
-	timestamp: null,
-};
-
-export const changeAddresses: IWalletItem<
-	IAddressTypeContent<IAddressContent>
-> = {
-	bitcoin: getAddressTypeContent({}),
-	bitcoinTestnet: getAddressTypeContent({}),
-	bitcoinRegtest: getAddressTypeContent({}),
-	timestamp: null,
+export const getAddressTypeContentShape = (content): IWalletItem<IAddress> => {
+	return {
+		bitcoin: getAddressTypeContent(content),
+		bitcoinTestnet: getAddressTypeContent(content),
+		bitcoinRegtest: getAddressTypeContent(content),
+		timestamp: null,
+	};
 };
 
 export const defaultKeyDerivationPath: IKeyDerivationPath = {
@@ -136,10 +113,12 @@ export const defaultWalletShape: IDefaultWalletShape = {
 	id: '',
 	name: '',
 	type: 'default',
-	addresses,
-	addressIndex,
-	changeAddresses,
-	changeAddressIndex,
+	addresses: getAddressTypeContentShape({}),
+	addressIndex: getAddressTypeContentShape(addressContent),
+	lastUsedAddressIndex: getAddressTypeContentShape(addressContent),
+	changeAddresses: getAddressTypeContentShape({}),
+	changeAddressIndex: getAddressTypeContentShape(addressContent),
+	lastUsedChangeAddressIndex: getAddressTypeContentShape(addressContent),
 	utxos: arrayTypeItems,
 	boostedTransactions: arrayTypeItems,
 	transactions: objectTypeItems,

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -9,6 +9,7 @@ import {
 	IAddressType,
 	TAssetNetwork,
 	IAddress,
+	IAddressContent,
 } from '../types/wallet';
 import { IHeader } from '../../utils/types/electrum';
 
@@ -86,11 +87,22 @@ export type IAddressTypeContent<T> = {
 	[key: string]: T;
 };
 
-export const getAddressTypeContentShape = (content): IWalletItem<IAddress> => {
+export const getAddressIndexShape = (): IWalletItem<IAddress> => {
 	return {
-		bitcoin: getAddressTypeContent(content),
-		bitcoinTestnet: getAddressTypeContent(content),
-		bitcoinRegtest: getAddressTypeContent(content),
+		bitcoin: getAddressTypeContent(addressContent),
+		bitcoinTestnet: getAddressTypeContent(addressContent),
+		bitcoinRegtest: getAddressTypeContent(addressContent),
+		timestamp: null,
+	};
+};
+
+export const getAddressesShape = (): IWalletItem<
+	IAddressTypeContent<IAddressContent>
+> => {
+	return {
+		bitcoin: getAddressTypeContent({}),
+		bitcoinTestnet: getAddressTypeContent({}),
+		bitcoinRegtest: getAddressTypeContent({}),
 		timestamp: null,
 	};
 };
@@ -113,12 +125,12 @@ export const defaultWalletShape: IDefaultWalletShape = {
 	id: '',
 	name: '',
 	type: 'default',
-	addresses: getAddressTypeContentShape({}),
-	addressIndex: getAddressTypeContentShape(addressContent),
-	lastUsedAddressIndex: getAddressTypeContentShape(addressContent),
-	changeAddresses: getAddressTypeContentShape({}),
-	changeAddressIndex: getAddressTypeContentShape(addressContent),
-	lastUsedChangeAddressIndex: getAddressTypeContentShape(addressContent),
+	addresses: getAddressesShape(),
+	addressIndex: getAddressIndexShape(),
+	lastUsedAddressIndex: getAddressIndexShape(),
+	changeAddresses: getAddressesShape(),
+	changeAddressIndex: getAddressIndexShape(),
+	lastUsedChangeAddressIndex: getAddressIndexShape(),
 	utxos: arrayTypeItems,
 	boostedTransactions: arrayTypeItems,
 	transactions: objectTypeItems,

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -227,8 +227,10 @@ export interface IDefaultWalletShape {
 	seedHash?: string; // Help components/hooks recognize when a seed is set/updated for the same wallet id/name.
 	addresses: IWalletItem<IAddress> | IWalletItem<{}>;
 	addressIndex: IWalletItem<IAddressTypeContent<IAddressContent>>;
+	lastUsedAddressIndex: IWalletItem<IAddressTypeContent<IAddressContent>>;
 	changeAddresses: IWalletItem<IAddress> | IWalletItem<{}>;
 	changeAddressIndex: IWalletItem<IAddressTypeContent<IAddressContent>>;
+	lastUsedChangeAddressIndex: IWalletItem<IAddressTypeContent<IAddressContent>>;
 	utxos: IWalletItem<IUtxo[]>;
 	boostedTransactions: IWalletItem<string[]>;
 	transactions: IWalletItem<IFormattedTransaction> | IWalletItem<{}>;

--- a/src/utils/wallet/constants.ts
+++ b/src/utils/wallet/constants.ts
@@ -4,3 +4,6 @@ export const BITKIT_WALLET_SEED_HASH_PREFIX = Buffer.from(
 
 //How many addresses to generate when more are needed.
 export const GENERATE_ADDRESS_AMOUNT = 2;
+
+// TODO: Add this as a settings for users to adjust when needed.
+export const GAP_LIMIT = 20;

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -2571,20 +2571,21 @@ export const getGapLimit = ({
 			selectedWallet,
 			selectedNetwork,
 		});
-		const addressIndex = currentWallet.addressIndex[addressType].index;
+		const addressIndex =
+			currentWallet.addressIndex[selectedNetwork][addressType].index;
 		const lastUsedAddressIndex =
-			currentWallet.lastUsedAddressIndex[addressType].index;
-
+			currentWallet.lastUsedAddressIndex[selectedNetwork][addressType].index;
 		const changeAddressIndex =
-			currentWallet.changeAddressIndex[addressType].index;
+			currentWallet.changeAddressIndex[selectedNetwork][addressType].index;
 		const lastUsedChangeAddressIndex =
-			currentWallet.lastUsedChangeAddressIndex[addressType].index;
+			currentWallet.lastUsedChangeAddressIndex[selectedNetwork][addressType]
+				.index;
 		const addressDelta = Math.abs(
-			addressIndex - (lastUsedAddressIndex >= 0 ? lastUsedAddressIndex : 0),
+			addressIndex - (lastUsedAddressIndex > 0 ? lastUsedAddressIndex : 0),
 		);
 		const changeAddressDelta = Math.abs(
 			changeAddressIndex -
-				(lastUsedChangeAddressIndex >= 0 ? lastUsedChangeAddressIndex : 0),
+				(lastUsedChangeAddressIndex > 0 ? lastUsedChangeAddressIndex : 0),
 		);
 
 		return ok({ addressDelta, changeAddressDelta });

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -850,7 +850,9 @@ interface ITxHashes extends TTxResult {
 }
 interface IGetNextAvailableAddressResponse {
 	addressIndex: IAddressContent;
+	lastUsedAddressIndex: IAddressContent;
 	changeAddressIndex: IAddressContent;
+	lastUsedChangeAddressIndex: IAddressContent;
 }
 interface IGetNextAvailableAddress {
 	selectedWallet?: string | undefined;
@@ -909,8 +911,19 @@ export const getNextAvailableAddress = async ({
 			//The currently known/stored address index.
 			let addressIndex =
 				currentWallet.addressIndex[selectedNetwork][addressType];
+			let lastUsedAddressIndex =
+				currentWallet.lastUsedAddressIndex[selectedNetwork][addressType];
 			let changeAddressIndex =
 				currentWallet.changeAddressIndex[selectedNetwork][addressType];
+			let lastUsedChangeAddressIndex =
+				currentWallet.lastUsedChangeAddressIndex[selectedNetwork][addressType];
+
+			const seedResponse = await getSeed(selectedWallet);
+			if (seedResponse.isErr()) {
+				return err(seedResponse.error.message);
+			}
+			const seed = seedResponse.value;
+
 			if (!addressIndex?.address) {
 				const generatedAddresses = await generateAddresses({
 					selectedWallet,
@@ -919,6 +932,7 @@ export const getNextAvailableAddress = async ({
 					changeAddressAmount: 0,
 					keyDerivationPath,
 					addressType,
+					seed,
 				});
 				if (generatedAddresses.isErr()) {
 					return resolve(err(generatedAddresses.error));
@@ -935,6 +949,7 @@ export const getNextAvailableAddress = async ({
 					changeAddressAmount: GENERATE_ADDRESS_AMOUNT,
 					keyDerivationPath,
 					addressType,
+					seed,
 				});
 				if (generatedChangeAddresses.isErr()) {
 					return resolve(err(generatedChangeAddresses.error));
@@ -968,6 +983,7 @@ export const getNextAvailableAddress = async ({
 					selectedWallet,
 					keyDerivationPath,
 					addressType,
+					seed,
 				});
 				if (!newAddresses.isErr()) {
 					addresses = newAddresses.value.addresses;
@@ -991,6 +1007,7 @@ export const getNextAvailableAddress = async ({
 					selectedWallet,
 					keyDerivationPath,
 					addressType,
+					seed,
 				});
 				if (!newChangeAddresses.isErr()) {
 					changeAddresses = newChangeAddresses.value.changeAddresses;
@@ -1030,7 +1047,7 @@ export const getNextAvailableAddress = async ({
 				});
 
 				if (addressHistory.isErr()) {
-					return resolve(ok({ addressIndex, changeAddressIndex }));
+					return resolve(err(addressHistory.error.message));
 				}
 
 				const txHashes: IGetAddressHistoryResponse[] = addressHistory.value;
@@ -1065,16 +1082,22 @@ export const getNextAvailableAddress = async ({
 					return resolve(err(highestStoredIndex.error));
 				}
 
-				if (
-					highestUsedIndex.value.addressIndex.index <
-					highestStoredIndex.value.addressIndex.index
-				) {
+				const {
+					addressIndex: highestUsedAddressIndex,
+					changeAddressIndex: highestUsedChangeAddressIndex,
+				} = highestUsedIndex.value;
+				const {
+					addressIndex: highestStoredAddressIndex,
+					changeAddressIndex: highestStoredChangeAddressIndex,
+				} = highestStoredIndex.value;
+
+				if (highestUsedAddressIndex.index < highestStoredAddressIndex.index) {
 					foundLastUsedAddress = true;
 				}
 
 				if (
-					highestUsedIndex.value.changeAddressIndex.index <
-					highestStoredIndex.value.changeAddressIndex.index
+					highestUsedChangeAddressIndex.index <
+					highestStoredChangeAddressIndex.index
 				) {
 					foundLastUsedChangeAddress = true;
 				}
@@ -1083,37 +1106,54 @@ export const getNextAvailableAddress = async ({
 					//Increase index by one if the current index was found in a txHash or is greater than the previous index.
 					let newAddressIndex = addressIndex.index;
 					if (
-						highestUsedIndex.value.addressIndex.index > addressIndex.index ||
+						highestUsedAddressIndex.index > addressIndex.index ||
 						addressHasBeenUsed
 					) {
-						newAddressIndex = highestUsedIndex.value.addressIndex.index + 1;
+						const index = highestUsedAddressIndex.index;
+						if (
+							highestUsedAddressIndex &&
+							index >= 0 &&
+							highestUsedIndex.value.foundAddressIndex
+						) {
+							lastUsedAddressIndex = highestUsedAddressIndex;
+						}
+						newAddressIndex = index >= 0 ? index + 1 : index;
 					}
 
 					let newChangeAddressIndex = changeAddressIndex.index;
 					if (
-						highestUsedIndex.value.changeAddressIndex.index >
-							changeAddressIndex.index ||
+						highestUsedChangeAddressIndex.index > changeAddressIndex.index ||
 						changeAddressHasBeenUsed
 					) {
-						newChangeAddressIndex =
-							highestUsedIndex.value.changeAddressIndex.index + 1;
+						const index = highestUsedChangeAddressIndex.index;
+						if (
+							highestUsedChangeAddressIndex &&
+							index >= 0 &&
+							highestUsedIndex.value.foundChangeAddressIndex
+						) {
+							lastUsedChangeAddressIndex = highestUsedChangeAddressIndex;
+						}
+						newChangeAddressIndex = index >= 0 ? index + 1 : index;
 					}
 
 					//Filter for and return the new index.
-					const nextAvailableAddress = Object.values(allAddresses).filter(
+					const allAddressValues = Object.values(allAddresses);
+					const nextAvailableAddress = allAddressValues.filter(
 						({ index }) => index === newAddressIndex,
 					);
-					const nextAvailableChangeAddress = Object.values(
-						allChangeAddresses,
-					).filter(({ index }) => index === newChangeAddressIndex);
-
+					const nextAvailableChangeAddress = allAddressValues.filter(
+						({ index }) => index === newChangeAddressIndex,
+					);
 					return resolve(
 						ok({
 							addressIndex: nextAvailableAddress[0],
+							lastUsedAddressIndex,
 							changeAddressIndex: nextAvailableChangeAddress[0],
+							lastUsedChangeAddressIndex,
 						}),
 					);
 				}
+
 				//Create receiving addresses for the next round
 				if (!foundLastUsedAddress) {
 					const newAddresses = await addAddresses({
@@ -1125,6 +1165,7 @@ export const getNextAvailableAddress = async ({
 						selectedWallet,
 						keyDerivationPath,
 						addressType,
+						seed,
 					});
 					if (!newAddresses.isErr()) {
 						addresses = newAddresses.value.addresses || {};
@@ -1142,6 +1183,7 @@ export const getNextAvailableAddress = async ({
 						selectedWallet,
 						keyDerivationPath,
 						addressType,
+						seed,
 					});
 					if (!newChangeAddresses.isErr()) {
 						changeAddresses = newChangeAddresses.value.changeAddresses || {};
@@ -1978,10 +2020,13 @@ export const createDefaultWallet = async ({
 		const seed = await bip39.mnemonicToSeed(mnemonic, bip39Passphrase);
 
 		//Generate a set of addresses & changeAddresses for each network.
-		const addressesObj = { ...defaultWalletShape.addresses };
-		const changeAddressesObj = { ...defaultWalletShape.changeAddresses };
-		const addressIndex = { ...defaultWalletShape.addressIndex };
-		const changeAddressIndex = { ...defaultWalletShape.changeAddressIndex };
+		const addressesObj = defaultWalletShape.addresses;
+		const changeAddressesObj = defaultWalletShape.changeAddresses;
+		const addressIndex = defaultWalletShape.addressIndex;
+		const changeAddressIndex = defaultWalletShape.changeAddressIndex;
+		const lastUsedAddressIndex = defaultWalletShape.lastUsedAddressIndex;
+		const lastUsedChangeAddressIndex =
+			defaultWalletShape.lastUsedChangeAddressIndex;
 		await Promise.all([
 			setKeychainSlashtagsPrimaryKey(seed),
 			Object.values(addressTypes).map(async ({ type, path }) => {
@@ -2014,8 +2059,8 @@ export const createDefaultWallet = async ({
 				addressIndex[selectedNetwork][type] = Object.values(addresses)[0];
 				changeAddressIndex[selectedNetwork][type] =
 					Object.values(changeAddresses)[0];
-				addressesObj[selectedNetwork][type] = { ...addresses };
-				changeAddressesObj[selectedNetwork][type] = { ...changeAddresses };
+				addressesObj[selectedNetwork][type] = addresses;
+				changeAddressesObj[selectedNetwork][type] = changeAddresses;
 			}),
 		]);
 		const payload: IDefaultWallet = {
@@ -2031,6 +2076,8 @@ export const createDefaultWallet = async ({
 				changeAddressIndex,
 				addresses: { ...addressesObj },
 				changeAddresses: { ...changeAddressesObj },
+				lastUsedAddressIndex,
+				lastUsedChangeAddressIndex,
 				id: walletName,
 			},
 		};
@@ -2419,52 +2466,6 @@ export const getReceiveAddress = ({
 	}
 };
 
-// TODO: mock function, replace
-/**
- * Returns a new receive address for the given network and wallet.
- * @param {TAddressType} [addressType]
- * @param {TAvailableNetworks} [selectedNetwork]
- * @param {string} [selectedWallet]
- * @return {Result<string>}
- */
-export const getNewReceiveAddress = ({
-	addressType,
-	selectedNetwork,
-	selectedWallet,
-}: {
-	addressType?: TAddressType;
-	selectedNetwork?: TAvailableNetworks;
-	selectedWallet?: string;
-}): Result<string> => {
-	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!addressType) {
-			addressType = getSelectedAddressType({ selectedNetwork, selectedWallet });
-		}
-
-		// TODO:
-		// - generate new receiving address
-		// - if gap limit is reached, cycle through unused addresses again
-		// - test tags again when implemented
-
-		const wallet = getStore().wallet?.wallets[selectedWallet];
-		const addressIndex = wallet?.addressIndex[selectedNetwork];
-		const receiveAddress = addressIndex[addressType]?.address;
-		if (!receiveAddress) {
-			return err('No receive address available.');
-		}
-
-		return ok(receiveAddress);
-	} catch (e) {
-		return err(e);
-	}
-};
-
 /**
  * Determines the asset network based on the provided asset name.
  * @param {string} asset
@@ -2538,4 +2539,57 @@ export const getBalance = ({
 	}
 
 	return getDisplayValues({ satoshis: balance });
+};
+
+/**
+ * Returns the difference between the current address index and the last used address index.
+ * @param {string} [selectedWallet]
+ * @param {TAvailableNetworks} [selectedNetwork]
+ * @param {TAddressType} [addressType]
+ * @returns {Result<{ addressDelta: number; changeAddressDelta: number }>}
+ */
+export const getGapLimit = ({
+	selectedWallet,
+	selectedNetwork,
+	addressType,
+}: {
+	selectedWallet?: string;
+	selectedNetwork?: TAvailableNetworks;
+	addressType?: TAddressType;
+}): Result<{ addressDelta: number; changeAddressDelta: number }> => {
+	try {
+		if (!selectedNetwork) {
+			selectedNetwork = getSelectedNetwork();
+		}
+		if (!selectedWallet) {
+			selectedWallet = getSelectedWallet();
+		}
+		if (!addressType) {
+			addressType = getSelectedAddressType({ selectedNetwork, selectedWallet });
+		}
+		const { currentWallet } = getCurrentWallet({
+			selectedWallet,
+			selectedNetwork,
+		});
+		const addressIndex = currentWallet.addressIndex[addressType].index;
+		const lastUsedAddressIndex =
+			currentWallet.lastUsedAddressIndex[addressType].index;
+
+		const changeAddressIndex =
+			currentWallet.changeAddressIndex[addressType].index;
+		const lastUsedChangeAddressIndex =
+			currentWallet.lastUsedChangeAddressIndex[addressType].index;
+		const addressDelta = Math.abs(
+			addressIndex - (lastUsedAddressIndex >= 0 ? lastUsedAddressIndex : 0),
+		);
+		const changeAddressDelta = Math.abs(
+			changeAddressIndex -
+				(lastUsedChangeAddressIndex >= 0 ? lastUsedChangeAddressIndex : 0),
+		);
+
+		return ok({ addressDelta, changeAddressDelta });
+	} catch (e) {
+		console.log(e);
+		return err(e);
+	}
 };


### PR DESCRIPTION
This PR:
- Adds and implements the `generateNewReceiveAddress` method when creating Bitcoin invoices.
- Adds `lastUsedAddressIndex` & `lastUsedChangeAddressIndex` to wallet reducer to track the gap limit as new addresses are generated.
  - The gap limit is only enforced when attempting to generate new addresses and is not yet implemented when scanning addresses for balances.