### PR TITLE
fix(ui): only hide balance where it makes sense

### DIFF
--- a/src/components/AssetCard.tsx
+++ b/src/components/AssetCard.tsx
@@ -29,13 +29,13 @@ const AssetCard = ({
 			<View color="transparent" style={styles.col2}>
 				<Money
 					sats={satoshis}
-					hide={true}
+					enableHide={true}
 					size="text01m"
 					style={styles.value}
 				/>
 				<Money
 					sats={satoshis}
-					hide={true}
+					enableHide={true}
 					size="caption13M"
 					showFiat={true}
 					color="gray1"

--- a/src/components/BalanceHeader.tsx
+++ b/src/components/BalanceHeader.tsx
@@ -41,6 +41,7 @@ const BalanceHeader = (): ReactElement => {
 			<Money
 				sats={satoshis}
 				unit={balanceUnit}
+				enableHide={true}
 				highlight={true}
 				symbol={true}
 			/>

--- a/src/components/Money.tsx
+++ b/src/components/Money.tsx
@@ -34,7 +34,7 @@ interface IMoney {
 	highlight?: boolean; // grey last 3 chars in sats/bitcoin or decimal in fiat
 	symbol?: boolean; // show symbol icon
 	color?: string;
-	hide?: boolean; // if true and settings.hideBalance === true it will replace number with dots
+	enableHide?: boolean; // if true and settings.hideBalance === true it will replace number with dots
 	style?: object;
 	sign?: string;
 }
@@ -50,7 +50,7 @@ const Money = (props: IMoney): ReactElement => {
 	const unit = props.unit ?? (showFiat ? 'fiat' : bitcoinUnit);
 	const showSymbol = props.symbol ?? (unit === 'fiat' ? true : false);
 	const color = props.color;
-	const hide = (props.hide ?? true) && hideBalance;
+	const hide = (props.enableHide ?? false) && hideBalance;
 	const sign = props.sign;
 
 	sats = Math.abs(sats);
@@ -138,15 +138,8 @@ const Money = (props: IMoney): ReactElement => {
 	}, [highlight, dv, unit, sats]);
 
 	if (hide) {
-		prim = prim
-			.split('')
-			.map(() => ' •') // Narrow No-Break Space
-			.join('');
-
-		secd = secd
-			.split('')
-			.map(() => ' •') // Narrow No-Break Space
-			.join('');
+		prim = '• • • • • • • •';
+		secd = '';
 	}
 
 	return (

--- a/src/screens/Activity/ListItem.tsx
+++ b/src/screens/Activity/ListItem.tsx
@@ -89,7 +89,7 @@ const ListItem = ({
 				<View style={styles.col2}>
 					<Money
 						sats={value}
-						hide={true}
+						enableHide={true}
 						size="text01m"
 						style={styles.value}
 						sign={txType === 'sent' ? '-' : '+'}
@@ -97,7 +97,7 @@ const ListItem = ({
 					/>
 					<Money
 						sats={value}
-						hide={true}
+						enableHide={true}
 						size="caption13M"
 						style={styles.value}
 						showFiat={true}

--- a/src/screens/Wallets/WalletsDetail/BitcoinBreakdown.tsx
+++ b/src/screens/Wallets/WalletsDetail/BitcoinBreakdown.tsx
@@ -38,9 +38,10 @@ const NetworkRow = ({
 				</View>
 			</View>
 			<View color={'transparent'} style={styles.valueContainer}>
-				<Money sats={satoshis} size="text01m" />
+				<Money sats={satoshis} size="text01m" enableHide={true} />
 				<Money
 					sats={satoshis}
+					enableHide={true}
 					size="caption13M"
 					showFiat={true}
 					color="gray1"

--- a/src/screens/Wallets/WalletsDetail/index.tsx
+++ b/src/screens/Wallets/WalletsDetail/index.tsx
@@ -41,6 +41,7 @@ import { updateSettings } from '../../../store/actions/settings';
 import BitcoinLogo from '../../../assets/bitcoin-logo.svg';
 import { capitalize } from '../../../utils/helpers';
 import type { RootStackParamList } from '../../../navigation/types';
+import DetectSwipe from '../../../components/DetectSwipe';
 
 const updateHeight = ({
 	height = new Animated.Value(0),
@@ -81,6 +82,7 @@ const WalletsDetail = (props: Props): ReactElement => {
 	const { assetType } = route.params;
 	const { satoshis } = useBalance({ onchain: true, lightning: true });
 	const bitcoinUnit = useSelector((store: Store) => store.settings.bitcoinUnit);
+	const hideBalance = useSelector((state: Store) => state.settings.hideBalance);
 	const colors = useColors();
 	const filter = useMemo(() => {
 		const types =
@@ -126,6 +128,10 @@ const WalletsDetail = (props: Props): ReactElement => {
 		},
 		[showDetails, height, headerHeight],
 	);
+
+	const toggleHideBalance = (): void => {
+		updateSettings({ hideBalance: !hideBalance });
+	};
 
 	const handleSwitchUnit = useCallback(() => {
 		const nextUnit = bitcoinUnit === 'satoshi' ? 'BTC' : 'satoshi';
@@ -178,7 +184,12 @@ const WalletsDetail = (props: Props): ReactElement => {
 										entering={FadeIn}
 										exiting={FadeOut}>
 										<TouchableOpacity onPress={handleSwitchUnit}>
-											<Money sats={satoshis} highlight={true} size="title" />
+											<Money
+												sats={satoshis}
+												enableHide={true}
+												highlight={true}
+												size="title"
+											/>
 										</TouchableOpacity>
 									</AnimatedView>
 								) : null}
@@ -190,11 +201,19 @@ const WalletsDetail = (props: Props): ReactElement => {
 									entering={FadeIn}
 									exiting={FadeOut}>
 									<View color={'transparent'} style={styles.balanceContainer}>
-										<TouchableOpacity
-											onPress={handleSwitchUnit}
-											style={styles.largeValueContainer}>
-											<Money sats={satoshis} highlight={true} />
-										</TouchableOpacity>
+										<DetectSwipe
+											onSwipeLeft={toggleHideBalance}
+											onSwipeRight={toggleHideBalance}>
+											<TouchableOpacity
+												onPress={handleSwitchUnit}
+												style={styles.largeValueContainer}>
+												<Money
+													sats={satoshis}
+													enableHide={true}
+													highlight={true}
+												/>
+											</TouchableOpacity>
+										</DetectSwipe>
 									</View>
 									{assetType === 'bitcoin' ? <BitcoinBreakdown /> : null}
 								</AnimatedView>


### PR DESCRIPTION
Closes https://github.com/synonymdev/bitkit/issues/376

### Changes
- set all `<Money />` components to use the correct `enableHide` prop 
- add ability to hide/show balance in `WalletsDetail` screen