### PR TITLE
fix: fontHeight on lightning quick setup screen

### DIFF
--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -5,7 +5,7 @@ import React, {
 	useMemo,
 	useEffect,
 } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet, Platform, View } from 'react-native';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import {
@@ -299,6 +299,7 @@ const styles = StyleSheet.create({
 	},
 	pText: {
 		marginLeft: 8,
+		paddingTop: Platform.OS === 'android' ? 20 : 0,
 	},
 	numberpad: {
 		marginHorizontal: -16,


### PR DESCRIPTION
lineHeight is buggy on Android RN, so I'm adding paddingTop to compensate it 

<img width="200" alt="image" src="https://user-images.githubusercontent.com/155891/192274840-73a8fa14-25b6-4ab8-80d8-1efc0355d835.png">

