### PR TITLE
fix: allow http on android (temp)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,12 +13,16 @@
     <uses-permission tools:node="remove" android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission tools:node="remove" android:name="android.permission.SYSTEM_ALERT_WINDOW" />
 
+    <!-- TODO: Remove this line before launch -->
+    <!-- android:usesCleartextTraffic="true" -->
+
     <application
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="false">
+      android:allowBackup="false"
+      android:usesCleartextTraffic="true">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"


### PR DESCRIPTION
Closes https://github.com/synonymdev/bitkit/issues/356

Untested. We should revert this before going live / after we got domains for all the APIs.