### PR TITLE
fix: swipe-to-go-back gesture

### DIFF
--- a/src/navigation/root/RootNavigator.tsx
+++ b/src/navigation/root/RootNavigator.tsx
@@ -108,6 +108,10 @@ const RootNavigator = (): ReactElement => {
 		<NavigationContainer ref={navigationRef}>
 			<Stack.Navigator
 				screenOptions={navOptions}
+				// adding this because we are using @react-navigation/stack instead of
+				// @react-navigation/native-stack header
+				// https://github.com/react-navigation/react-navigation/issues/9015#issuecomment-828700138
+				detachInactiveScreens={false}
 				initialRouteName={initialRouteName}>
 				<Stack.Group screenOptions={navOptions}>
 					<Stack.Screen name="RootAuthCheck" component={AuthCheckComponent} />


### PR DESCRIPTION
I’ve found a reason why app hangs on iOS when you swipe-to-go-back.
It’s because of using @react-navigation/stack instead of @react-navigation/stack-native  for RootNavigation.
There is a [workaround](https://github.com/react-navigation/react-navigation/issues/9015#issuecomment-828700138) to fix that. The downside is it may lead to memory issues (unused screens will not be detached from view hierarchy)
I think we should try it to keep nice animations for Profile screen.

closes #289