### PR TITLE
feat: iOS only portrait mode

### DIFF
--- a/ios/bitkit/Info.plist
+++ b/ios/bitkit/Info.plist
@@ -77,8 +77,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>


### PR DESCRIPTION
Allow only Portrait mode on iOS.
Looks like for android it is already enabled.