### PR TITLE
fix(wallet): Improve Bitcoin Network Toggling

### DIFF
--- a/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
+++ b/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
@@ -30,7 +30,6 @@ const BitcoinNetworkSelection = ({ navigation }): ReactElement => {
 						value: network === selectedNetwork,
 						type: 'button',
 						onPress: async (): Promise<void> => {
-							navigation.goBack();
 							// Switch to new network.
 							await updateWallet({ selectedNetwork: network });
 							// Grab the selectedWallet.

--- a/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
+++ b/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
@@ -30,6 +30,7 @@ const BitcoinNetworkSelection = ({ navigation }): ReactElement => {
 						value: network === selectedNetwork,
 						type: 'button',
 						onPress: async (): Promise<void> => {
+							navigation.goBack();
 							// Switch to new network.
 							await updateWallet({ selectedNetwork: network });
 							// Grab the selectedWallet.

--- a/src/screens/Wallets/Receive/index.tsx
+++ b/src/screens/Wallets/Receive/index.tsx
@@ -114,7 +114,10 @@ const Receive = ({ navigation }): ReactElement => {
 				setReceiveAddress(response.value.address);
 			}
 		} else {
-			const response = getReceiveAddress({});
+			const response = getReceiveAddress({
+				selectedNetwork,
+				selectedWallet,
+			});
 			if (response.isOk()) {
 				console.info(`reusing address ${response.value}`);
 				setReceiveAddress(response.value);

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -1,5 +1,106 @@
 import { ISettings } from '../types/settings';
 
+//TODO: Remove the public Electrum servers below once we spin up our own.
+const customElectrumPeers = {
+	bitcoin: [
+		{
+			host: 'kirsche.emzy.de',
+			ssl: 50002,
+			tcp: 50001,
+			protocol: 'ssl',
+		},
+		{
+			host: 'electrum.emzy.de',
+			ssl: 50002,
+			tcp: 50001,
+			protocol: 'ssl',
+		},
+		{
+			host: 'de.poiuty',
+			ssl: 50002,
+			tcp: 50001,
+			protocol: 'ssl',
+		},
+		{
+			host: 'electrum.coinext.com.br',
+			ssl: 50002,
+			tcp: 50001,
+			protocol: 'ssl',
+		},
+		{
+			host: 'fortress.qtornado.com',
+			ssl: 443,
+			tcp: 442,
+			protocol: 'ssl',
+		},
+		{
+			host: '157.245.172.236',
+			ssl: 50002,
+			tcp: 50001,
+			protocol: 'ssl',
+		},
+		{
+			host: 'electrumx.alexridevski.net',
+			ssl: 50002,
+			tcp: 50001,
+			protocol: 'ssl',
+		},
+		{
+			host: 'electrumx.info',
+			ssl: 50002,
+			tcp: 50001,
+			protocol: 'ssl',
+		},
+		{
+			host: '178.62.80.20',
+			ssl: 50002,
+			tcp: 50001,
+			protocol: 'ssl',
+		},
+		{
+			host: 'node1.btccuracao.com',
+			ssl: 50002,
+			tcp: 50001,
+			protocol: 'ssl',
+		},
+	],
+	bitcoinTestnet: [
+		{
+			host: 'testnet.hsmiths.com',
+			ssl: 53012,
+			tcp: 53012,
+			protocol: 'ssl',
+		},
+		{
+			host: 'tn.not.fyi',
+			ssl: 55002,
+			tcp: 55002,
+			protocol: 'ssl',
+		},
+		{
+			host: 'testnet.aranguren.org',
+			ssl: 51002,
+			tcp: 51001,
+			protocol: 'ssl',
+		},
+		{
+			host: 'blackie.c3-soft.com',
+			ssl: 57006,
+			tcp: 57006,
+			protocol: 'ssl',
+		},
+	],
+	bitcoinRegtest: [
+		{
+			host: '35.233.47.252',
+			ssl: 18484,
+			tcp: 18483,
+			protocol: 'tcp',
+		},
+	],
+	timestamp: null,
+};
+
 export const defaultSettingsShape: ISettings = {
 	loading: false,
 	error: false,
@@ -14,19 +115,7 @@ export const defaultSettingsShape: ISettings = {
 	selectedCurrency: 'USD',
 	selectedLanguage: 'english',
 	selectedNetwork: 'bitcoinRegtest',
-	customElectrumPeers: {
-		bitcoin: [],
-		bitcoinTestnet: [],
-		bitcoinRegtest: [
-			{
-				host: '35.233.47.252',
-				ssl: 18484,
-				tcp: 18483,
-				protocol: 'tcp',
-			},
-		],
-		timestamp: null,
-	},
+	customElectrumPeers,
 	coinSelectAuto: true,
 	coinSelectPreference: 'small',
 	unitPreference: 'asset',

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -67,7 +67,7 @@ export const stringTypeItems: IWalletItem<string> = {
 	timestamp: null,
 };
 
-export const addressContent = {
+export const addressContent: IAddressContent = {
 	index: -1,
 	path: '',
 	address: '',
@@ -75,7 +75,9 @@ export const addressContent = {
 	publicKey: '',
 };
 
-export const getAddressTypeContent = (data: any): IAddressTypeContent<any> => {
+export const getAddressTypeContent = (
+	data: IAddressContent | IAddress,
+): IAddressTypeContent<IAddressContent> => {
 	let content = {};
 	Object.keys(addressTypes).map((addressType) => {
 		content[addressType] = data;

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -105,7 +105,7 @@ export const setupLdk = async ({
 		if (genesisHash.isErr()) {
 			return err(genesisHash.error.message);
 		}
-		const account = await getAccount({});
+		const account = await getAccount({ selectedWallet });
 		if (account.isErr()) {
 			return err(account.error.message);
 		}


### PR DESCRIPTION
This PR:
- Temporarily adds public Electrum servers to assist with bootstrapping when toggling Bitcoin networks.
  - This will be replaced with our own servers once online.
- Created additional checks in `startWalletServices` method to ensure we're connected to Electrum prior to running certain methods.
- Updated `getNextAvailableAddress` to return the last known address indexes if an error occurs.

Notes:
- This only enables onchain for mainnet and testnet. LDK is still disabled for mainnet/testnet. So you will see LDK notification errors after switching to mainnet/testnet. This is expected.

To Test:
- Navigate to Settings->Networks->Bitcoin Network.
- Select "Bitcoin Mainnet" or "Bitcoin Testnet".
  - In the background, Bitkit should successfully connect to the appropriate Electrum server and generate addresses as needed.
- Navigate back to the main view and tap "Receive".
- An address for the selected network (bc1 for mainnet) should be generated and displayed via the qrcode similar to the attached image.
  - You should also see an LDK error notification that reads "Unable to generate Lightning Invoice". This is expected until we enable these network in LDK.

![Simulator Screen Shot - iPhone 13 - 2022-09-11 at 10 28 09](https://user-images.githubusercontent.com/8532651/189533018-6bf8f40b-0f9f-48df-a597-d5a59f6033ac.png)
![Simulator Screen Shot - iPhone 13 - 2022-09-11 at 10 28 23](https://user-images.githubusercontent.com/8532651/189533016-b3b7273b-fe55-40cc-8c8f-a5487b0e885d.png)
