### PR TITLE
fix(wallet): Coin Select Auto Update

### DIFF
--- a/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
@@ -381,8 +381,8 @@ const AddressAndAmount = ({ index = 0, navigation }): ReactElement => {
 							text="Next"
 							onPress={(): void => {
 								let view = 'ReviewAndSend';
-								// If coin select is enabled and there is no lightning invoice.
-								if (coinSelectAuto && !transaction?.lightningInvoice) {
+								// If auto coin-select is disabled and there is no lightning invoice.
+								if (!coinSelectAuto && !transaction?.lightningInvoice) {
 									view = 'CoinSelection';
 								}
 								navigation.navigate(view);


### PR DESCRIPTION
This PR:
- Updates the navigation flow to skip coin selection if `coinSelectAuto` is set to `false`.
- This closes #382