### PR TITLE
Upgrade react-native-ldk

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:7.2.2')
+        classpath('com.android.tools.build:gradle:7.0.4')
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:4.1.2")
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:7.0.4')
+        classpath("com.android.tools.build:gradle:7.0.4")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:4.1.2")
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 31
         targetSdkVersion = 31
+        kotlinVersion = '1.7.10'
 
         if (System.properties['os.arch'] == "aarch64") {
             // For M1 Users we need to use the NDK 24 which added support for aarch64
@@ -22,9 +23,10 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
+        classpath('com.android.tools.build:gradle:7.2.2')
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("de.undercouch:gradle-download-task:4.1.2")
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -324,7 +324,7 @@ PODS:
     - React-Core
   - react-native-image-picker (4.10.0):
     - React-Core
-  - react-native-ldk (0.0.51):
+  - react-native-ldk (0.0.53):
     - React
   - react-native-libsodium (0.0.1):
     - React-Core
@@ -793,7 +793,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: f68191637788994baed5f57d12994aa32cf8bf88
   react-native-flipper: 7eeb9b59b667dd0619372c7349cf7c78032d1de2
   react-native-image-picker: 4bc9ed38c8be255b515d8c88babbaf74973f91a8
-  react-native-ldk: ad26f1f6932bfa7eb07a35a9b8ea74a7aa794c44
+  react-native-ldk: 19c21a681ad35c1e236dda7ffbdeaa745fb1a789
   react-native-libsodium: f4eba037c4ddf73f86b08075452cacb957256147
   react-native-mmkv: 1265a348a4711097ba29c8bcefd5971f48220f2b
   react-native-netinfo: 1a6035d3b9780221d407c277ebfb5722ace00658

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@sentry/react-native": "^4.2.2",
     "@shopify/react-native-skia": "^0.1.137",
     "@synonymdev/blocktank-client": "0.0.47",
-    "@synonymdev/react-native-ldk": "0.0.51",
+    "@synonymdev/react-native-ldk": "^0.0.53",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-sdk": "1.0.0-alpha.13",

--- a/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
@@ -47,10 +47,7 @@ import { useTransactionDetails } from '../../../hooks/transaction';
 import useColors from '../../../hooks/colors';
 import { updateOnchainFeeEstimates } from '../../../store/actions/fees';
 import { toggleView } from '../../../store/actions/user';
-import {
-	decodeLightningInvoice,
-	milliSatoshisToSatoshis,
-} from '../../../utils/lightning';
+import { decodeLightningInvoice } from '../../../utils/lightning';
 import { TInvoice } from '@synonymdev/react-native-ldk';
 import { processInputData } from '../../../utils/scanner';
 import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
@@ -165,13 +162,13 @@ const AddressAndAmount = ({ index = 0, navigation }): ReactElement => {
 	const decodedInvoiceAmount = useMemo(() => {
 		if (
 			lightningInvoice &&
-			decodedInvoice?.amount_milli_satoshis &&
-			decodedInvoice?.amount_milli_satoshis > 0
+			decodedInvoice?.amount_satoshis &&
+			decodedInvoice?.amount_satoshis > 0
 		) {
-			return milliSatoshisToSatoshis(decodedInvoice?.amount_milli_satoshis);
+			return decodedInvoice?.amount_satoshis;
 		}
 		return 0;
-	}, [decodedInvoice?.amount_milli_satoshis, lightningInvoice]);
+	}, [decodedInvoice?.amount_satoshis, lightningInvoice]);
 
 	/**
 	 * Returns the value of the current output.

--- a/src/screens/Wallets/SendOnChainTransaction/ReviewAndSend.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/ReviewAndSend.tsx
@@ -45,7 +45,6 @@ import { hasEnabledAuthentication } from '../../../utils/settings';
 import { EFeeIds } from '../../../store/types/fees';
 import {
 	decodeLightningInvoice,
-	milliSatoshisToSatoshis,
 	payLightningInvoice,
 } from '../../../utils/lightning';
 import { refreshWallet } from '../../../utils/wallet';
@@ -224,9 +223,7 @@ const ReviewAndSend = ({ navigation, index = 0 }): ReactElement => {
 			setIsLoading(false);
 			return;
 		}
-		const amountRequestedFromInvoice = milliSatoshisToSatoshis(
-			decodedInvoice?.amount_milli_satoshis ?? 0,
-		);
+		const amountRequestedFromInvoice = decodedInvoice?.amount_satoshis ?? 0;
 		// Determine if we should add a custom sat value to the lightning invoice.
 		let customSatAmount = 0;
 		if (
@@ -256,7 +253,7 @@ const ReviewAndSend = ({ navigation, index = 0 }): ReactElement => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		_onError,
-		decodedInvoice?.amount_milli_satoshis,
+		decodedInvoice?.amount_satoshis,
 		transaction.lightningInvoice,
 		transaction?.outputs,
 		transaction?.tags,

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -552,7 +552,3 @@ export const decodeLightningInvoice = ({
 	paymentRequest = paymentRequest.replace('lightning:', '').trim();
 	return ldk.decode({ paymentRequest });
 };
-
-export const milliSatoshisToSatoshis = (milliSatoshis = 0): number => {
-	return milliSatoshis * 0.001;
-};

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -30,7 +30,7 @@ import { getBalance, getSelectedNetwork, getSelectedWallet } from './wallet';
 import { toggleView } from '../store/actions/user';
 import { sleep } from './helpers';
 import { handleSlashtagURL } from './slashtags';
-import { decodeLightningInvoice, milliSatoshisToSatoshis } from './lightning';
+import { decodeLightningInvoice } from './lightning';
 
 const availableNetworksList = availableNetworks();
 
@@ -280,9 +280,7 @@ export const decodeQRData = async (
 					qrDataType: EQRDataType.lightningPaymentRequest,
 					lightningPaymentRequest: options.lightning,
 					network: selectedNetwork,
-					sats: milliSatoshisToSatoshis(
-						decodedInvoice.value?.amount_milli_satoshis ?? 0,
-					),
+					sats: decodedInvoice.value?.amount_satoshis ?? 0,
 					message: decodedInvoice.value?.description ?? '',
 				});
 				lightningInvoice = options.lightning;
@@ -299,9 +297,7 @@ export const decodeQRData = async (
 				qrDataType: EQRDataType.lightningPaymentRequest,
 				lightningPaymentRequest: data,
 				network: selectedNetwork,
-				sats: milliSatoshisToSatoshis(
-					decodedInvoice.value?.amount_milli_satoshis ?? 0,
-				),
+				sats: decodedInvoice.value?.amount_satoshis ?? 0,
 				message: decodedInvoice.value?.description ?? '',
 			});
 		}
@@ -377,9 +373,7 @@ export const processBitcoinTransactionData = async ({
 						// Ensure we can afford to pay the lightning invoice. If so, pass it through.
 						if (
 							lightningBalance.satoshis >
-							milliSatoshisToSatoshis(
-								decodedLightningInvoice.value?.amount_milli_satoshis ?? 0,
-							)
+							(decodedLightningInvoice.value?.amount_satoshis ?? 0)
 						) {
 							response = filteredLightningInvoice[0];
 						}
@@ -544,9 +538,7 @@ export const handleData = async ({
 					outputs: [
 						{
 							address: '',
-							value: milliSatoshisToSatoshis(
-								decodedInvoice.value?.amount_milli_satoshis ?? 0,
-							),
+							value: decodedInvoice.value?.amount_satoshis ?? 0,
 							index: 0,
 						},
 					],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2037,10 +2037,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@0.0.51":
-  version "0.0.51"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.51.tgz#a8731998c0f1cb1dc047dc7afb5f7e5921a66902"
-  integrity sha512-RnknBp+lWP3atj1OxUTsRXbKXzCe1xQyxh0YP3Na2ZkCc6hfGbWjHsjU8J1YT8gg3uSPPWWpEwdacVBd7cEyPw==
+"@synonymdev/react-native-ldk@^0.0.53":
+  version "0.0.53"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.53.tgz#6d14de677187bdf6038b3e7b3dd17602ff796f3c"
+  integrity sha512-Ld8qXisG6PN/V4Cvf8RimdWMtLDJgXDLiyue0AizqfHMtO83s/BcwDARxQ2aB8tUA1UIrbcwxg/8QwsHiCxBWQ==
 
 "@synonymdev/react-native-lnurl@0.0.3":
   version "0.0.3"


### PR DESCRIPTION
This PR:
- Upgrades `react-native-ldk` to `v0.0.53`.
- Sets kotlin version to `1.7.10`.
- Fixes breaking changes from `react-native-ldk` upgrade.
- Replaces all instances of `amount_milli_satoshis` with `amount_satoshis`.
- Removed `milliSatoshisToSatoshis` method.

Notes:
 - Previously we were unable to successfully create an Android build using the latest version of LDK (v0.0.110) packaged within `v0.0.53` of `react-native-ldk`. With these changes, we should now be able to create a stable apk.