### PR TITLE
fix(settings): reposition bitcoin network menu

### DIFF
--- a/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
+++ b/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
@@ -15,7 +15,7 @@ import {
 	getSelectedAddressType,
 } from '../../../utils/wallet';
 
-const BitcoinNetworkSelection = (): ReactElement => {
+const BitcoinNetworkSelection = ({ navigation }): ReactElement => {
 	const selectedNetwork = useSelector(
 		(state: Store) => state.wallet.selectedNetwork,
 	);
@@ -30,6 +30,7 @@ const BitcoinNetworkSelection = (): ReactElement => {
 						value: network === selectedNetwork,
 						type: 'button',
 						onPress: async (): Promise<void> => {
+							navigation.goBack();
 							// Switch to new network.
 							await updateWallet({ selectedNetwork: network });
 							// Grab the selectedWallet.
@@ -54,7 +55,7 @@ const BitcoinNetworkSelection = (): ReactElement => {
 				}),
 			},
 		],
-		[selectedNetwork],
+		[navigation, selectedNetwork],
 	);
 
 	return (

--- a/src/screens/Settings/DevSettings/index.tsx
+++ b/src/screens/Settings/DevSettings/index.tsx
@@ -19,7 +19,7 @@ import SettingsView from './../SettingsView';
 import { resetSlashtagsStore } from '../../../store/actions/slashtags';
 import { clearSlashtagsStorage } from '../../../components/SlashtagsProvider';
 
-const SettingsMenu = ({ navigation }): ReactElement => {
+const SettingsMenu = (): ReactElement => {
 	const [throwError, setThrowError] = useState(false);
 	const selectedWallet = useSelector(
 		(state: Store) => state.wallet.selectedWallet,
@@ -32,12 +32,6 @@ const SettingsMenu = ({ navigation }): ReactElement => {
 			{
 				title: 'Dev Settings',
 				data: [
-					{
-						title: 'Bitcoin Network Selection',
-						type: 'button',
-						onPress: (): void => navigation.navigate('BitcoinNetworkSelection'),
-						hide: false,
-					},
 					{
 						title: 'Reset Current Wallet Store',
 						type: 'button',

--- a/src/screens/Settings/Networks/index.tsx
+++ b/src/screens/Settings/Networks/index.tsx
@@ -1,12 +1,31 @@
 import React, { memo, ReactElement, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import { IListData } from '../../../components/List';
+import Store from '../../../store/types';
 import SettingsView from '../SettingsView';
 
 const NetworksSettings = ({ navigation }): ReactElement => {
+	const networkLabels = {
+		bitcoin: 'Mainnet',
+		bitcoinTestnet: 'Testnet',
+		bitcoinRegtest: 'Regtest',
+	};
+
+	const selectedNetwork = useSelector(
+		(state: Store) => state.wallet.selectedNetwork,
+	);
+
 	const SettingsListData: IListData[] = useMemo(
 		() => [
 			{
 				data: [
+					{
+						title: 'Bitcoin Network',
+						value: networkLabels[selectedNetwork],
+						type: 'button',
+						onPress: (): void => navigation.navigate('BitcoinNetworkSelection'),
+						hide: false,
+					},
 					{
 						title: 'Lightning Node Info',
 						type: 'button',
@@ -28,8 +47,7 @@ const NetworksSettings = ({ navigation }): ReactElement => {
 				],
 			},
 		],
-		//eslint-disable-next-line react-hooks/exhaustive-deps
-		[],
+		[navigation, networkLabels, selectedNetwork],
 	);
 
 	return (

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -23,7 +23,10 @@ export type TBalanceUnit = 'satoshi' | 'BTC' | 'fiat';
 
 export type TBitcoinAbbreviation = 'sats' | 'BTC';
 
-export type TBitcoinLabel = 'Bitcoin' | 'Bitcoin Testnet' | 'Bitcoin Regtest';
+export type TBitcoinLabel =
+	| 'Bitcoin Mainnet'
+	| 'Bitcoin Testnet'
+	| 'Bitcoin Regtest';
 
 export type TTicker = 'BTC' | 'tBTC';
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -112,16 +112,16 @@ export const getNetworkData = ({
 	try {
 		switch (selectedNetwork) {
 			case 'bitcoin':
-				return { abbreviation, label: 'Bitcoin', ticker: 'BTC' };
+				return { abbreviation, label: 'Bitcoin Mainnet', ticker: 'BTC' };
 			case 'bitcoinTestnet':
 				return { abbreviation, label: 'Bitcoin Testnet', ticker: 'tBTC' };
 			case 'bitcoinRegtest':
 				return { abbreviation, label: 'Bitcoin Regtest', ticker: 'tBTC' };
 			default:
-				return { abbreviation, label: 'Bitcoin', ticker: 'BTC' };
+				return { abbreviation, label: 'Bitcoin Mainnet', ticker: 'BTC' };
 		}
 	} catch {
-		return { abbreviation, label: 'Bitcoin', ticker: 'BTC' };
+		return { abbreviation, label: 'Bitcoin Mainnet', ticker: 'BTC' };
 	}
 };
 


### PR DESCRIPTION
## Description
Reposition `bitcoin network` menu to: `Settings` > `Networks`.

## Preview

https://user-images.githubusercontent.com/5798170/187325406-3e439324-7c54-4b34-9a11-d2af91099b52.mp4

