### PR TITLE
fix(ui): close bottomSheet on hardwareBackPress

### DIFF
--- a/src/hooks/bottomSheet.ts
+++ b/src/hooks/bottomSheet.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react';
+import { BackHandler, NativeEventSubscription } from 'react-native';
+import { toggleView } from '../store/actions/user';
+import { TViewController } from '../store/types/user';
+import { useAppSelector } from './redux';
+
+export const useBottomSheetBackPress = (viewController: TViewController) => {
+	const isBottomSheetOpen = useAppSelector(
+		(store) => store.user.viewController[viewController].isOpen,
+	);
+
+	const backHandlerSubscriptionRef = useRef<NativeEventSubscription | null>(
+		null,
+	);
+
+	useEffect(() => {
+		if (!isBottomSheetOpen) {
+			return;
+		}
+
+		backHandlerSubscriptionRef.current = BackHandler.addEventListener(
+			'hardwareBackPress',
+			() => {
+				toggleView({ view: viewController, data: { isOpen: false } });
+				return true;
+			},
+		);
+
+		return () => {
+			backHandlerSubscriptionRef.current?.remove();
+			backHandlerSubscriptionRef.current = null;
+		};
+	}, [isBottomSheetOpen]);
+};

--- a/src/screens/Activity/ActivityTagsPrompt.tsx
+++ b/src/screens/Activity/ActivityTagsPrompt.tsx
@@ -12,6 +12,7 @@ import Tag from '../../components/Tag';
 import useColors from '../../hooks/colors';
 import { addMetaTxTag } from '../../store/actions/metadata';
 import { sleep } from '../../utils/helpers';
+import { useBottomSheetBackPress } from '../../hooks/bottomSheet';
 
 const Form = ({ id }: { id: string }): ReactElement => {
 	const [text, setText] = useState('');
@@ -99,6 +100,9 @@ const ActivityTagsPrompt = (): ReactElement => {
 	const id = useSelector(
 		(store: Store) => store.user.viewController?.activityTagsPrompt?.id,
 	);
+
+	useBottomSheetBackPress('activityTagsPrompt');
+
 	const handleClose = (): void => {
 		toggleView({
 			view: 'activityTagsPrompt',

--- a/src/screens/Contacts/Contacts.tsx
+++ b/src/screens/Contacts/Contacts.tsx
@@ -23,6 +23,7 @@ import { useSelectedSlashtag } from '../../hooks/slashtags';
 import { handleSlashtagURL } from '../../utils/slashtags';
 import { IContactRecord } from '../../store/types/slashtags';
 import { useSlashtagsContacts } from '../../components/SlashtagContactsProvider';
+import { useBottomSheetBackPress } from '../../hooks/bottomSheet';
 
 export const Contacts = ({ navigation }): JSX.Element => {
 	const onboardedContacts = useSelector(
@@ -56,6 +57,8 @@ const ContactsScreen = ({ navigation }): JSX.Element => {
 	);
 
 	const { url: myProfileURL, profile } = useSelectedSlashtag();
+
+	useBottomSheetBackPress('addContactModal');
 
 	const sectionedContacts = useMemo(() => {
 		const sections: { [char: string]: IContactRecord[] } = {};

--- a/src/screens/Profile/ProfileEdit.tsx
+++ b/src/screens/Profile/ProfileEdit.tsx
@@ -20,6 +20,7 @@ import { useSelector } from 'react-redux';
 import { setOnboardingProfileStep } from '../../store/actions/slashtags';
 import Store from '../../store/types';
 import { BasicProfile } from '../../store/types/slashtags';
+import { useBottomSheetBackPress } from '../../hooks/bottomSheet';
 
 export const ProfileEdit = ({ navigation }): JSX.Element => {
 	const [fields, setFields] = useState<Omit<BasicProfile, 'links'>>({});
@@ -35,6 +36,8 @@ export const ProfileEdit = ({ navigation }): JSX.Element => {
 	const onboardedProfile =
 		useSelector((state: Store) => state.slashtags.onboardingProfileStep) ===
 		'Done';
+
+	useBottomSheetBackPress('profileAddLinkForm');
 
 	useEffect(() => {
 		const savedLinks = savedProfile?.links || [];

--- a/src/screens/Settings/Backup/BackupPrompt.tsx
+++ b/src/screens/Settings/Backup/BackupPrompt.tsx
@@ -10,6 +10,7 @@ import SafeAreaInsets from '../../../components/SafeAreaInsets';
 import Store from '../../../store/types';
 import { toggleView, ignoreBackup } from '../../../store/actions/user';
 import { useNoTransactions } from '../../../hooks/wallet';
+import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
 
 const ASK_INTERVAL = 60_000; // how long this propt will be hidden if user taps Later
 const CHECK_INTERVAL = 10_000; // how long user needs to stay on Wallets screen before he will see this prompt
@@ -27,6 +28,8 @@ const BackupPrompt = ({ screen }: { screen: string }): ReactElement => {
 		Object.values(state.user.viewController).some(({ isOpen }) => isOpen),
 	);
 	const empty = useNoTransactions();
+
+	useBottomSheetBackPress('backupPrompt');
 
 	const handleBackup = (): void => {
 		toggleView({

--- a/src/screens/Settings/Backup/ShowMnemonic.tsx
+++ b/src/screens/Settings/Backup/ShowMnemonic.tsx
@@ -12,6 +12,7 @@ import {
 import NavigationHeader from '../../../components/NavigationHeader';
 import Button from '../../../components/Button';
 import { getMnemonicPhrase } from '../../../utils/wallet';
+import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
 
 const Word = ({
 	number,
@@ -39,6 +40,8 @@ const ShowMnemonic = ({ navigation }): ReactElement => {
 		}),
 		[insets.bottom],
 	);
+
+	useBottomSheetBackPress('backupNavigation');
 
 	useEffect(() => {
 		getMnemonicPhrase().then((res) => {

--- a/src/screens/Settings/PIN/ChoosePIN.tsx
+++ b/src/screens/Settings/PIN/ChoosePIN.tsx
@@ -20,6 +20,7 @@ import { vibrate, setKeychainValue } from '../../../utils/helpers';
 import { removeTodo } from '../../../store/actions/todos';
 import { updateSettings } from '../../../store/actions/settings';
 import { todoPresets } from '../../../utils/todos';
+import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
 
 const ChoosePIN = ({ navigation, route }): ReactElement => {
 	const [pin, setPin] = useState<string>('');
@@ -42,6 +43,8 @@ const ChoosePIN = ({ navigation, route }): ReactElement => {
 
 	// reset pin on back
 	useFocusEffect(useCallback(() => setPin(''), []));
+
+	useBottomSheetBackPress('PINNavigation');
 
 	useEffect(() => {
 		const timer = setTimeout(async () => {

--- a/src/screens/Settings/PIN/PINPrompt.tsx
+++ b/src/screens/Settings/PIN/PINPrompt.tsx
@@ -6,9 +6,12 @@ import BottomSheetWrapper from '../../../components/BottomSheetWrapper';
 import Glow from '../../../components/Glow';
 import Button from '../../../components/Button';
 import { toggleView } from '../../../store/actions/user';
+import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
 
 const PINPrompt = (): ReactElement => {
 	const snapPoints = useMemo(() => [450], []);
+
+	useBottomSheetBackPress('PINPrompt');
 
 	const handlePIN = (): void => {
 		toggleView({

--- a/src/screens/Wallets/BoostPrompt.tsx
+++ b/src/screens/Wallets/BoostPrompt.tsx
@@ -23,6 +23,7 @@ import {
 } from '../../utils/notifications';
 import { btcToSats } from '../../utils/helpers';
 import { IActivityItem } from '../../store/types/activity';
+import { useBottomSheetBackPress } from '../../hooks/bottomSheet';
 
 const BoostForm = ({
 	activityItem,
@@ -176,11 +177,13 @@ const BoostForm = ({
 const BoostPrompt = (): ReactElement => {
 	const snapPoints = useMemo(() => [400], []);
 	const activityItem = useSelector(
-		(store: Store) => store.user.viewController?.boostPrompt?.activityItem,
+		(store: Store) => store.user.viewController.boostPrompt?.activityItem,
 	);
 	const isOpen = useSelector(
-		(store: Store) => store.user.viewController?.boostPrompt?.isOpen,
+		(store: Store) => store.user.viewController.boostPrompt?.isOpen,
 	);
+
+	useBottomSheetBackPress('boostPrompt');
 
 	const handleClose = (): void => {
 		toggleView({

--- a/src/screens/Wallets/NewTxPrompt.tsx
+++ b/src/screens/Wallets/NewTxPrompt.tsx
@@ -15,6 +15,7 @@ import AmountToggle from '../../components/AmountToggle';
 import SafeAreaInsets from '../../components/SafeAreaInsets';
 import Store from '../../store/types';
 import { toggleView } from '../../store/actions/user';
+import { useBottomSheetBackPress } from '../../hooks/bottomSheet';
 
 const NewTxPrompt = (): ReactElement => {
 	const snapPoints = useMemo(() => [600], []);
@@ -34,6 +35,8 @@ const NewTxPrompt = (): ReactElement => {
 		const network = store.wallet.selectedNetwork;
 		return store.wallet?.wallets[wallet]?.transactions[network]?.[txid];
 	});
+
+	useBottomSheetBackPress('newTxPrompt');
 
 	const handleClose = (): void => {
 		toggleView({

--- a/src/screens/Wallets/Receive/ReceiveNumberPad.tsx
+++ b/src/screens/Wallets/Receive/ReceiveNumberPad.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../../utils/exchange-rate';
 import { btcToSats } from '../../../utils/helpers';
 import { useExchangeRate } from '../../../hooks/displayValues';
+import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
 
 /**
  * Handles the number pad logic (add/remove/clear) for invoices.
@@ -28,6 +29,8 @@ const ReceiveNumberPad = (): ReactElement => {
 		(store: Store) => store.settings.selectedCurrency,
 	);
 	const exchangeRate = useExchangeRate(currency);
+
+	useBottomSheetBackPress('numberPadReceive');
 
 	// Add, shift and update the current invoice amount based on the provided fiat value or bitcoin unit.
 	const onPress = (key): void => {

--- a/src/screens/Wallets/Receive/index.tsx
+++ b/src/screens/Wallets/Receive/index.tsx
@@ -39,6 +39,7 @@ import Button from '../../../components/Button';
 import Tooltip from '../../../components/Tooltip';
 import { generateNewReceiveAddress } from '../../../store/actions/wallet';
 import { showErrorNotification } from '../../../utils/notifications';
+import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
 
 const bitcoinLogo = require('../../../assets/bitcoin-logo.png');
 
@@ -62,6 +63,8 @@ const Receive = ({ navigation }): ReactElement => {
 	const [receiveAddress, setReceiveAddress] = useState('');
 	const [lightningInvoice, setLightningInvoice] = useState('');
 	const qrRef = useRef<object>(null);
+
+	useBottomSheetBackPress('receiveNavigation');
 
 	const getLightningInvoice = useCallback(async (): Promise<void> => {
 		if (!receiveNavigationIsOpen) {

--- a/src/screens/Wallets/SendOnChainTransaction/FeeNumberPad.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/FeeNumberPad.tsx
@@ -9,6 +9,7 @@ import Store from '../../../store/types';
 import { useTransactionDetails } from '../../../hooks/transaction';
 import { updateFee } from '../../../utils/wallet/transactions';
 import { toggleView } from '../../../store/actions/user';
+import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
 
 /**
  * Handles the number pad logic (add/remove/clear) for on-chain fee.
@@ -23,6 +24,8 @@ const FeeNumberPad = (): ReactElement => {
 		(store: Store) => store.wallet.selectedNetwork,
 	);
 	const transaction = useTransactionDetails();
+
+	useBottomSheetBackPress('numberPadFee');
 
 	// Add, shift and update the current transaction amount based on the provided fiat value or bitcoin unit.
 	const onPress = (key): void => {

--- a/src/screens/Wallets/SendOnChainTransaction/OnChainNumberPad.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/OnChainNumberPad.tsx
@@ -17,6 +17,7 @@ import {
 } from '../../../utils/exchange-rate';
 import { btcToSats } from '../../../utils/helpers';
 import { useExchangeRate } from '../../../hooks/displayValues';
+import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
 
 /**
  * Handles the number pad logic (add/remove/clear) for on-chain transactions.
@@ -47,6 +48,8 @@ const OnChainNumberPad = (): ReactElement => {
 			store.wallet.wallets[selectedWallet]?.transaction[selectedNetwork] ||
 			defaultOnChainTransactionData,
 	);
+
+	useBottomSheetBackPress('numberPad');
 
 	/*
 	 * Retrieves total value of all outputs. Excludes change address.

--- a/src/screens/Wallets/SendOnChainTransaction/SendAssetPickerList.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/SendAssetPickerList.tsx
@@ -1,13 +1,17 @@
 import React, { memo, ReactElement, useCallback } from 'react';
 import AssetPickerList from '../../../components/AssetPickerList';
+import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
 
 const SendAssetPickerList = ({ navigation }): ReactElement => {
+	useBottomSheetBackPress('sendNavigation');
+
 	const onAssetPress = useCallback(
 		(asset) => {
 			navigation.navigate('AddressAndAmount', { asset });
 		},
 		[navigation],
 	);
+
 	return (
 		<AssetPickerList
 			headerTitle="Send Bitcoin"


### PR DESCRIPTION
closes https://github.com/synonymdev/bitkit/issues/292

This solution registers a hook on the first screen of the navigation stack of the respective BottomSheet, or if there is no nested stack directly on the BottomSheet. Then we close it via redux action and unsubscribe. Very manual but it should work.

### Changes
- added `hardwareBackPress` handler hook to close `BottomSheet`s

### Preview

https://user-images.githubusercontent.com/8538369/187926830-ce36c166-2833-4f0d-b820-e8279ce691aa.mov

