### PR TITLE
fix(lightning): Channel Purchase Improvements

### DIFF
--- a/src/components/FancySlider.tsx
+++ b/src/components/FancySlider.tsx
@@ -29,7 +29,12 @@ const valueToX = (
 	if (value > maximumValue) {
 		newValue = maximumValue;
 	}
-	return (width / (maximumValue - minimumValue)) * newValue;
+	const delta = maximumValue - minimumValue;
+	// Make sure we're not dividing by zero.
+	if (delta === 0) {
+		return 0;
+	}
+	return (width / delta) * newValue;
 };
 
 const xToValue = (
@@ -44,6 +49,10 @@ const xToValue = (
 	}
 	if (x > width) {
 		newX = width;
+	}
+	// Make sure we're not dividing by zero.
+	if (width === 0) {
+		return 0;
 	}
 	return ((maximumValue - minimumValue) / width) * newX;
 };

--- a/src/screens/Lightning/CustomConfirm.tsx
+++ b/src/screens/Lightning/CustomConfirm.tsx
@@ -60,7 +60,15 @@ const CustomConfirm = ({
 		return defaultOrderResponse;
 	}, [orderId, orders]);
 
-	const cost = useDisplayValues(order?.price ?? 0);
+	const blocktankPurchaseFee = useDisplayValues(order?.price ?? 0);
+	const transactionFee = useSelector(
+		(state: Store) =>
+			state.wallet.wallets[selectedWallet].transaction[selectedNetwork].fee,
+	);
+	const fiatTransactionFee = useDisplayValues(transactionFee ?? 0);
+	const channelOpenCost = useMemo(() => {
+		return blocktankPurchaseFee.fiatValue + fiatTransactionFee.fiatValue;
+	}, [fiatTransactionFee.fiatValue, blocktankPurchaseFee.fiatValue]);
 
 	const handleConfirm = async (): Promise<void> => {
 		setLoading(true);
@@ -109,11 +117,9 @@ const CustomConfirm = ({
 						</Display>
 						<Text01S color="gray1" style={styles.text}>
 							It costs
-							<Text01S>
-								{' ' + cost.fiatSymbol + cost.fiatFormatted + ' '}
-							</Text01S>
-							to connect and setup your balance. Your Lightning connection will
-							stay open for at least
+							<Text01S>{` ${blocktankPurchaseFee.fiatSymbol}${channelOpenCost} `}</Text01S>
+							to connect you to Lightning and set up your spending balance. Your
+							Lightning connection will stay open for at least
 							<Text01S onPress={(): void => setKeybrd(true)}>
 								{' '}
 								{weeks} weeks <PenIcon height={18} width={18} />

--- a/src/screens/Lightning/QuickConfirm.tsx
+++ b/src/screens/Lightning/QuickConfirm.tsx
@@ -26,6 +26,7 @@ import { IGetOrderResponse } from '@synonymdev/blocktank-client';
 import { sleep } from '../../utils/helpers';
 import { defaultOrderResponse } from '../../store/shapes/blocktank';
 import { confirmChannelPurchase } from '../../store/actions/blocktank';
+import useDisplayValues from '../../hooks/displayValues';
 
 const PIE_SIZE = 140;
 const PIE_SHIFT = 70;
@@ -42,6 +43,9 @@ const QuickConfirm = ({
 	const selectedNetwork = useSelector(
 		(state: Store) => state.wallet.selectedNetwork,
 	);
+	const selectedWallet = useSelector(
+		(state: Store) => state.wallet.selectedWallet,
+	);
 	const orderId = useMemo(
 		() => route.params?.orderId ?? '',
 		[route.params?.orderId],
@@ -55,6 +59,16 @@ const QuickConfirm = ({
 		}
 		return defaultOrderResponse;
 	}, [orderId, orders]);
+	const blocktankPurchaseFee = useDisplayValues(order?.price ?? 0);
+	const transactionFee = useSelector(
+		(state: Store) =>
+			state.wallet.wallets[selectedWallet].transaction[selectedNetwork].fee,
+	);
+	const fiatTransactionFee = useDisplayValues(transactionFee ?? 0);
+	const channelOpenCost = useMemo(() => {
+		return blocktankPurchaseFee.fiatValue + fiatTransactionFee.fiatValue;
+	}, [fiatTransactionFee.fiatValue, blocktankPurchaseFee.fiatValue]);
+
 	const [keybrd, setKeybrd] = useState(false);
 	const [loading, setLoading] = useState(false);
 
@@ -86,8 +100,9 @@ const QuickConfirm = ({
 				<View>
 					<Display color="purple">Please {'\n'}confirm.</Display>
 					<Text01S color="gray1" style={styles.text}>
-						It costs <Text01S>{order.price} sats</Text01S> to connect you to
-						Lightning and set up your spending balance.
+						It costs
+						<Text01S>{` ${blocktankPurchaseFee.fiatSymbol}${channelOpenCost} `}</Text01S>
+						to connect you to Lightning and set up your spending balance.
 					</Text01S>
 				</View>
 

--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -58,7 +58,7 @@ const QuickSetup = ({
 	const colors = useColors();
 	const [keybrd, setKeybrd] = useState(false);
 	const [loading, setLoading] = useState(false);
-	const [totalBalance, setTotalBalance] = useState(20000);
+	const [totalBalance, setTotalBalance] = useState(0);
 	const [spendingAmount, setSpendingAmount] = useState(0);
 	const currentBalance = useBalance({ onchain: true });
 	const bitcoinUnit = useSelector((state: Store) => state.settings.bitcoinUnit);
@@ -96,12 +96,13 @@ const QuickSetup = ({
 	}, [bitcoinUnit, unitPreference]);
 
 	useEffect(() => {
-		let spendingLimit = currentBalance.satoshis;
-		if (blocktankService?.max_chan_spending < currentBalance.satoshis) {
+		let spendingLimit = Math.round(currentBalance.satoshis / 1.5);
+		if (blocktankService?.max_chan_spending < spendingLimit) {
 			spendingLimit = blocktankService?.max_chan_spending;
 		}
 		setTotalBalance(spendingLimit);
 	}, [blocktankService?.max_chan_spending, currentBalance.satoshis]);
+
 	useEffect(() => {
 		setupOnChainTransaction({ rbf: false }).then();
 	}, []);

--- a/src/store/reducers/todos.ts
+++ b/src/store/reducers/todos.ts
@@ -7,7 +7,7 @@ const todos = (state: ITodos = defaultTodosShape, action): ITodos => {
 		case actions.ADD_TODO:
 			return {
 				...state,
-				todos: [...state.todos, action.payload],
+				todos: [action.payload, ...state.todos],
 			};
 
 		case actions.REMOVE_TODO:

--- a/src/utils/todos/index.ts
+++ b/src/utils/todos/index.ts
@@ -57,9 +57,11 @@ export const setupTodos = async (): Promise<void> => {
 	 */
 	const backupTodo = todos.filter((todo) => todo.type === 'activateBackup');
 	const backupStatus = store.backup.remoteBackupsEnabled;
-	const activateBackupIsDismissed = 'activateBackup' in dismissedTodos;
+	const activateBackupIsDismissed = dismissedTodos.some(
+		(todo) => todo === 'activateBackup',
+	);
 	// Add backupTodo if status is false and is not included in the todos array.
-	if (!backupStatus && !backupTodo?.length && activateBackupIsDismissed) {
+	if (!backupStatus && !backupTodo?.length && !activateBackupIsDismissed) {
 		addTodo(todoPresets.activateBackup);
 	}
 	// Remove backupTodo if status is true and hasn't been removed from the todos array.
@@ -70,7 +72,7 @@ export const setupTodos = async (): Promise<void> => {
 	/*
 	 * Check for seed phrase backup.
 	 */
-	const seedPhraseDismissed = dismissedTodos.filter(
+	const seedPhraseDismissed = dismissedTodos.some(
 		(todo) => todo === 'backupSeedPhrase',
 	);
 	const seedPhraseTodo = todos.filter(
@@ -81,7 +83,7 @@ export const setupTodos = async (): Promise<void> => {
 	// and backup has not been verified
 	if (
 		!backupSeedPhraseStatus &&
-		!seedPhraseDismissed.length &&
+		!seedPhraseDismissed &&
 		!seedPhraseTodo.length
 	) {
 		addTodo(todoPresets.backupSeedPhrase);
@@ -94,7 +96,9 @@ export const setupTodos = async (): Promise<void> => {
 	 * Check for lightning.
 	 */
 	const lightning = todos.some((todo) => todo.type === 'lightning');
-	const lightningIsDismissed = 'lightning' in dismissedTodos;
+	const lightningIsDismissed = dismissedTodos.some(
+		(todo) => todo === 'lightning',
+	);
 	const getLightningChannelsResponse = await getOpenChannels({
 		fromStorage: true,
 	});
@@ -124,7 +128,7 @@ export const setupTodos = async (): Promise<void> => {
 	 * Check for PIN.
 	 */
 	const pin = todos.some((todo) => todo.type === 'pin');
-	const pinIsDismissed = 'pin' in dismissedTodos;
+	const pinIsDismissed = dismissedTodos.some((todo) => todo === 'pin');
 	// Add pin if status is false and is not included in the todos array.
 	if (!pin && !pinIsDismissed) {
 		addTodo(todoPresets.pin);
@@ -135,12 +139,14 @@ export const setupTodos = async (): Promise<void> => {
 	// }
 
 	/*
-	 * Check for PIN.
+	 * Check for Slashtags Profile.
 	 */
 	const slashtagsProfile = todos.some(
 		(todo) => todo.type === 'slashtagsProfile',
 	);
-	const slashtagsProfileIsDismissed = 'slashtagsProfile' in dismissedTodos;
+	const slashtagsProfileIsDismissed = dismissedTodos.some(
+		(todo) => todo === 'slashtagsProfile',
+	);
 	const slashtagsProfileStatus =
 		store.slashtags.onboardingProfileStep !== 'Intro';
 	// Add pin if status is false and is not included in the todos array.

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -86,6 +86,7 @@ import {
 } from './constants';
 import { moveMetaIncTxTags } from '../../store/actions/metadata';
 import { refreshOrdersList } from '../../store/actions/blocktank';
+import { setupTodos } from '../todos';
 
 export const refreshWallet = async ({
 	onchain = true,
@@ -145,6 +146,8 @@ export const refreshWallet = async ({
 			await updateActivityList();
 			await moveMetaIncTxTags();
 		}
+
+		setupTodos().then();
 
 		return ok('');
 	} catch (e) {


### PR DESCRIPTION
This PR:
- Adds on-chain transaction fees to the channel purchase cost in the `QuickConfirm` & `CustomConfirm` components.
- Updates the max spend/receive calculations in the `CustomSetup` and `QuickSetup` channel purchase flows.
- Fixes slider divide by zero bug.
- Updates lightning todo logic.
- Updated `ADD_TODO` reducer to add new todos to the front.