### PR TITLE
Pay Lightning Invoice

### DIFF
--- a/__tests__/transactions.ts
+++ b/__tests__/transactions.ts
@@ -1,7 +1,7 @@
 import {
 	createWallet,
 	setupOnChainTransaction,
-	updateOnChainTransaction,
+	updateBitcoinTransaction,
 	updateWallet,
 } from '../src/store/actions/wallet';
 import { getSelectedWallet } from '../src/utils/wallet';
@@ -28,7 +28,7 @@ describe('On chain transactions', () => {
 	it('Creates an on chain transaction from the transaction store', async () => {
 		const selectedWallet = getSelectedWallet();
 
-		await updateOnChainTransaction({
+		await updateBitcoinTransaction({
 			selectedNetwork,
 			selectedWallet,
 			transaction: {

--- a/src/hooks/transaction.ts
+++ b/src/hooks/transaction.ts
@@ -1,9 +1,9 @@
 import { useSelector } from 'react-redux';
 import Store from '../store/types';
 import {
-	defaultOnChainTransactionData,
+	defaultBitcoinTransactionData,
 	IAddressContent,
-	IOnChainTransactionData,
+	IBitcoinTransactionData,
 } from '../store/types/wallet';
 import { reduceValue } from '../utils/helpers';
 import { EFeeIds } from '../store/types/fees';
@@ -11,7 +11,7 @@ import { EFeeIds } from '../store/types/fees';
 /**
  * Current transaction object of the selectedWallet/Network.
  */
-export function useTransactionDetails(): IOnChainTransactionData {
+export function useTransactionDetails(): IBitcoinTransactionData {
 	const selectedWallet = useSelector(
 		(store: Store) => store.wallet.selectedWallet,
 	);
@@ -22,7 +22,7 @@ export function useTransactionDetails(): IOnChainTransactionData {
 	const transaction = useSelector(
 		(store: Store) =>
 			store.wallet.wallets[selectedWallet]?.transaction[selectedNetwork] ||
-			defaultOnChainTransactionData,
+			defaultBitcoinTransactionData,
 	);
 
 	return transaction;

--- a/src/hooks/wallet.ts
+++ b/src/hooks/wallet.ts
@@ -31,7 +31,17 @@ export function useBalance({
 		}
 
 		if (lightning) {
-			//TODO: Iterate over each lightning channel and acquire the total balance.
+			const channels =
+				store.lightning.nodes[selectedWallet]?.channels[selectedNetwork];
+			balance = Object.values(channels).reduce(
+				(previousValue, currentChannel) => {
+					if (currentChannel?.short_channel_id) {
+						return previousValue + currentChannel.balance_sat;
+					}
+					return previousValue;
+				},
+				balance,
+			);
 		}
 
 		return balance;

--- a/src/screens/Blocktank/Payment.tsx
+++ b/src/screens/Blocktank/Payment.tsx
@@ -12,7 +12,7 @@ import { Text } from '../../styles/components';
 import {
 	resetOnChainTransaction,
 	setupOnChainTransaction,
-	updateOnChainTransaction,
+	updateBitcoinTransaction,
 	updateWalletBalance,
 } from '../../store/actions/wallet';
 import { useBalance, useTransactionDetails } from '../../hooks/transaction';
@@ -60,7 +60,7 @@ const BlocktankPayment = (props: Props): ReactElement => {
 			selectedNetwork,
 		});
 
-		updateOnChainTransaction({
+		updateBitcoinTransaction({
 			selectedWallet,
 			selectedNetwork,
 			transaction: {

--- a/src/screens/Scanner/MainScanner.tsx
+++ b/src/screens/Scanner/MainScanner.tsx
@@ -1,8 +1,8 @@
-import React, { ReactElement } from 'react';
+import React, { memo, ReactElement } from 'react';
 import { StyleSheet } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { handleData, decodeQRData } from '../../utils/scanner';
+import { processInputData } from '../../utils/scanner';
 import Store from '../../store/types';
 import SafeAreaInsets from '../../components/SafeAreaInsets';
 import NavigationHeader from '../../components/NavigationHeader';
@@ -18,22 +18,19 @@ const ScannerScreen = ({ navigation }): ReactElement => {
 	);
 
 	const onRead = async (data): Promise<void> => {
-		const res = await decodeQRData(data, selectedNetwork);
-		if (res.isErr() || (res.isOk() && res.value.length === 0)) {
+		if (!data) {
 			showErrorNotification({
-				title: 'QR code',
-				message: 'Sorry. Bitkit can’t read this QR code.',
+				title: 'No Data Detected',
+				message: 'Sorry. Bitkit is not able to read this QR code.',
 			});
 			return;
 		}
-
 		navigation.pop();
-
-		await handleData({
-			qrData: res.value,
+		processInputData({
+			data,
 			selectedNetwork,
 			selectedWallet,
-		});
+		}).then();
 	};
 
 	return (
@@ -53,4 +50,4 @@ const styles = StyleSheet.create({
 	},
 });
 
-export default ScannerScreen;
+export default memo(ScannerScreen);

--- a/src/screens/Wallets/SendOnChainTransaction/OnChainNumberPad.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/OnChainNumberPad.tsx
@@ -10,7 +10,7 @@ import NumberPad from '../../../components/NumberPad';
 import BottomSheetWrapper from '../../../components/BottomSheetWrapper';
 import { toggleView } from '../../../store/actions/user';
 import Store from '../../../store/types';
-import { defaultOnChainTransactionData } from '../../../store/types/wallet';
+import { defaultBitcoinTransactionData } from '../../../store/types/wallet';
 import {
 	fiatToBitcoinUnit,
 	getDisplayValues,
@@ -46,7 +46,7 @@ const OnChainNumberPad = (): ReactElement => {
 	const transaction = useSelector(
 		(store: Store) =>
 			store.wallet.wallets[selectedWallet]?.transaction[selectedNetwork] ||
-			defaultOnChainTransactionData,
+			defaultBitcoinTransactionData,
 	);
 
 	useBottomSheetBackPress('numberPad');

--- a/src/screens/Wallets/SendOnChainTransaction/Scanner.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/Scanner.tsx
@@ -1,45 +1,35 @@
-import React, { ReactElement } from 'react';
+import React, { memo, ReactElement } from 'react';
 import { StyleSheet } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { decodeQRData, EQRDataType } from '../../../utils/scanner';
+import { processInputData } from '../../../utils/scanner';
 import Store from '../../../store/types';
 import NavigationHeader from '../../../components/NavigationHeader';
 import ScannerComponent from '../../Scanner/ScannerComponent';
 import { showErrorNotification } from '../../../utils/notifications';
 
-const ScannerScreen = ({ navigation, route }): ReactElement => {
-	const { onScan } = route.params;
-
+const ScannerScreen = ({ navigation }): ReactElement => {
 	const selectedNetwork = useSelector(
 		(state: Store) => state.wallet.selectedNetwork,
 	);
+	const selectedWallet = useSelector(
+		(state: Store) => state.wallet.selectedWallet,
+	);
 
 	const onRead = async (data): Promise<void> => {
-		const res = await decodeQRData(data, selectedNetwork);
-
-		if (res.isErr()) {
+		if (!data) {
 			showErrorNotification({
-				title: 'Sorry. Bitkit can’t read this QR code.',
-				message: res.error.message,
+				title: 'No Data Detected',
+				message: 'Sorry. Bitkit is not able to read this QR code.',
 			});
 			return;
 		}
-
-		const bitcoinAddress = res.value.find(
-			({ qrDataType }) => qrDataType === EQRDataType.bitcoinAddress,
-		);
-
-		if (!bitcoinAddress) {
-			showErrorNotification({
-				title: 'QR code',
-				message: "Sorry. We couldn't find Bitcoin address.",
-			});
-			return;
-		}
-
 		navigation.pop();
-		onScan(bitcoinAddress);
+		processInputData({
+			data,
+			selectedNetwork,
+			selectedWallet,
+		}).then();
 	};
 
 	return (
@@ -55,4 +45,4 @@ const styles = StyleSheet.create({
 	},
 });
 
-export default ScannerScreen;
+export default memo(ScannerScreen);

--- a/src/store/reducers/wallet.ts
+++ b/src/store/reducers/wallet.ts
@@ -1,6 +1,6 @@
 import actions from '../actions/actions';
 import {
-	defaultOnChainTransactionData,
+	defaultBitcoinTransactionData,
 	EOutput,
 	IWallet,
 } from '../types/wallet';
@@ -270,7 +270,7 @@ const wallet = (state = { ...defaultWalletStoreShape }, action): IWallet => {
 						transaction: {
 							...state.wallets[selectedWallet].transaction,
 							[selectedNetwork]: {
-								...defaultOnChainTransactionData,
+								...defaultBitcoinTransactionData,
 								outputs: [EOutput],
 							},
 						},

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -3,8 +3,8 @@ import {
 	IDefaultWalletShape,
 	EWallet,
 	IWallet,
-	IOnChainTransactionData,
-	defaultOnChainTransactionData,
+	IBitcoinTransactionData,
+	defaultBitcoinTransactionData,
 	IKeyDerivationPath,
 	IAddressType,
 	TAssetNetwork,
@@ -33,10 +33,10 @@ export const addressTypes: IAddressType = {
 	},
 };
 
-export const onChainTransaction: IWalletItem<IOnChainTransactionData> = {
-	bitcoin: defaultOnChainTransactionData,
-	bitcoinTestnet: defaultOnChainTransactionData,
-	bitcoinRegtest: defaultOnChainTransactionData,
+export const bitcoinTransaction: IWalletItem<IBitcoinTransactionData> = {
+	bitcoin: defaultBitcoinTransactionData,
+	bitcoinTestnet: defaultBitcoinTransactionData,
+	bitcoinRegtest: defaultBitcoinTransactionData,
 };
 
 export const numberTypeItems: IWalletItem<number> = {
@@ -158,7 +158,7 @@ export const defaultWalletShape: IDefaultWalletShape = {
 		bitcoinRegtest: EWallet.addressType,
 	},
 	rbfData: objectTypeItems,
-	transaction: onChainTransaction,
+	transaction: bitcoinTransaction,
 };
 
 export const defaultWalletStoreShape: IWallet = {

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -189,7 +189,7 @@ export interface IFormattedTransaction {
 	[key: string]: IFormattedTransactionContent;
 }
 
-export interface IOnChainTransactionData {
+export interface IBitcoinTransactionData {
 	outputs?: IOutput[];
 	inputs?: IUtxo[];
 	changeAddress?: string;
@@ -204,9 +204,10 @@ export interface IOnChainTransactionData {
 	minFee?: number; // (sats) Used for RBF/CPFP transactions where the fee needs to be greater than the original.
 	max?: boolean; // If the user intends to send the max amount.
 	tags?: string[];
+	lightningInvoice?: string;
 }
 
-export const defaultOnChainTransactionData: IOnChainTransactionData = {
+export const defaultBitcoinTransactionData: IBitcoinTransactionData = {
 	outputs: [],
 	inputs: [],
 	changeAddress: '',
@@ -221,6 +222,7 @@ export const defaultOnChainTransactionData: IOnChainTransactionData = {
 	minFee: 1,
 	max: false,
 	tags: [],
+	lightningInvoice: '',
 };
 
 export interface IDefaultWalletShape {
@@ -250,7 +252,7 @@ export interface IDefaultWalletShape {
 		bitcoinRegtest: TAddressType;
 	};
 	rbfData: IWalletItem<object>;
-	transaction: IWalletItem<IOnChainTransactionData>;
+	transaction: IWalletItem<IBitcoinTransactionData>;
 }
 
 export interface IDefaultWallet {

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -14,7 +14,7 @@ import {
 	IDefaultWalletShape,
 	IFormattedTransaction,
 	IKeyDerivationPath,
-	IOnChainTransactionData,
+	IBitcoinTransactionData,
 	IOutput,
 	IUtxo,
 	TAddressType,
@@ -1903,12 +1903,12 @@ export const getRbfData = async ({
 };
 
 /**
- * Converts IRbfData to IOnChainTransactionData.
+ * Converts IRbfData to IBitcoinTransactionData.
  * @param data
  */
 export const formatRbfData = async (
 	data: IRbfData,
-): Promise<IOnChainTransactionData> => {
+): Promise<IBitcoinTransactionData> => {
 	const { selectedWallet, inputs, outputs, fee, selectedNetwork, message } =
 		data;
 
@@ -2535,7 +2535,17 @@ export const getBalance = ({
 	}
 
 	if (lightning) {
-		// TODO: Get LDK channel balance.
+		const channels =
+			getStore().lightning.nodes[selectedWallet]?.channels[selectedNetwork];
+		balance = Object.values(channels).reduce(
+			(previousValue, currentChannel) => {
+				if (currentChannel?.short_channel_id) {
+					return previousValue + currentChannel.balance_sat;
+				}
+				return previousValue;
+			},
+			balance,
+		);
 	}
 
 	return getDisplayValues({ satoshis: balance });

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -4,9 +4,9 @@ import { validateAddress } from '../scanner';
 import { EAvailableNetworks, networks, TAvailableNetworks } from '../networks';
 import { btcToSats, getKeychainValue, reduceValue } from '../helpers';
 import {
-	defaultOnChainTransactionData,
+	defaultBitcoinTransactionData,
 	ETransactionDefaults,
-	IOnChainTransactionData,
+	IBitcoinTransactionData,
 	IOutput,
 	IUtxo,
 	TAddressType,
@@ -36,7 +36,7 @@ import {
 	addBoostedTransaction,
 	deleteOnChainTransactionById,
 	setupOnChainTransaction,
-	updateOnChainTransaction,
+	updateBitcoinTransaction,
 } from '../../store/actions/wallet';
 import { TCoinSelectPreference } from '../../store/types/settings';
 import { showErrorNotification } from '../notifications';
@@ -324,7 +324,7 @@ export const getTotalFee = ({
 	selectedNetwork?: undefined | TAvailableNetworks;
 	message?: string;
 	fundingLightning?: boolean | undefined;
-	transaction?: IOnChainTransactionData | undefined;
+	transaction?: IBitcoinTransactionData;
 }): number => {
 	const fallBackFee = ETransactionDefaults.recommendedBaseFee;
 	try {
@@ -381,7 +381,7 @@ export const getTotalFee = ({
 export interface ICreateTransaction {
 	selectedWallet?: string;
 	selectedNetwork?: TAvailableNetworks;
-	transactionData?: IOnChainTransactionData;
+	transactionData?: IBitcoinTransactionData;
 }
 
 export interface ICreatePsbt {
@@ -441,7 +441,7 @@ const createPsbtFromTransactionData = async ({
 }: {
 	selectedWallet: string;
 	selectedNetwork: TAvailableNetworks;
-	transactionData: IOnChainTransactionData;
+	transactionData: IBitcoinTransactionData;
 }): Promise<Result<Psbt>> => {
 	const {
 		inputs = [],
@@ -633,7 +633,7 @@ export const signPsbt = ({
  * Creates complete signed transaction using the transaction data store
  * @param selectedWallet
  * @param selectedNetwork
- * @param {IOnChainTransactionData} [transactionData]
+ * @param {IBitcoinTransactionData} [transactionData]
  * @returns {Promise<Result<{id: string, hex: string}>>}
  */
 export const createTransaction = ({
@@ -729,7 +729,7 @@ export const getOnchainTransactionData = ({
 }: {
 	selectedWallet: string | undefined;
 	selectedNetwork: TAvailableNetworks | undefined;
-}): Result<IOnChainTransactionData> => {
+}): Result<IBitcoinTransactionData> => {
 	try {
 		if (!selectedWallet) {
 			selectedWallet = getSelectedWallet();
@@ -1013,7 +1013,7 @@ export const getTransactionInputs = ({
  * @param {EFeeIds} [selectedFeeId]
  * @param {string} [selectedWallet]
  * @param {TAvailableNetworks} [selectedNetwork]
- * @param {IOnChainTransactionData} [transaction]
+ * @param {IBitcoinTransactionData} [transaction]
  */
 export const updateFee = ({
 	satsPerByte = 1,
@@ -1026,7 +1026,7 @@ export const updateFee = ({
 	selectedFeeId?: EFeeIds;
 	selectedWallet?: string;
 	selectedNetwork?: TAvailableNetworks;
-	transaction?: IOnChainTransactionData;
+	transaction?: IBitcoinTransactionData;
 }): Result<string> => {
 	// if (!satsPerByte || satsPerByte < 1) {
 	if (satsPerByte === undefined) {
@@ -1047,7 +1047,7 @@ export const updateFee = ({
 			return err(transactionDataResponse.error.message);
 		}
 		transaction =
-			transactionDataResponse?.value ?? defaultOnChainTransactionData;
+			transactionDataResponse?.value ?? defaultBitcoinTransactionData;
 	}
 	const inputTotal = getTransactionInputValue({
 		selectedNetwork,
@@ -1067,13 +1067,13 @@ export const updateFee = ({
 		selectedNetwork,
 	});
 	const newTotalAmount = Number(totalTransactionValue) + Number(newFee);
-	const _transaction: IOnChainTransactionData = {
+	const _transaction: IBitcoinTransactionData = {
 		satsPerByte,
 		fee: newFee,
 		selectedFeeId,
 	};
 	if (newTotalAmount <= inputTotal) {
-		updateOnChainTransaction({
+		updateBitcoinTransaction({
 			selectedNetwork,
 			selectedWallet,
 			transaction: _transaction,
@@ -1277,11 +1277,11 @@ export const autoCoinSelect = async ({
 
 /**
  * Used to validate transaction form data.
- * @param {IOnChainTransactionData} transaction
+ * @param {IBitcoinTransactionData} transaction
  * @return {Result<string>}
  */
 export const validateTransaction = (
-	transaction: IOnChainTransactionData,
+	transaction: IBitcoinTransactionData,
 ): Result<string> => {
 	try {
 		if (!transaction) {
@@ -1427,7 +1427,7 @@ export const sendMax = ({
 	index = 0,
 }: {
 	address?: string;
-	transaction?: IOnChainTransactionData;
+	transaction?: IBitcoinTransactionData;
 	selectedNetwork?: TAvailableNetworks;
 	selectedWallet?: string;
 	index?: number;
@@ -1480,19 +1480,19 @@ export const sendMax = ({
 			const totalNewAmount = totalTransactionValue + newFee;
 
 			if (totalNewAmount <= inputTotal) {
-				const _transaction: IOnChainTransactionData = {
+				const _transaction: IBitcoinTransactionData = {
 					fee: newFee,
 					outputs: [{ address, value: inputTotal - newFee, index }],
 					max: !max,
 				};
-				updateOnChainTransaction({
+				updateBitcoinTransaction({
 					selectedWallet,
 					selectedNetwork,
 					transaction: _transaction,
 				}).then();
 			}
 		} else {
-			updateOnChainTransaction({
+			updateBitcoinTransaction({
 				selectedWallet,
 				selectedNetwork,
 				transaction: { max: !max },
@@ -1506,7 +1506,7 @@ export const sendMax = ({
 
 /**
  * Increases the fee by a given sat per byte.
- * @param {IOnChainTransactionData} [transaction]
+ * @param {IBitcoinTransactionData} [transaction]
  * @param {TAvailableNetworks} [selectedNetwork]
  * @param {string} [selectedWallet]
  * @param {number} [index]
@@ -1519,7 +1519,7 @@ export const adjustFee = ({
 	index = 0,
 	adjustBy = 1,
 }: {
-	transaction?: IOnChainTransactionData;
+	transaction?: IBitcoinTransactionData;
 	selectedNetwork?: TAvailableNetworks;
 	selectedWallet?: string;
 	index?: number;
@@ -1574,14 +1574,14 @@ export const adjustFee = ({
 					'Unable to increase the fee any further. Otherwise, it will exceed half the current balance.',
 				);
 			}
-			const _transaction: IOnChainTransactionData = {
+			const _transaction: IBitcoinTransactionData = {
 				satsPerByte: newSatsPerByte,
 				selectedFeeId: EFeeIds.custom,
 				fee: newFee,
 			};
 			//Update the tx value with the new fee to continue sending the max amount.
 			_transaction.outputs = [{ address, value: inputTotal - newFee, index }];
-			updateOnChainTransaction({
+			updateBitcoinTransaction({
 				selectedNetwork,
 				selectedWallet,
 				transaction: _transaction,
@@ -1607,7 +1607,7 @@ export const adjustFee = ({
  * Updates the amount to send for the currently selected output.
  * @param {string} amount
  * @param {number} [index]
- * @param {IOnChainTransactionData} [transaction]
+ * @param {IBitcoinTransactionData} [transaction]
  * @param {TAvailableNetworks} [selectedNetwork]
  * @param {string} [selectedWallet]
  * @param {boolean} [max]
@@ -1622,7 +1622,7 @@ export const updateAmount = async ({
 }: {
 	amount: string;
 	index?: number;
-	transaction?: IOnChainTransactionData;
+	transaction?: IBitcoinTransactionData;
 	selectedNetwork?: TAvailableNetworks;
 	selectedWallet?: string;
 	max?: boolean;
@@ -1693,7 +1693,7 @@ export const updateAmount = async ({
 	}
 
 	const output = { address, value: newAmount, index };
-	await updateOnChainTransaction({
+	await updateBitcoinTransaction({
 		selectedWallet,
 		selectedNetwork,
 		transaction: {
@@ -1707,7 +1707,7 @@ export const updateAmount = async ({
 /**
  * Updates the OP_RETURN message.
  * @param {string} message
- * @param {IOnChainTransactionData} [transaction]
+ * @param {IBitcoinTransactionData} [transaction]
  * @param {number} [index]
  * @param {string} [selectedWallet]
  * @param {TAvailableNetworks} [selectedNetwork]
@@ -1720,7 +1720,7 @@ export const updateMessage = async ({
 	selectedNetwork,
 }: {
 	message: string;
-	transaction?: IOnChainTransactionData;
+	transaction?: IBitcoinTransactionData;
 	index?: number;
 	selectedWallet?: string;
 	selectedNetwork?: TAvailableNetworks;
@@ -1762,33 +1762,33 @@ export const updateMessage = async ({
 	if (outputs?.length > index) {
 		address = outputs[index].address ?? '';
 	}
-	const _transaction: IOnChainTransactionData = {
+	const _transaction: IBitcoinTransactionData = {
 		message,
 		fee: newFee,
 	};
 	if (max) {
 		_transaction.outputs = [{ address, value: inputTotal - newFee, index }];
 		//Update the tx value with the new fee to continue sending the max amount.
-		updateOnChainTransaction({
+		updateBitcoinTransaction({
 			selectedNetwork,
 			selectedWallet,
 			transaction: _transaction,
-		});
+		}).then();
 		return ok('Successfully updated the message.');
 	}
 	if (totalNewAmount <= inputTotal) {
-		await updateOnChainTransaction({
+		updateBitcoinTransaction({
 			selectedNetwork,
 			selectedWallet,
 			transaction: _transaction,
-		});
+		}).then();
 	}
 	return ok('Successfully updated the message.');
 };
 
 /**
  * Runs & Applies the autoCoinSelect method to the current transaction.
- * @param {IOnChainTransactionData} [transaction]
+ * @param {IBitcoinTransactionData} [transaction]
  * @param {string} [selectedWallet]
  * @param {TAvailableNetworks} [selectedNetwork]
  */
@@ -1799,7 +1799,7 @@ const runCoinSelect = async ({
 	selectedWallet,
 	selectedNetwork,
 }: {
-	transaction?: IOnChainTransactionData;
+	transaction?: IBitcoinTransactionData;
 	selectedNetwork?: TAvailableNetworks;
 	selectedWallet?: string;
 }): Promise<Result<string>> => {
@@ -1844,11 +1844,11 @@ const runCoinSelect = async ({
 		if (
 			transaction?.inputs?.length !== autoCoinSelectResponse.value.inputs.length
 		) {
-			const updatedTx: IOnChainTransactionData = {
+			const updatedTx: IBitcoinTransactionData = {
 				fee: autoCoinSelectResponse.value.fee,
 				inputs: autoCoinSelectResponse.value.inputs,
 			};
-			updateOnChainTransaction({
+			updateBitcoinTransaction({
 				selectedWallet,
 				selectedNetwork,
 				transaction: updatedTx,
@@ -1955,7 +1955,7 @@ export const setupRbf = async ({
 	txid: string;
 	selectedWallet?: string;
 	selectedNetwork?: TAvailableNetworks;
-}): Promise<Result<IOnChainTransactionData>> => {
+}): Promise<Result<IBitcoinTransactionData>> => {
 	try {
 		if (!txid) {
 			return err('No txid provided.');
@@ -2007,7 +2007,7 @@ export const setupRbf = async ({
 			rbf: true,
 		};
 
-		await updateOnChainTransaction({
+		await updateBitcoinTransaction({
 			selectedWallet,
 			selectedNetwork,
 			transaction: newTransaction,


### PR DESCRIPTION
This PR:
- Updates the scanning & clipboard paste logic to handle and prioritize lightning invoices when able.
  - All scanned and most clipboard paste data can now be pushed through the `processInputData` method.
  - The new scanner components have been wired up accordingly.
  - This method will parse the information as before, but in the event it is a lightning or on-chain payment request it will ensure we have lighting-channels, enough funds to pay the lightning invoice and that the invoice is not expired. If not, it will attempt to determine if we have enough funds to pay the on-chain address. If not, it will simply forward the Bitcoin address to the send form.
- Adds `lightningInvoice` to `defaultBitcoinTransactionData`.
- Renamed several "OnChain" names and types to "Bitcoin".