### PR TITLE
feat(lightning): Implemented Custom Channels

### DIFF
--- a/src/navigation/lightning/LightningNavigator.tsx
+++ b/src/navigation/lightning/LightningNavigator.tsx
@@ -24,7 +24,7 @@ export type LightningStackParamList = {
 	CustomConfirm: {
 		spendingAmount: number;
 		receivingAmount: number;
-		receivingCost: number;
+		orderId: string;
 	};
 	Result: undefined;
 	QuickSetup: undefined;

--- a/src/screens/Blocktank/Payment.tsx
+++ b/src/screens/Blocktank/Payment.tsx
@@ -59,7 +59,9 @@ const BlocktankPayment = (props: Props): ReactElement => {
 			selectedWallet,
 			selectedNetwork,
 			transaction: {
-				outputs: [{ address: order.btc_address, value: order.total_amount }],
+				outputs: [
+					{ index: 0, address: order.btc_address, value: order.total_amount },
+				],
 				rbf: false, //Always needs to be false for zero conf payments to be accepted by blocktank
 				satsPerByte: order.zero_conf_satvbyte || 1,
 			},

--- a/src/screens/Lightning/Barrel.tsx
+++ b/src/screens/Lightning/Barrel.tsx
@@ -1,0 +1,51 @@
+import React, { memo, ReactElement, useMemo } from 'react';
+import useColors from '../../hooks/colors';
+import useDisplayValues from '../../hooks/displayValues';
+import { Subtitle, TouchableOpacity } from '../../styles/components';
+import { Image, StyleSheet } from 'react-native';
+
+const Barrel = ({ active, id, amount, img, onPress }): ReactElement => {
+	const colors = useColors();
+	const style = useMemo(
+		() =>
+			active ? [styles.bRoot, { borderColor: colors.purple }] : styles.bRoot,
+		[active, colors.purple],
+	);
+	const dp = useDisplayValues(Number(amount));
+
+	return (
+		<TouchableOpacity
+			color="purple16"
+			style={style}
+			onPress={(): void => onPress(id)}>
+			<Image style={styles.bImage} source={img} />
+			<Subtitle style={styles.bAmount}>
+				{dp.fiatSymbol} {dp.fiatWhole}
+			</Subtitle>
+		</TouchableOpacity>
+	);
+};
+
+const styles = StyleSheet.create({
+	bRoot: {
+		flex: 1,
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		marginHorizontal: 8,
+		borderRadius: 8,
+		borderWidth: 1,
+	},
+	bImage: {
+		margin: 8,
+		height: 100,
+		width: 100,
+		resizeMode: 'contain',
+	},
+	bAmount: {
+		marginTop: 8,
+		marginBottom: 16,
+		textAlign: 'center',
+	},
+});
+
+export default memo(Barrel);

--- a/src/screens/Lightning/NumberPadLightning.tsx
+++ b/src/screens/Lightning/NumberPadLightning.tsx
@@ -1,5 +1,5 @@
-import React, { ReactElement, useState } from 'react';
-import { StyleSheet, View, Alert } from 'react-native';
+import React, { memo, ReactElement, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import { Text02B, TouchableOpacity, SwitchIcon } from '../../styles/components';
@@ -14,11 +14,13 @@ const NumberPadLightning = ({
 	sats,
 	onChange,
 	onDone,
+	onMaxPress,
 	style,
 }: {
 	sats: number;
 	onChange: (amount: number) => void;
 	onDone: () => void;
+	onMaxPress: () => void;
 	style?: object | Array<object>;
 }): ReactElement => {
 	const [decimalMode, setDecimalMode] = useState(false);
@@ -81,10 +83,10 @@ const NumberPadLightning = ({
 					}
 				}
 
-				amount = String(btcToSats(Number(amount)));
+				newAmount = btcToSats(Number(amount));
 			} else {
 				amount = String(sats);
-				amount = `${amount}${key}`;
+				newAmount = Number(`${amount}${key}`);
 			}
 		} else {
 			amount = displayValue.fiatValue.toString();
@@ -114,16 +116,13 @@ const NumberPadLightning = ({
 			}
 
 			// Convert new fiat amount to satoshis.
-			amount = fiatToBitcoinUnit({
+			newAmount = fiatToBitcoinUnit({
 				fiatValue: amount,
 				bitcoinUnit: 'satoshi',
 				currency,
 				exchangeRate,
 			});
 		}
-
-		newAmount = Number(amount);
-
 		// limit amount to 21 000 000 BTC
 		if (newAmount > 2.1e15) {
 			newAmount = 2.1e15;
@@ -180,9 +179,7 @@ const NumberPadLightning = ({
 				<TouchableOpacity
 					style={styles.topRowButtons}
 					color="onSurface"
-					onPress={(): void => {
-						Alert.alert('TODO');
-					}}>
+					onPress={onMaxPress}>
 					<Text02B size="12px" color="purple">
 						MAX
 					</Text02B>
@@ -245,4 +242,4 @@ const styles = StyleSheet.create({
 	},
 });
 
-export default NumberPadLightning;
+export default memo(NumberPadLightning);

--- a/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
@@ -128,9 +128,7 @@ const AddressAndAmount = ({ index = 0, navigation }): ReactElement => {
 	 * Returns the current output by index.
 	 */
 	const getOutput = useMemo((): IOutput | undefined => {
-		try {
-			return transaction.outputs?.[index];
-		} catch {
+		return transaction.outputs?.[index] ?? { address: '', value: 0, index: 0 };
 			return { address: '', value: 0, index: 0 };
 		}
 	}, [index, transaction?.outputs]);

--- a/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
@@ -127,10 +127,8 @@ const AddressAndAmount = ({ index = 0, navigation }): ReactElement => {
 	/**
 	 * Returns the current output by index.
 	 */
-	const getOutput = useMemo((): IOutput | undefined => {
+	const getOutput = useMemo((): IOutput => {
 		return transaction.outputs?.[index] ?? { address: '', value: 0, index: 0 };
-			return { address: '', value: 0, index: 0 };
-		}
 	}, [index, transaction?.outputs]);
 
 	/**

--- a/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
@@ -131,7 +131,7 @@ const AddressAndAmount = ({ index = 0, navigation }): ReactElement => {
 		try {
 			return transaction.outputs?.[index];
 		} catch {
-			return { address: '', value: 0 };
+			return { address: '', value: 0, index: 0 };
 		}
 	}, [index, transaction?.outputs]);
 

--- a/src/screens/Wallets/SendOnChainTransaction/ReviewAndSend.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/ReviewAndSend.tsx
@@ -155,12 +155,8 @@ const ReviewAndSend = ({ navigation, index = 0 }): ReactElement => {
 	/**
 	 * Returns the current output by index.
 	 */
-	const getOutput = useMemo((): IOutput | undefined => {
-		try {
-			return transaction.outputs?.[index];
-		} catch {
-			return { address: '', value: 0, index: 0 };
-		}
+	const getOutput = useMemo((): IOutput => {
+		return transaction.outputs?.[index] ?? { address: '', value: 0, index: 0 };
 	}, [index, transaction?.outputs]);
 
 	/**

--- a/src/screens/Wallets/SendOnChainTransaction/ReviewAndSend.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/ReviewAndSend.tsx
@@ -159,7 +159,7 @@ const ReviewAndSend = ({ navigation, index = 0 }): ReactElement => {
 		try {
 			return transaction.outputs?.[index];
 		} catch {
-			return { address: '', value: 0 };
+			return { address: '', value: 0, index: 0 };
 		}
 	}, [index, transaction?.outputs]);
 

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -7,7 +7,6 @@ import {
 	IFormattedTransaction,
 	IKeyDerivationPath,
 	IBitcoinTransactionData,
-	IOutput,
 	IUtxo,
 	TAddressType,
 } from '../types/wallet';
@@ -842,10 +841,6 @@ export const setupOnChainTransaction = async ({
 	}
 };
 
-export interface IUpdateOutput extends IOutput {
-	index: number | undefined;
-}
-
 /**
  * This updates the specified on-chain transaction.
  * @param selectedWallet
@@ -854,13 +849,13 @@ export interface IUpdateOutput extends IOutput {
  * @return {Promise<void>}
  */
 export const updateBitcoinTransaction = async ({
-	selectedWallet = undefined,
-	selectedNetwork = undefined,
 	transaction,
+	selectedWallet,
+	selectedNetwork,
 }: {
 	transaction: IBitcoinTransactionData;
-	selectedWallet?: string | undefined;
-	selectedNetwork?: TAvailableNetworks | undefined;
+	selectedWallet?: string;
+	selectedNetwork?: TAvailableNetworks;
 }): Promise<void> => {
 	try {
 		if (!selectedNetwork) {
@@ -877,21 +872,8 @@ export const updateBitcoinTransaction = async ({
 					.outputs || [];
 			await Promise.all(
 				transaction?.outputs.map((output) => {
-					const outputIndex = output?.index;
-					if (outputIndex === undefined || isNaN(outputIndex)) {
-						//Ensure we're not pushing a duplicate address.
-						const foundOutput = outputs.filter(
-							(o) => o.address === output.address,
-						);
-						if (foundOutput?.length) {
-							// @ts-ignore // TODO: there is a bug here
-							outputs[foundOutput.index] = output;
-						} else {
-							outputs.push(output);
-						}
-					} else {
-						outputs[outputIndex] = output;
-					}
+					const outputIndex = output.index;
+					outputs[outputIndex] = output;
 				}),
 			);
 			transaction.outputs = outputs;

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -167,7 +167,7 @@ export interface IUtxo {
 export interface IOutput {
 	address?: string; //Address to send to.
 	value?: number; //Amount denominated in sats.
-	index?: number;
+	index: number; //Used to specify which output to update or edit when using updateBitcoinTransaction.
 }
 
 export interface IFormattedTransactionContent {

--- a/src/utils/blocktank/index.ts
+++ b/src/utils/blocktank/index.ts
@@ -7,7 +7,7 @@ import bt, {
 } from '@synonymdev/blocktank-client';
 import { TAvailableNetworks } from '../networks';
 import { err, ok, Result } from '@synonymdev/result';
-import { getNodeId } from '../lightning';
+import { getNodeId, refreshLdk } from '../lightning';
 import { refreshOrder } from '../../store/actions/blocktank';
 import { sleep } from '../helpers';
 import { getStore } from '../../store/helpers';
@@ -111,6 +111,8 @@ export const finalizeChannel = async (
 		if (nodeId.isErr()) {
 			return err(nodeId.error.message);
 		}
+		//Attempt to sync and re-add peers prior to channel open.
+		await refreshLdk({});
 
 		const params = {
 			order_id: orderId,

--- a/src/utils/exchange-rate/index.ts
+++ b/src/utils/exchange-rate/index.ts
@@ -64,11 +64,11 @@ export const fiatToBitcoinUnit = ({
 	currency,
 	bitcoinUnit,
 }: {
-	fiatValue: string;
+	fiatValue: string | number;
 	exchangeRate?: number;
 	currency?: string;
 	bitcoinUnit?: TBitcoinUnit;
-}): string => {
+}): number => {
 	if (!currency) {
 		currency = getStore().settings.selectedCurrency;
 	}
@@ -87,9 +87,9 @@ export const fiatToBitcoinUnit = ({
 			.value()
 			.toFixed(bitcoinUnit === 'satoshi' ? 0 : 8); // satoshi cannot be a fractional number
 
-		return value;
+		return Number(value);
 	} catch (e) {
-		return '';
+		return 0;
 	}
 };
 
@@ -172,14 +172,13 @@ export const getFiatDisplayValues = ({
 	bitcoinUnit?: TBitcoinUnit;
 	locale?: string;
 }): IFiatDisplayValues => {
-	const store = getStore();
-	const exchangeRates = store.wallet.exchangeRates;
+	const exchangeRates = getStore().wallet.exchangeRates;
 
 	if (!currency) {
-		currency = store.settings.selectedCurrency;
+		currency = getStore().settings.selectedCurrency;
 	}
 	if (!bitcoinUnit) {
-		bitcoinUnit = store.settings.bitcoinUnit;
+		bitcoinUnit = getStore().settings.bitcoinUnit;
 	}
 
 	try {
@@ -207,7 +206,7 @@ export const getFiatDisplayValues = ({
 		}
 
 		if (!exchangeRate) {
-			exchangeRate = store.wallet.exchangeRates[currency].rate;
+			exchangeRate = getStore().wallet.exchangeRates[currency].rate;
 		}
 
 		// this throws if exchangeRate is 0

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -92,7 +92,6 @@ export const startWalletServices = async ({
 			let { wallets, selectedNetwork } = getStore().wallet;
 			let isConnectedToElectrum = false;
 
-			setupTodos().then();
 			updateExchangeRates().then();
 
 			// Before we do anything we should connect to an Electrum server.
@@ -171,6 +170,9 @@ export const startWalletServices = async ({
 				await refreshServiceList();
 				watchPendingOrders();
 			}
+
+			// This should be last so that we know all on-chain and lightning data is synced/up-to-date.
+			setupTodos().then();
 			//backupServiceStart().then();
 		});
 

--- a/src/utils/todos/index.ts
+++ b/src/utils/todos/index.ts
@@ -3,7 +3,7 @@ import { ITodo, TTodoType } from '../../store/types/todos';
 import { getStore } from '../../store/helpers';
 import { addTodo, removeTodo } from '../../store/actions/todos';
 import { toggleView } from '../../store/actions/user';
-import { getLightningChannels } from '../lightning';
+import { getOpenChannels } from '../lightning';
 import { TChannel } from '@synonymdev/react-native-ldk';
 
 type TTodoPresets = { [key in TTodoType]: ITodo };
@@ -93,7 +93,9 @@ export const setupTodos = async (): Promise<void> => {
 	 * Check for lightning.
 	 */
 	const lightning = todos.some((todo) => todo.type === 'lightning');
-	const getLightningChannelsResponse = await getLightningChannels();
+	const getLightningChannelsResponse = await getOpenChannels({
+		fromStorage: true,
+	});
 	let lightningChannels: TChannel[] = [];
 	if (getLightningChannelsResponse.isOk()) {
 		lightningChannels = getLightningChannelsResponse.value;


### PR DESCRIPTION
This PR:
 - Adds the ability to purchase Blocktank channels via the Custom Channels flow.

To Test:
1. Ensure the app has around at least 20,000-100,000 sats.
2. Select the "Get on Lightning" suggestion on the Home screen or navigate to:
   - Settings->Networks->Lightning Connections->Add New Connection
3. Select "Custom Setup".
4. Keep "0" selected as your spending balance and press "Continue".
5. Keep the pre-set receiving amount and press "Continue".
6. Swipe to pay on the confirm screen.
7. Once confirmed, mine a block or two and wait for Blocktank to see the transaction and open the channel.
    - If the channel doesn't open after some time attempt to refresh the app or mine another block.

Notes:
- Attempting to set the max amount when specifying spending or receiving channel balances will not always work yet. We will need to implement the calculation Blocktank uses to calculate channel costs to more accurately set these values. Right now it does its best to calculate what the user can and cannot afford.
