### PR TITLE
feat(wallet): Boost (RBF/CPFP) Improvements

### DIFF
--- a/src/store/reducers/wallet.ts
+++ b/src/store/reducers/wallet.ts
@@ -241,6 +241,7 @@ const wallet = (state: IWallet = defaultWalletStoreShape, action): IWallet => {
 								outputs: action.payload.outputs,
 								fee: action.payload.fee,
 								rbf: action.payload.rbf,
+								max: defaultBitcoinTransactionData.max,
 							},
 						},
 					},
@@ -274,10 +275,7 @@ const wallet = (state: IWallet = defaultWalletStoreShape, action): IWallet => {
 						...state.wallets[selectedWallet],
 						transaction: {
 							...state.wallets[selectedWallet].transaction,
-							[selectedNetwork]: {
-								...defaultBitcoinTransactionData,
-								outputs: [EOutput],
-							},
+							[selectedNetwork]: defaultBitcoinTransactionData,
 						},
 					},
 				},

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -209,7 +209,7 @@ export interface IBitcoinTransactionData {
 }
 
 export const defaultBitcoinTransactionData: IBitcoinTransactionData = {
-	outputs: [],
+	outputs: [EOutput],
 	inputs: [],
 	changeAddress: '',
 	fiatAmount: 0,

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -1754,13 +1754,13 @@ export interface IRbfData {
  */
 
 export const getRbfData = async ({
-	txHash = undefined,
-	selectedWallet = undefined,
-	selectedNetwork = undefined,
+	txHash,
+	selectedWallet,
+	selectedNetwork,
 }: {
-	txHash: ITxHash | undefined;
-	selectedWallet: string | undefined;
-	selectedNetwork: TAvailableNetworks | undefined;
+	txHash?: ITxHash;
+	selectedWallet?: string;
+	selectedNetwork?: TAvailableNetworks;
 }): Promise<Result<IRbfData>> => {
 	if (!txHash) {
 		return err('No txid provided.');
@@ -1839,12 +1839,23 @@ export const getRbfData = async ({
 				return err('Transaction is already confirmed. Unable to RBF.');
 			}
 			const txVout = tx.value.data[0].result.vout[input.vout];
-			if (txVout.scriptPubKey.address) {
+			if (txVout.scriptPubKey?.address) {
 				address = txVout.scriptPubKey.address;
-			} else if (txVout.scriptPubKey.addresses) {
+			} else if (
+				txVout.scriptPubKey?.addresses &&
+				txVout.scriptPubKey.addresses.length
+			) {
 				address = txVout.scriptPubKey.addresses[0];
 			}
+			if (!address) {
+				continue;
+			}
 			scriptHash = getScriptHash(address, selectedNetwork);
+			// Check that we are in possession of this scriptHash.
+			if (!(scriptHash in allAddresses)) {
+				// This output did not come from us.
+				continue;
+			}
 			path = allAddresses[scriptHash].path;
 			value = btcToSats(txVout.value);
 			inputs.push({
@@ -1878,6 +1889,9 @@ export const getRbfData = async ({
 				}
 			} catch (e) {}
 		}
+		if (!address) {
+			continue;
+		}
 		const changeAddressScriptHash = getScriptHash(address, selectedNetwork);
 
 		// If the address scripthash matches one of our change address scripthashes, add it accordingly. Otherwise, add it as another output.
@@ -1899,9 +1913,15 @@ export const getRbfData = async ({
 	}
 
 	if (!changeAddressData?.address && outputs.length >= 2) {
-		return err(
-			'Unable to determine change address. Performing an RBF could divert funds from the incorrect output. Consider CPFP instead.',
-		);
+		/*
+		 * Unable to determine change address.
+		 * Performing an RBF could divert funds from the incorrect output.
+		 *
+		 * It's very possible that this tx sent the max amount of sats to a foreign/unknown address.
+		 * Instead of pulling sats from that output to accommodate the higher fee (reducing how much the recipient receives)
+		 * suggest a CPFP transaction.
+		 */
+		return err('cpfp');
 	}
 
 	if (outputTotal > inputTotal) {


### PR DESCRIPTION
This PR:
- Updates RBF logic to better transition to CPFP when unable to RBF.
- Improves the `canBoost` method logic for both `rbf` & `cpfp`.
- Adds several additional checks to the `getRbfData`, `setupRbf` & `setupCpfp` methods. 
- Adds `inputTxHashes` to `setupOnChainTransaction` to pre-specify and filter for desired inputs when setting up transactions.
- Adds default `max` value in `SETUP_ON_CHAIN_TRANSACTION` reducer.
- Adds `txid` & `satsPerByte` params to the `setupCpfp` method.
