### PR TITLE
fix(wallet): Boost Fixes

### DIFF
--- a/src/screens/Wallets/BoostPrompt.tsx
+++ b/src/screens/Wallets/BoostPrompt.tsx
@@ -137,7 +137,7 @@ const BoostForm = ({
 					satsPerByte > 1 ? 's' : ''
 				}/B\n+${boostFee.toFixed(0)} sats`}
 				decreaseValue={(): void => {
-					if (satsPerByte - 1 > minFee) {
+					if (satsPerByte - 1 >= minFee) {
 						const res = adjustFee({
 							selectedNetwork,
 							selectedWallet,

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -18,6 +18,7 @@ import {
 	getMnemonicPhrase,
 	getOnChainBalance,
 	getRbfData,
+	getReceiveAddress,
 	getScriptHash,
 	getSelectedNetwork,
 	getSelectedWallet,
@@ -1956,6 +1957,11 @@ export const setupCpfp = async ({
 		return err(response.error?.message);
 	}
 
+	const receiveAddress = getReceiveAddress({ selectedWallet, selectedNetwork });
+	if (receiveAddress.isErr()) {
+		return err(receiveAddress.error.message);
+	}
+
 	const sendMaxResponse = await sendMax({
 		selectedWallet,
 		selectedNetwork,
@@ -1963,7 +1969,7 @@ export const setupCpfp = async ({
 			...response.value,
 			satsPerByte: satsPerByte ?? response.value.satsPerByte,
 		},
-		address: response.value.changeAddress,
+		address: receiveAddress.value,
 	});
 	if (sendMaxResponse.isErr()) {
 		return err(sendMaxResponse.error.message);


### PR DESCRIPTION
This PR:
- Swaps out change address for receiving address in `setupCpfp` method.
- Adjusts `decreaseValue`'s condition in `BoostPrompt.tsx`.