### PR TITLE
fix: BottomSheet, NumberPads, Backup todo

### DIFF
--- a/src/components/BottomSheetGradient.tsx
+++ b/src/components/BottomSheetGradient.tsx
@@ -1,4 +1,6 @@
 import React, { memo, ReactElement } from 'react';
+import { StyleProp, StyleSheet, ViewStyle } from 'react-native';
+import { SharedValue, useAnimatedStyle } from 'react-native-reanimated';
 import {
 	Canvas,
 	LinearGradient,
@@ -8,32 +10,39 @@ import {
 	useComputedValue,
 	vec,
 } from '@shopify/react-native-skia';
-import { StyleSheet } from 'react-native';
-import { useAnimatedStyle } from 'react-native-reanimated';
 
 import { AnimatedView, View as ThemedView } from '../styles/components';
+import colors, { IColors } from '../styles/colors';
 
-const Gradient = (): ReactElement => {
+const Gradient = ({
+	startColor,
+}: {
+	startColor: keyof IColors;
+}): ReactElement => {
 	const { size } = useCanvas();
-
 	const rct = useComputedValue(
 		() => rect(0, 0, size.current.width, size.current.height),
 		[size],
 	);
 	const end = useComputedValue(() => vec(0, size.current.height), [size]);
+	const gradientColors = [colors[startColor] ?? colors.gray6, 'black'];
 
 	return (
 		<Rect x={0} y={0} rect={rct}>
-			<LinearGradient
-				start={vec(0, 0)}
-				end={end}
-				colors={['#101010', 'black']}
-			/>
+			<LinearGradient start={vec(0, 0)} end={end} colors={gradientColors} />
 		</Rect>
 	);
 };
 
-const GradientWrapper = ({ animatedContentHeight, style }): ReactElement => {
+const GradientWrapper = ({
+	animatedContentHeight,
+	startColor = 'gray6',
+	style,
+}: {
+	animatedContentHeight: SharedValue<number>;
+	startColor: keyof IColors;
+	style: StyleProp<ViewStyle>;
+}): ReactElement => {
 	const animatedStyle = useAnimatedStyle(
 		() => ({ height: animatedContentHeight.value + 32 }),
 		[animatedContentHeight],
@@ -43,7 +52,7 @@ const GradientWrapper = ({ animatedContentHeight, style }): ReactElement => {
 		<ThemedView style={[styles.root, style]}>
 			<AnimatedView style={animatedStyle}>
 				<Canvas style={styles.canvas}>
-					<Gradient />
+					<Gradient startColor={startColor} />
 				</Canvas>
 			</AnimatedView>
 		</ThemedView>

--- a/src/components/BottomSheetWrapper.tsx
+++ b/src/components/BottomSheetWrapper.tsx
@@ -39,29 +39,33 @@ import themes from '../styles/themes';
 import { toggleView } from '../store/actions/user';
 import { defaultViewController } from '../store/shapes/user';
 import BottomSheetGradient from './BottomSheetGradient';
+import { IColors } from '../styles/colors';
 
-export interface IModalProps {
+export interface BottomSheetWrapperProps {
 	children: ReactElement;
 	view?: TViewController;
-	onOpen?: () => any;
-	onClose?: () => any;
 	snapPoints?: (string | number)[];
 	backdrop?: boolean;
+	backgroundStartColor?: keyof IColors;
+	onOpen?: () => void;
+	onClose?: () => void;
 }
+
 const BottomSheetWrapper = forwardRef(
 	(
 		{
 			children,
 			view,
-			onOpen = (): null => null,
-			onClose = (): null => null,
 			snapPoints = ['60%', '95%'],
 			backdrop = true,
-		}: IModalProps,
+			backgroundStartColor = 'gray6',
+			onOpen = (): void => {},
+			onClose = (): void => {},
+		}: BottomSheetWrapperProps,
 		ref,
 	): ReactElement => {
 		const data = useSelector((state: Store) =>
-			view ? state.user?.viewController[view] : defaultViewController,
+			view ? state.user.viewController[view] : defaultViewController,
 		);
 		const bottomSheetRef = useRef<BottomSheet>(null);
 
@@ -152,6 +156,7 @@ const BottomSheetWrapper = forwardRef(
 			({ style, ...props }: BottomSheetBackgroundProps) => (
 				<BottomSheetGradient
 					animatedContentHeight={animatedContentHeight}
+					startColor={backgroundStartColor}
 					style={style}
 					{...props}
 				/>

--- a/src/components/GradientView.tsx
+++ b/src/components/GradientView.tsx
@@ -1,0 +1,70 @@
+import React, { memo, ReactElement } from 'react';
+import { StyleProp, StyleSheet, ViewStyle } from 'react-native';
+import {
+	Canvas,
+	LinearGradient,
+	Rect,
+	rect,
+	useCanvas,
+	useComputedValue,
+	vec,
+} from '@shopify/react-native-skia';
+
+import { View as ThemedView } from '../styles/components';
+import colors, { IColors } from '../styles/colors';
+
+const Gradient = ({
+	startColor,
+	endColor,
+}: {
+	startColor: keyof IColors;
+	endColor: keyof IColors;
+}): ReactElement => {
+	const { size } = useCanvas();
+	const rct = useComputedValue(
+		() => rect(0, 0, size.current.width, size.current.height),
+		[size],
+	);
+	const end = useComputedValue(() => vec(0, size.current.height), [size]);
+	const gradientColors = [
+		colors[startColor] ?? colors.gray6,
+		colors[endColor] ?? 'black',
+	];
+
+	return (
+		<Rect x={0} y={0} rect={rct}>
+			<LinearGradient start={vec(0, 0)} end={end} colors={gradientColors} />
+		</Rect>
+	);
+};
+
+const GradientView = ({
+	startColor = 'gray6',
+	endColor = 'black',
+	style,
+	children,
+}: {
+	startColor?: keyof IColors;
+	endColor?: keyof IColors;
+	style?: StyleProp<ViewStyle>;
+	children?: JSX.Element | JSX.Element[];
+}): ReactElement => {
+	return (
+		<ThemedView style={style}>
+			<Canvas style={styles.canvas}>
+				<Gradient startColor={startColor} endColor={endColor} />
+			</Canvas>
+			{children}
+		</ThemedView>
+	);
+};
+
+const styles = StyleSheet.create({
+	canvas: {
+		position: 'absolute',
+		height: '100%',
+		width: '100%',
+	},
+});
+
+export default memo(GradientView);

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -7,14 +7,6 @@ import { vibrate } from '../utils/helpers';
 const ACTIVE_OPACITY = 0.2;
 const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
 
-interface NumberPad {
-	onPress: (key: number | string) => void;
-	onRemove: Function;
-	style?: object | Array<object>;
-	children?: ReactElement;
-	showDot?: boolean;
-}
-
 const Button = memo(
 	({
 		num,
@@ -34,6 +26,14 @@ const Button = memo(
 		);
 	},
 );
+
+type NumberPad = {
+	style?: object | Array<object>;
+	children?: ReactElement;
+	showDot?: boolean;
+	onPress: (key: number | string) => void;
+	onRemove: () => void;
+};
 
 const NumberPad = ({
 	onPress,
@@ -112,6 +112,7 @@ const NumberPad = ({
 const styles = StyleSheet.create({
 	container: {
 		flex: 1,
+		paddingBottom: 16,
 	},
 	buttonContainer: {
 		flex: 1,

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -1,9 +1,8 @@
 import React, { memo, ReactElement, useMemo } from 'react';
-import { StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { GestureResponderEvent } from 'react-native-modal';
-import { Text, TouchableOpacity, Ionicons, View } from '../styles/components';
-
-const { vibrate } = require('../utils/helpers');
+import { Text, TouchableOpacity, Ionicons } from '../styles/components';
+import { vibrate } from '../utils/helpers';
 
 const ACTIVE_OPACITY = 0.2;
 const digits = [1, 2, 3, 4, 5, 6, 7, 8, 9, 0];
@@ -59,7 +58,7 @@ const NumberPad = ({
 	};
 
 	return (
-		<View color={'background'} style={container}>
+		<View style={container}>
 			{children}
 			<View style={styles.row}>
 				<Button onPress={(): void => handlePress(digits[0])} num={digits[0]} />

--- a/src/components/PinPad2.tsx
+++ b/src/components/PinPad2.tsx
@@ -32,7 +32,7 @@ const ChoosePIN = ({
 	const handleOnPress = (number: number | string): void => {
 		if (pin.length !== 4) {
 			vibrate({});
-			setPin((p) => (p.length === 4 ? '' : p + String(number)));
+			setPin((p) => p + String(number));
 		}
 	};
 

--- a/src/components/PinPad2.tsx
+++ b/src/components/PinPad2.tsx
@@ -29,14 +29,18 @@ const ChoosePIN = ({
 	const [attemptsRemaining, setAttemptsRemaining] = useState(0);
 	const { brand, brand08 } = useColors();
 
-	const handleOnPress = (n): void => {
-		vibrate({});
-		setPin((p) => (p.length === 4 ? '' : p + String(n)));
+	const handleOnPress = (number: number | string): void => {
+		if (pin.length !== 4) {
+			vibrate({});
+			setPin((p) => (p.length === 4 ? '' : p + String(number)));
+		}
 	};
 
 	const handleOnRemove = (): void => {
-		vibrate({});
-		setPin((p) => p.slice(0, -1));
+		if (pin.length !== 0) {
+			vibrate({});
+			setPin((p) => p.slice(0, -1));
+		}
 	};
 
 	// Reduce the amount of pin attempts remaining.

--- a/src/navigation/bottom-sheet/SendNavigation.tsx
+++ b/src/navigation/bottom-sheet/SendNavigation.tsx
@@ -21,7 +21,6 @@ import Scanner from '../../screens/Wallets/SendOnChainTransaction/Scanner';
 import Contacts from '../../screens/Wallets/SendOnChainTransaction/Contacts';
 import CoinSelection from '../../screens/Wallets/SendOnChainTransaction/CoinSelection';
 import SendNumberPad from '../../screens/Wallets/SendOnChainTransaction/SendNumberPad';
-import FeeNumberPad from '../../screens/Wallets/SendOnChainTransaction/FeeNumberPad';
 import AuthCheck from '../../components/AuthCheck';
 import { NavigationContainer } from '../../styles/components';
 import {
@@ -90,7 +89,6 @@ const SendNavigation = (): ReactElement => {
 				</NavigationContainer>
 			</BottomSheetWrapper>
 			<SendNumberPad />
-			<FeeNumberPad />
 		</>
 	);
 };

--- a/src/navigation/settings/SettingsNavigator.tsx
+++ b/src/navigation/settings/SettingsNavigator.tsx
@@ -21,7 +21,7 @@ import TransactionSpeedSettings from '../../screens/Settings/TransactionSpeed';
 import AuthCheck from '../../components/AuthCheck';
 import GeneralSettings from '../../screens/Settings/General';
 import SecuritySettings from '../../screens/Settings/Security';
-import BackupMenu from '../../screens/Settings/BackupMenu';
+import BackupSettings from '../../screens/Settings/BackupSettings';
 import NetworksSettings from '../../screens/Settings/Networks';
 import AdvancedSettings from '../../screens/Settings/Advanced';
 import AboutSettings from '../../screens/Settings/About';
@@ -47,7 +47,7 @@ export type SettingsStackParamList = {
 	SettingsMenu: undefined;
 	GeneralSettings: undefined;
 	SecuritySettings: undefined;
-	BackupMenu: undefined;
+	BackupSettings: undefined;
 	NetworksSettings: undefined;
 	AdvancedSettings: undefined;
 	AboutSettings: undefined;
@@ -91,7 +91,7 @@ const SettingsNavigator = (): ReactElement => {
 				<Stack.Screen name="SettingsMenu" component={SettingsMenu} />
 				<Stack.Screen name="GeneralSettings" component={GeneralSettings} />
 				<Stack.Screen name="SecuritySettings" component={SecuritySettings} />
-				<Stack.Screen name="BackupMenu" component={BackupMenu} />
+				<Stack.Screen name="BackupSettings" component={BackupSettings} />
 				<Stack.Screen name="NetworksSettings" component={NetworksSettings} />
 				<Stack.Screen name="AdvancedSettings" component={AdvancedSettings} />
 				<Stack.Screen name="AboutSettings" component={AboutSettings} />

--- a/src/screens/Lightning/NumberPadLightning.tsx
+++ b/src/screens/Lightning/NumberPadLightning.tsx
@@ -7,7 +7,7 @@ import Store from '../../store/types';
 import useDisplayValues, { useExchangeRate } from '../../hooks/displayValues';
 import { fiatToBitcoinUnit } from '../../utils/exchange-rate';
 import { btcToSats } from '../../utils/helpers';
-import AmountButtonRow from '../Wallets/AmountButtonRow';
+import NumberPadButtons from '../Wallets/NumberPadButtons';
 
 const NumberPadLightning = ({
 	sats,
@@ -174,7 +174,7 @@ const NumberPadLightning = ({
 			showDot={showDot}
 			onPress={onPress}
 			onRemove={onRemove}>
-			<AmountButtonRow color="white" onMaxPress={onMaxPress} onDone={onDone} />
+			<NumberPadButtons color="white" onMaxPress={onMaxPress} onDone={onDone} />
 		</NumberPad>
 	);
 };

--- a/src/screens/Lightning/NumberPadLightning.tsx
+++ b/src/screens/Lightning/NumberPadLightning.tsx
@@ -1,14 +1,13 @@
 import React, { memo, ReactElement, useState } from 'react';
-import { StyleSheet, View } from 'react-native';
+import { StyleSheet } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { Text02B, TouchableOpacity, SwitchIcon } from '../../styles/components';
 import NumberPad from '../../components/NumberPad';
 import Store from '../../store/types';
 import useDisplayValues, { useExchangeRate } from '../../hooks/displayValues';
 import { fiatToBitcoinUnit } from '../../utils/exchange-rate';
-import { updateSettings } from '../../store/actions/settings';
 import { btcToSats } from '../../utils/helpers';
+import AmountButtonRow from '../Wallets/AmountButtonRow';
 
 const NumberPadLightning = ({
 	sats,
@@ -175,70 +174,14 @@ const NumberPadLightning = ({
 			showDot={showDot}
 			onPress={onPress}
 			onRemove={onRemove}>
-			<View style={styles.topRow}>
-				<TouchableOpacity
-					style={styles.topRowButtons}
-					color="onSurface"
-					onPress={onMaxPress}>
-					<Text02B size="12px" color="purple">
-						MAX
-					</Text02B>
-				</TouchableOpacity>
-				<TouchableOpacity
-					style={styles.topRowButtons}
-					color="onSurface"
-					onPress={(): void => {
-						const newUnitPreference =
-							unitPreference === 'asset' ? 'fiat' : 'asset';
-						updateSettings({ unitPreference: newUnitPreference });
-					}}>
-					<SwitchIcon color="white" width={16.44} height={13.22} />
-					<Text02B size="12px" color="purple" style={styles.middleButtonText}>
-						{unitPreference === 'asset'
-							? displayValue.fiatTicker
-							: displayValue.bitcoinTicker}
-					</Text02B>
-				</TouchableOpacity>
-				<TouchableOpacity
-					style={styles.topRowButtons}
-					color="onSurface"
-					onPress={onDone}>
-					<Text02B size="12px" color="purple">
-						DONE
-					</Text02B>
-				</TouchableOpacity>
-			</View>
+			<AmountButtonRow color="white" onMaxPress={onMaxPress} onDone={onDone} />
 		</NumberPad>
 	);
 };
 
 const styles = StyleSheet.create({
 	numberpad: {
-		maxHeight: 350,
-	},
-	topRow: {
-		flexDirection: 'row',
-		alignItems: 'center',
-		justifyContent: 'space-between',
-		paddingVertical: 5,
-		paddingHorizontal: 5,
-		// TODO: replace shadow with proper gradient
-		shadowColor: 'rgba(185, 92, 232, 0.36)',
-		shadowOpacity: 0.8,
-		elevation: 6,
-		shadowRadius: 15,
-		shadowOffset: { width: 1, height: 13 },
-	},
-	topRowButtons: {
-		paddingVertical: 5,
-		paddingHorizontal: 8,
-		borderRadius: 8,
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
-	},
-	middleButtonText: {
-		marginLeft: 11,
+		maxHeight: 425,
 	},
 });
 

--- a/src/screens/Profile/ProfileLinkSuggestions.tsx
+++ b/src/screens/Profile/ProfileLinkSuggestions.tsx
@@ -4,8 +4,8 @@ import { View, StyleSheet } from 'react-native';
 import Button from '../../components/Button';
 import BottomSheetNavigationHeader from '../../components/BottomSheetNavigationHeader';
 import { ProfileLinkScreenProps } from '../../navigation/types';
-import { View as ThemedView } from '../../styles/components';
 import { updateProfileLink } from '../../store/actions/ui';
+import GradientView from '../../components/GradientView';
 
 const suggestions = [
 	'Email',
@@ -35,7 +35,7 @@ export const ProfileLinkSuggestions = ({
 	};
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader title="Suggestions To Add" />
 			<View style={styles.buttons}>
 				{suggestions.map((suggestion) => (
@@ -48,7 +48,7 @@ export const ProfileLinkSuggestions = ({
 					/>
 				))}
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Settings/Backup/ConfirmMnemonic.tsx
+++ b/src/screens/Settings/Backup/ConfirmMnemonic.tsx
@@ -2,14 +2,11 @@ import React, { memo, ReactElement, useMemo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import {
-	View as ThemedView,
-	Text01S,
-	Text01M,
-} from '../../../styles/components';
+import { Text01S, Text01M } from '../../../styles/components';
 import Button from '../../../components/Button';
 import { shuffleArray } from '../../../utils/helpers';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
 
 const Word = ({
 	number,
@@ -84,7 +81,7 @@ const ConfirmMnemonic = ({ navigation, route }): ReactElement => {
 	const showButton = seed.some((v, i) => origSeed[i] !== v);
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader title="Confirm Recovery Phrase" />
 
 			<Text01S color="gray1" style={styles.text}>
@@ -132,7 +129,7 @@ const ConfirmMnemonic = ({ navigation, route }): ReactElement => {
 					/>
 				)}
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Settings/Backup/Metadata.tsx
+++ b/src/screens/Settings/Backup/Metadata.tsx
@@ -2,7 +2,8 @@ import React, { memo, ReactElement, useMemo } from 'react';
 import { StyleSheet, View, Image } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { View as ThemedView, Text01S } from '../../../styles/components';
+import { Text01S } from '../../../styles/components';
+import GradientView from '../../../components/GradientView';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
 import Button from '../../../components/Button';
 import Glow from '../../../components/Glow';
@@ -28,7 +29,7 @@ const Result = (): ReactElement => {
 	};
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader
 				title="Wallet Metadata"
 				displayBackButton={false}
@@ -47,7 +48,7 @@ const Result = (): ReactElement => {
 			<View style={buttonContainerStyles}>
 				<Button size="large" text="OK" onPress={handleButtonPress} />
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Settings/Backup/Result.tsx
+++ b/src/screens/Settings/Backup/Result.tsx
@@ -2,13 +2,14 @@ import React, { memo, ReactElement, useMemo } from 'react';
 import { StyleSheet, View, Image } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { View as ThemedView, Text01S } from '../../../styles/components';
+import { Text01S } from '../../../styles/components';
 import Button from '../../../components/Button';
 import Glow from '../../../components/Glow';
 import { verifyBackup } from '../../../store/actions/user';
 import { removeTodo } from '../../../store/actions/todos';
 import { todoPresets } from '../../../utils/todos';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
 import { BackupScreenProps } from '../../../navigation/types';
 
 const Result = ({ navigation }: BackupScreenProps<'Result'>): ReactElement => {
@@ -28,7 +29,7 @@ const Result = ({ navigation }: BackupScreenProps<'Result'>): ReactElement => {
 	};
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader title="Successful" />
 
 			<Text01S color="gray1" style={styles.text}>
@@ -47,7 +48,7 @@ const Result = ({ navigation }: BackupScreenProps<'Result'>): ReactElement => {
 			<View style={nextButtonContainer}>
 				<Button size="large" text="OK" onPress={handleButtonPress} />
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Settings/Backup/ShowMnemonic.tsx
+++ b/src/screens/Settings/Backup/ShowMnemonic.tsx
@@ -58,7 +58,7 @@ const ShowMnemonic = ({ navigation }): ReactElement => {
 	const seedToShow = Platform.OS === 'android' && !show ? dummySeed : seed;
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<View style={styles.container}>
 			<BottomSheetNavigationHeader
 				title="Your Recovery Phrase"
 				displayBackButton={false}
@@ -118,7 +118,7 @@ const ShowMnemonic = ({ navigation }): ReactElement => {
 					/>
 				)}
 			</View>
-		</ThemedView>
+		</View>
 	);
 };
 

--- a/src/screens/Settings/BackupSettings/index.tsx
+++ b/src/screens/Settings/BackupSettings/index.tsx
@@ -4,9 +4,9 @@ import SettingsView from './../SettingsView';
 import { toggleView } from '../../../store/actions/user';
 import { SettingsScreenProps } from '../../../navigation/types';
 
-const BackupMenu = ({
+const BackupSettings = ({
 	navigation,
-}: SettingsScreenProps<'BackupMenu'>): ReactElement => {
+}: SettingsScreenProps<'BackupSettings'>): ReactElement => {
 	const SettingsListData: IListData[] = useMemo(
 		() => [
 			{
@@ -55,4 +55,4 @@ const BackupMenu = ({
 	);
 };
 
-export default memo(BackupMenu);
+export default memo(BackupSettings);

--- a/src/screens/Settings/PIN/AskForBiometrics.tsx
+++ b/src/screens/Settings/PIN/AskForBiometrics.tsx
@@ -95,7 +95,7 @@ const ChoosePIN = ({ navigation }): ReactElement => {
 				)}
 			</View>
 
-			{biometryData?.biometryType && (
+			{biometryData?.biometryType ? (
 				<View style={styles.imageContainer}>
 					<Glow style={styles.glow} size={600} color="brand" />
 					{biometryData?.biometryType === 'FaceID' ? (
@@ -104,6 +104,8 @@ const ChoosePIN = ({ navigation }): ReactElement => {
 						<TouchIdIcon />
 					)}
 				</View>
+			) : (
+				<></>
 			)}
 
 			<View style={buttonContainerStyles}>

--- a/src/screens/Settings/PIN/AskForBiometrics.tsx
+++ b/src/screens/Settings/PIN/AskForBiometrics.tsx
@@ -9,13 +9,13 @@ import {
 	Text01M,
 	Text01S,
 	TouchIdIcon,
-	View as ThemedView,
 } from '../../../styles/components';
 import Button from '../../../components/Button';
 import Glow from '../../../components/Glow';
 import { toggleBiometrics } from '../../../utils/settings';
 import { IsSensorAvailableResult } from '../../../components/Biometrics';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
 
 const rnBiometrics = ReactNativeBiometrics;
 
@@ -72,7 +72,7 @@ const ChoosePIN = ({ navigation }): ReactElement => {
 			: biometryData?.biometryType ?? 'Biometric';
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader
 				title={typeName}
 				onBackPress={handleOnBack}
@@ -123,7 +123,7 @@ const ChoosePIN = ({ navigation }): ReactElement => {
 					disabled={!biometryData}
 				/>
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Settings/PIN/ChoosePIN.tsx
+++ b/src/screens/Settings/PIN/ChoosePIN.tsx
@@ -10,6 +10,7 @@ import { useFocusEffect } from '@react-navigation/native';
 
 import { Text01S, Text02S } from '../../../styles/components';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
 import NumberPad from '../../../components/NumberPad';
 import useColors from '../../../hooks/colors';
 import { vibrate, setKeychainValue } from '../../../utils/helpers';
@@ -65,7 +66,7 @@ const ChoosePIN = ({ navigation, route }): ReactElement => {
 	}, [pin, origPIN, navigation]);
 
 	return (
-		<View style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader
 				title={origPIN ? 'Retype 4-Digit PIN' : 'Choose 4-Digit PIN'}
 				displayBackButton={origPIN ? true : false}
@@ -112,7 +113,7 @@ const ChoosePIN = ({ navigation, route }): ReactElement => {
 				onPress={handleOnPress}
 				onRemove={handleOnRemove}
 			/>
-		</View>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Settings/PIN/ChoosePIN.tsx
+++ b/src/screens/Settings/PIN/ChoosePIN.tsx
@@ -8,11 +8,7 @@ import React, {
 import { StyleSheet, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 
-import {
-	View as ThemedView,
-	Text01S,
-	Text02S,
-} from '../../../styles/components';
+import { Text01S, Text02S } from '../../../styles/components';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
 import NumberPad from '../../../components/NumberPad';
 import useColors from '../../../hooks/colors';
@@ -69,7 +65,7 @@ const ChoosePIN = ({ navigation, route }): ReactElement => {
 	}, [pin, origPIN, navigation]);
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<View style={styles.container}>
 			<BottomSheetNavigationHeader
 				title={origPIN ? 'Retype 4-Digit PIN' : 'Choose 4-Digit PIN'}
 				displayBackButton={origPIN ? true : false}
@@ -116,7 +112,7 @@ const ChoosePIN = ({ navigation, route }): ReactElement => {
 				onPress={handleOnPress}
 				onRemove={handleOnRemove}
 			/>
-		</ThemedView>
+		</View>
 	);
 };
 

--- a/src/screens/Settings/PIN/Result.tsx
+++ b/src/screens/Settings/PIN/Result.tsx
@@ -2,11 +2,12 @@ import React, { memo, ReactElement, useMemo } from 'react';
 import { StyleSheet, View, Image } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { View as ThemedView, Text01S } from '../../../styles/components';
+import { Text01S } from '../../../styles/components';
 import Button from '../../../components/Button';
 import Glow from '../../../components/Glow';
 import { toggleView } from '../../../store/actions/user';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
 
 const imageSrc = require('../../../assets/illustrations/check.png');
 
@@ -28,7 +29,7 @@ const Result = ({ route }): ReactElement => {
 		});
 	};
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader
 				title="Wallet Secured"
 				displayBackButton={false}
@@ -56,7 +57,7 @@ const Result = ({ route }): ReactElement => {
 			<View style={nextButtonContainer}>
 				<Button size="large" text="OK" onPress={handleButtonPress} />
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -25,7 +25,7 @@ const SettingsMenu = ({ navigation }): ReactElement => {
 					{
 						title: 'Back up or Restore',
 						type: 'button',
-						onPress: (): void => navigation.navigate('BackupMenu'),
+						onPress: (): void => navigation.navigate('BackupSettings'),
 						hide: false,
 					},
 					{

--- a/src/screens/Wallets/AmountButtonRow.tsx
+++ b/src/screens/Wallets/AmountButtonRow.tsx
@@ -1,22 +1,23 @@
 import React, { memo, ReactElement } from 'react';
-import { StyleSheet, GestureResponderEvent } from 'react-native';
+import { View, StyleSheet, GestureResponderEvent } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { TouchableOpacity, View, SwitchIcon } from '../../styles/components';
+import { TouchableOpacity, SwitchIcon } from '../../styles/components';
 import Store from '../../store/types';
-import { sendMax } from '../../utils/wallet/transactions';
 import { Text02B } from '../../styles/components';
-import { getStore } from '../../store/helpers';
 import { updateSettings } from '../../store/actions/settings';
 import useDisplayValues from '../../hooks/displayValues';
+import { IColors } from '../../styles/colors';
 
 type AmountButtonRowProps = {
-	showMaxButton?: boolean;
+	color?: keyof IColors;
+	onMaxPress?: (event: GestureResponderEvent) => void;
 	onDone: (event: GestureResponderEvent) => void;
 };
 
 const AmountButtonRow = ({
-	showMaxButton = true,
+	color = 'brand',
+	onMaxPress,
 	onDone,
 }: AmountButtonRowProps): ReactElement => {
 	const selectedWallet = useSelector(
@@ -37,28 +38,27 @@ const AmountButtonRow = ({
 
 	const displayValues = useDisplayValues(balance);
 
-	const max = useSelector(
+	const isMaxSendAmount = useSelector(
 		(state: Store) =>
 			state.wallet.wallets[selectedWallet]?.transaction[selectedNetwork]?.max ??
 			false,
 	);
 
 	const onChangeUnit = (): void => {
-		const unit =
-			getStore().settings?.unitPreference === 'asset' ? 'fiat' : 'asset';
+		const unit = unitPreference === 'asset' ? 'fiat' : 'asset';
 		updateSettings({ unitPreference: unit });
 	};
 
 	return (
 		<View style={styles.container}>
 			<View style={styles.buttonContainer}>
-				{showMaxButton && (
+				{onMaxPress && (
 					<TouchableOpacity
 						style={styles.button}
 						color="white08"
 						disabled={balance <= 0}
-						onPress={sendMax}>
-						<Text02B size="12px" color={max ? 'orange' : 'brand'}>
+						onPress={onMaxPress}>
+						<Text02B size="12px" color={isMaxSendAmount ? 'orange' : color}>
 							MAX
 						</Text02B>
 					</TouchableOpacity>
@@ -70,8 +70,8 @@ const AmountButtonRow = ({
 					style={styles.button}
 					color="white08"
 					onPress={onChangeUnit}>
-					<SwitchIcon color="brand" width={16.44} height={13.22} />
-					<Text02B size="12px" color="brand" style={styles.middleButtonText}>
+					<SwitchIcon color={color} width={16.44} height={13.22} />
+					<Text02B size="12px" color={color} style={styles.middleButtonText}>
 						{unitPreference === 'asset'
 							? displayValues.fiatTicker
 							: displayValues.bitcoinTicker}
@@ -84,7 +84,7 @@ const AmountButtonRow = ({
 					style={styles.button}
 					color="white08"
 					onPress={onDone}>
-					<Text02B size="12px" color="brand">
+					<Text02B size="12px" color={color}>
 						DONE
 					</Text02B>
 				</TouchableOpacity>
@@ -105,7 +105,7 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 	},
 	button: {
-		paddingVertical: 6,
+		paddingVertical: 7,
 		paddingHorizontal: 8,
 		borderRadius: 8,
 		flexDirection: 'row',

--- a/src/screens/Wallets/NumberPadButtons.tsx
+++ b/src/screens/Wallets/NumberPadButtons.tsx
@@ -9,17 +9,19 @@ import { updateSettings } from '../../store/actions/settings';
 import useDisplayValues from '../../hooks/displayValues';
 import { IColors } from '../../styles/colors';
 
-type AmountButtonRowProps = {
+type NumberPadButtons = {
 	color?: keyof IColors;
+	showUnitButton?: boolean;
 	onMaxPress?: (event: GestureResponderEvent) => void;
-	onDone: (event: GestureResponderEvent) => void;
+	onDone?: (event: GestureResponderEvent) => void;
 };
 
-const AmountButtonRow = ({
+const NumberPadButtons = ({
 	color = 'brand',
+	showUnitButton = true,
 	onMaxPress,
 	onDone,
-}: AmountButtonRowProps): ReactElement => {
+}: NumberPadButtons): ReactElement => {
 	const selectedWallet = useSelector(
 		(store: Store) => store.wallet.selectedWallet,
 	);
@@ -66,28 +68,32 @@ const AmountButtonRow = ({
 			</View>
 
 			<View style={styles.buttonContainer}>
-				<TouchableOpacity
-					style={styles.button}
-					color="white08"
-					onPress={onChangeUnit}>
-					<SwitchIcon color={color} width={16.44} height={13.22} />
-					<Text02B size="12px" color={color} style={styles.middleButtonText}>
-						{unitPreference === 'asset'
-							? displayValues.fiatTicker
-							: displayValues.bitcoinTicker}
-					</Text02B>
-				</TouchableOpacity>
+				{showUnitButton && (
+					<TouchableOpacity
+						style={styles.button}
+						color="white08"
+						onPress={onChangeUnit}>
+						<SwitchIcon color={color} width={16.44} height={13.22} />
+						<Text02B size="12px" color={color} style={styles.middleButtonText}>
+							{unitPreference === 'asset'
+								? displayValues.fiatTicker
+								: displayValues.bitcoinTicker}
+						</Text02B>
+					</TouchableOpacity>
+				)}
 			</View>
 
 			<View style={styles.buttonContainer}>
-				<TouchableOpacity
-					style={styles.button}
-					color="white08"
-					onPress={onDone}>
-					<Text02B size="12px" color={color}>
-						DONE
-					</Text02B>
-				</TouchableOpacity>
+				{onDone && (
+					<TouchableOpacity
+						style={styles.button}
+						color="white08"
+						onPress={onDone}>
+						<Text02B size="12px" color={color}>
+							DONE
+						</Text02B>
+					</TouchableOpacity>
+				)}
 			</View>
 		</View>
 	);
@@ -103,6 +109,7 @@ const styles = StyleSheet.create({
 	buttonContainer: {
 		flex: 1,
 		alignItems: 'center',
+		minHeight: 28,
 	},
 	button: {
 		paddingVertical: 7,
@@ -116,4 +123,4 @@ const styles = StyleSheet.create({
 	},
 });
 
-export default memo(AmountButtonRow);
+export default memo(NumberPadButtons);

--- a/src/screens/Wallets/Receive/ReceiveDetails.tsx
+++ b/src/screens/Wallets/Receive/ReceiveDetails.tsx
@@ -13,7 +13,6 @@ import {
 	BottomSheetTextInput,
 	Caption13Up,
 	TagIcon,
-	View as ThemedView,
 } from '../../../styles/components';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
 import AmountToggle from '../../../components/AmountToggle';
@@ -26,6 +25,7 @@ import {
 } from '../../../store/actions/receive';
 import useKeyboard from '../../../hooks/keyboard';
 import { toggleView } from '../../../store/actions/user';
+import GradientView from '../../../components/GradientView';
 
 const ReceiveDetails = ({ navigation }): ReactElement => {
 	const insets = useSafeAreaInsets();
@@ -72,7 +72,7 @@ const ReceiveDetails = ({ navigation }): ReactElement => {
 	};
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader
 				title="Specify Invoice"
 				displayBackButton={false}
@@ -139,7 +139,7 @@ const ReceiveDetails = ({ navigation }): ReactElement => {
 					</View>
 				)}
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Wallets/Receive/ReceiveNumberPad.tsx
+++ b/src/screens/Wallets/Receive/ReceiveNumberPad.tsx
@@ -19,7 +19,7 @@ import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
  * Handles the number pad logic (add/remove/clear) for invoices.
  */
 const ReceiveNumberPad = (): ReactElement => {
-	const snapPoints = useMemo(() => [375], []);
+	const snapPoints = useMemo(() => [425], []);
 	const [decimalMode, setDecimalMode] = useState(false);
 	const [prefixZeros, setPrefixZeros] = useState(0);
 	const invoice = useSelector((store: Store) => store.receive);
@@ -174,9 +174,10 @@ const ReceiveNumberPad = (): ReactElement => {
 
 	return (
 		<BottomSheetWrapper
+			view="numberPadReceive"
 			snapPoints={snapPoints}
 			backdrop={false}
-			view="numberPadReceive">
+			backgroundStartColor="black">
 			<NumberPad showDot={showDot} onPress={onPress} onRemove={onRemove}>
 				<AmountButtonRow showMaxButton={false} onDone={onDone} />
 			</NumberPad>

--- a/src/screens/Wallets/Receive/ReceiveNumberPad.tsx
+++ b/src/screens/Wallets/Receive/ReceiveNumberPad.tsx
@@ -1,7 +1,7 @@
 import React, { memo, ReactElement, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-import AmountButtonRow from '../AmountButtonRow';
+import NumberPadButtons from '../NumberPadButtons';
 import NumberPad from '../../../components/NumberPad';
 import BottomSheetWrapper from '../../../components/BottomSheetWrapper';
 import { toggleView } from '../../../store/actions/user';
@@ -179,7 +179,7 @@ const ReceiveNumberPad = (): ReactElement => {
 			backdrop={false}
 			backgroundStartColor="black">
 			<NumberPad showDot={showDot} onPress={onPress} onRemove={onRemove}>
-				<AmountButtonRow onDone={onDone} />
+				<NumberPadButtons onDone={onDone} />
 			</NumberPad>
 		</BottomSheetWrapper>
 	);

--- a/src/screens/Wallets/Receive/ReceiveNumberPad.tsx
+++ b/src/screens/Wallets/Receive/ReceiveNumberPad.tsx
@@ -179,7 +179,7 @@ const ReceiveNumberPad = (): ReactElement => {
 			backdrop={false}
 			backgroundStartColor="black">
 			<NumberPad showDot={showDot} onPress={onPress} onRemove={onRemove}>
-				<AmountButtonRow showMaxButton={false} onDone={onDone} />
+				<AmountButtonRow onDone={onDone} />
 			</NumberPad>
 		</BottomSheetWrapper>
 	);

--- a/src/screens/Wallets/Receive/Tags.tsx
+++ b/src/screens/Wallets/Receive/Tags.tsx
@@ -2,12 +2,9 @@ import React, { memo, ReactElement, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import {
-	BottomSheetTextInput,
-	Caption13Up,
-	View as ThemedView,
-} from '../../../styles/components';
+import { BottomSheetTextInput, Caption13Up } from '../../../styles/components';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
 import Tag from '../../../components/Tag';
 import Store from '../../../store/types';
 import { updateInvoice } from '../../../store/actions/receive';
@@ -32,7 +29,7 @@ const Tags = ({ navigation }): ReactElement => {
 	};
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader title="Add Tag" />
 			<View style={styles.content}>
 				{lastUsedTags.length !== 0 && (
@@ -65,7 +62,7 @@ const Tags = ({ navigation }): ReactElement => {
 					returnKeyType="done"
 				/>
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Wallets/Receive/index.tsx
+++ b/src/screens/Wallets/Receive/index.tsx
@@ -22,7 +22,6 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import Share from 'react-native-share';
 
 import {
-	View as ThemedView,
 	CopyIcon,
 	ShareIcon,
 	TouchableOpacity,
@@ -204,7 +203,7 @@ const Receive = ({ navigation }): ReactElement => {
 	);
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<View style={styles.container}>
 			<BottomSheetNavigationHeader
 				title="Receive Bitcoin"
 				displayBackButton={false}
@@ -268,7 +267,7 @@ const Receive = ({ navigation }): ReactElement => {
 					onPress={(): void => navigation.navigate('ReceiveDetails')}
 				/>
 			</View>
-		</ThemedView>
+		</View>
 	);
 };
 

--- a/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/AddressAndAmount.tsx
@@ -24,7 +24,6 @@ import {
 	ScanIcon,
 	TagIcon,
 	UserIcon,
-	View as ThemedView,
 } from '../../../styles/components';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
 import AmountToggle from '../../../components/AmountToggle';
@@ -309,7 +308,7 @@ const AddressAndAmount = ({ index = 0, navigation }): ReactElement => {
 	}, [address, amount, transaction?.lightningInvoice]);
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<View style={styles.container}>
 			<BottomSheetNavigationHeader
 				title="Send Bitcoin"
 				displayBackButton={false}
@@ -396,7 +395,7 @@ const AddressAndAmount = ({ index = 0, navigation }): ReactElement => {
 					)}
 				</View>
 			</View>
-		</ThemedView>
+		</View>
 	);
 };
 

--- a/src/screens/Wallets/SendOnChainTransaction/Contacts.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/Contacts.tsx
@@ -2,8 +2,8 @@ import React, { memo, ReactElement } from 'react';
 import { Alert, StyleSheet, View } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import { View as ThemedView } from '../../../styles/components';
 import NavigationHeader from '../../../components/NavigationHeader';
+import GradientView from '../../../components/GradientView';
 import ContactsList from '../../../components/ContactsList';
 import { validateAddress } from '../../../utils/scanner';
 import { EAddressTypeNames } from '../../../store/types/wallet';
@@ -62,7 +62,7 @@ const Contacts = ({ navigation }): ReactElement => {
 	};
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<NavigationHeader title="Send to Contact" size="sm" />
 			<View style={styles.content}>
 				<ContactsList
@@ -70,7 +70,7 @@ const Contacts = ({ navigation }): ReactElement => {
 					sectionBackgroundColor="onSurface"
 				/>
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Wallets/SendOnChainTransaction/FeeCustom.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/FeeCustom.tsx
@@ -1,70 +1,38 @@
-import React, { ReactElement, memo, useMemo, useCallback } from 'react';
-import { StyleSheet, View, Keyboard } from 'react-native';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useFocusEffect } from '@react-navigation/native';
+import React, { ReactElement, memo } from 'react';
+import { StyleSheet, View } from 'react-native';
 
-import { Caption13Up, View as ThemedView } from '../../../styles/components';
+import { Caption13Up } from '../../../styles/components';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
-import Button from '../../../components/Button';
+import GradientView from '../../../components/GradientView';
 import { useTransactionDetails } from '../../../hooks/transaction';
-import { toggleView } from '../../../store/actions/user';
 import FeeCustomToggle from './FeeCustomToggle';
+import FeeNumberPad from './FeeNumberPad';
 
 const FeeRate = ({ navigation }): ReactElement => {
-	const insets = useSafeAreaInsets();
-	const nextButtonContainer = useMemo(
-		() => ({
-			...styles.nextButtonContainer,
-			paddingBottom: insets.bottom + 16,
-		}),
-		[insets.bottom],
-	);
+	const { satsPerByte } = useTransactionDetails();
 
-	const transaction = useTransactionDetails();
+	let onDone: (() => void) | undefined = undefined;
 
-	useFocusEffect(
-		useCallback(() => {
-			Keyboard.dismiss();
-			toggleView({
-				view: 'numberPadFee',
-				data: {
-					isOpen: true,
-					snapPoint: 0,
-				},
-			});
-			return (): void => {
-				toggleView({
-					view: 'numberPadFee',
-					data: {
-						isOpen: false,
-					},
-				});
-			};
-		}, []),
-	);
+	if (satsPerByte !== 0) {
+		onDone = (): void => {
+			navigation.navigate('ReviewAndSend');
+		};
+	}
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader
 				title="Set Custom Fee"
-				displayBackButton={transaction.satsPerByte !== 0}
+				displayBackButton={satsPerByte !== 0}
 			/>
 			<View style={styles.content}>
 				<Caption13Up color="gray1" style={styles.title}>
 					SAT / VBYTE
 				</Caption13Up>
 				<FeeCustomToggle />
-
-				<View style={nextButtonContainer}>
-					<Button
-						size="large"
-						text="Done"
-						disabled={transaction.satsPerByte === 0}
-						onPress={(): void => navigation.navigate('ReviewAndSend')}
-					/>
-				</View>
+				<FeeNumberPad style={styles.numberPad} onDone={onDone} />
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 
@@ -79,9 +47,9 @@ const styles = StyleSheet.create({
 	title: {
 		marginBottom: 16,
 	},
-	nextButtonContainer: {
+	numberPad: {
 		marginTop: 'auto',
-		paddingHorizontal: 16,
+		maxHeight: 350,
 	},
 });
 

--- a/src/screens/Wallets/SendOnChainTransaction/FeeCustom.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/FeeCustom.tsx
@@ -49,7 +49,7 @@ const styles = StyleSheet.create({
 	},
 	numberPad: {
 		marginTop: 'auto',
-		maxHeight: 350,
+		maxHeight: 425,
 	},
 });
 

--- a/src/screens/Wallets/SendOnChainTransaction/FeeCustomToggle.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/FeeCustomToggle.tsx
@@ -1,29 +1,17 @@
-import React, { memo, ReactElement, useCallback } from 'react';
-import { StyleSheet, Keyboard } from 'react-native';
+import React, { memo, ReactElement } from 'react';
+import { View, StyleSheet } from 'react-native';
 
-import { Display, Pressable, LightningIcon } from '../../../styles/components';
-import { toggleView } from '../../../store/actions/user';
+import { Display, LightningIcon } from '../../../styles/components';
 import { useTransactionDetails } from '../../../hooks/transaction';
 
 const FeeCustomToggle = ({ style }: { style?: object }): ReactElement => {
 	const transaction = useTransactionDetails();
 
-	const onTogglePress = useCallback(() => {
-		Keyboard.dismiss(); // in case it was opened by Address input
-		toggleView({
-			view: 'numberPadFee',
-			data: {
-				isOpen: true,
-				snapPoint: 0,
-			},
-		});
-	}, []);
-
 	return (
-		<Pressable onPress={onTogglePress} style={[styles.row, style]}>
+		<View style={[styles.row, style]}>
 			<LightningIcon height={38} style={styles.symbol} color="gray2" />
 			<Display>{transaction.satsPerByte}</Display>
-		</Pressable>
+		</View>
 	);
 };
 

--- a/src/screens/Wallets/SendOnChainTransaction/FeeNumberPad.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/FeeNumberPad.tsx
@@ -1,22 +1,23 @@
-import React, { memo, ReactElement, useMemo } from 'react';
-import { StyleSheet, Alert } from 'react-native';
+import React, { memo, ReactElement } from 'react';
+import { Alert } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import NumberPad from '../../../components/NumberPad';
-import { View, TouchableOpacity, Text02B } from '../../../styles/components';
-import BottomSheetWrapper from '../../../components/BottomSheetWrapper';
 import Store from '../../../store/types';
 import { useTransactionDetails } from '../../../hooks/transaction';
 import { updateFee } from '../../../utils/wallet/transactions';
-import { toggleView } from '../../../store/actions/user';
-import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
+import NumberPadButtons from '../NumberPadButtons';
 
 /**
  * Handles the number pad logic (add/remove/clear) for on-chain fee.
  */
-const FeeNumberPad = (): ReactElement => {
-	const snapPoints = useMemo(() => [375], []);
-
+const FeeNumberPad = ({
+	style,
+	onDone,
+}: {
+	style?: object | Array<object>;
+	onDone?: () => void;
+}): ReactElement => {
 	const selectedWallet = useSelector(
 		(store: Store) => store.wallet.selectedWallet,
 	);
@@ -24,8 +25,6 @@ const FeeNumberPad = (): ReactElement => {
 		(store: Store) => store.wallet.selectedNetwork,
 	);
 	const transaction = useTransactionDetails();
-
-	useBottomSheetBackPress('numberPadFee');
 
 	// Add, shift and update the current transaction amount based on the provided fiat value or bitcoin unit.
 	const onPress = (key): void => {
@@ -63,44 +62,14 @@ const FeeNumberPad = (): ReactElement => {
 	};
 
 	return (
-		<BottomSheetWrapper
-			snapPoints={snapPoints}
-			backdrop={false}
-			view="numberPadFee">
-			<NumberPad onPress={onPress} onRemove={onRemove}>
-				<View style={styles.topRow}>
-					<TouchableOpacity
-						style={styles.topRowButtons}
-						color="onSurface"
-						onPress={(): void => {
-							toggleView({ view: 'numberPadFee', data: { isOpen: false } });
-						}}>
-						<Text02B size="12px" color="brand">
-							DONE
-						</Text02B>
-					</TouchableOpacity>
-				</View>
-			</NumberPad>
-		</BottomSheetWrapper>
+		<NumberPad
+			style={style}
+			showDot={false}
+			onPress={onPress}
+			onRemove={onRemove}>
+			<NumberPadButtons showUnitButton={false} onDone={onDone} />
+		</NumberPad>
 	);
 };
-
-const styles = StyleSheet.create({
-	topRow: {
-		flexDirection: 'row',
-		alignItems: 'center',
-		justifyContent: 'flex-end',
-		paddingVertical: 5,
-		paddingHorizontal: 5,
-	},
-	topRowButtons: {
-		paddingVertical: 5,
-		paddingHorizontal: 8,
-		borderRadius: 8,
-		flexDirection: 'row',
-		justifyContent: 'center',
-		alignItems: 'center',
-	},
-});
 
 export default memo(FeeNumberPad);

--- a/src/screens/Wallets/SendOnChainTransaction/FeeRate.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/FeeRate.tsx
@@ -3,8 +3,9 @@ import { StyleSheet, View, Alert } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import { Caption13Up, View as ThemedView } from '../../../styles/components';
+import { Caption13Up } from '../../../styles/components';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
 import Button from '../../../components/Button';
 import Store from '../../../store/types';
 import { EFeeIds } from '../../../store/types/fees';
@@ -135,7 +136,7 @@ const FeeRate = ({ navigation }): ReactElement => {
 	}, [satsPerByte, navigation, onCardPress]);
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader title="Speed" />
 			<View style={styles.content}>
 				<Caption13Up color="gray1" style={styles.title}>
@@ -199,7 +200,7 @@ const FeeRate = ({ navigation }): ReactElement => {
 					/>
 				</View>
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Wallets/SendOnChainTransaction/Result.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/Result.tsx
@@ -3,12 +3,9 @@ import { StyleSheet, View, Image } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Lottie from 'lottie-react-native';
 
-import {
-	View as ThemedView,
-	Subtitle,
-	Text01S,
-} from '../../../styles/components';
+import { Subtitle, Text01S } from '../../../styles/components';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
 import Button from '../../../components/Button';
 import Glow from '../../../components/Glow';
 import { toggleView } from '../../../store/actions/user';
@@ -42,7 +39,7 @@ const Result = ({ navigation, route }): ReactElement => {
 	};
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			{success && (
 				<Lottie
 					source={require('../../../assets/lottie/confetti-green.json')}
@@ -84,7 +81,7 @@ const Result = ({ navigation, route }): ReactElement => {
 					onPress={handleButtonPress}
 				/>
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Wallets/SendOnChainTransaction/ReviewAndSend.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/ReviewAndSend.tsx
@@ -18,9 +18,9 @@ import {
 	PenIcon,
 	Text02M,
 	TimerIcon,
-	View as ThemedView,
 } from '../../../styles/components';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
 import SwipeToConfirm from '../../../components/SwipeToConfirm';
 import AmountToggle from '../../../components/AmountToggle';
 import Tag from '../../../components/Tag';
@@ -408,7 +408,7 @@ const ReviewAndSend = ({ navigation, index = 0 }): ReactElement => {
 	}, [customDescription, selectedFeeId]);
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader title="Review & Send" />
 			<View style={styles.content}>
 				<AmountToggle sats={amount} style={styles.amountToggle} />
@@ -483,7 +483,7 @@ const ReviewAndSend = ({ navigation, index = 0 }): ReactElement => {
 					/>
 				</View>
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/screens/Wallets/SendOnChainTransaction/ReviewAndSend.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/ReviewAndSend.tsx
@@ -382,8 +382,7 @@ const ReviewAndSend = ({ navigation, index = 0 }): ReactElement => {
 
 	const feeSats = getFee(satsPerByte);
 	const totalFeeDisplay = useDisplayValues(feeSats);
-
-	let feeAmount =
+	const feeAmount =
 		totalFeeDisplay.fiatFormatted !== '—'
 			? ` (${totalFeeDisplay.fiatSymbol} ${totalFeeDisplay.fiatFormatted})`
 			: '';

--- a/src/screens/Wallets/SendOnChainTransaction/SendNumberPad.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/SendNumberPad.tsx
@@ -29,7 +29,7 @@ import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
  * Handles the number pad logic (add/remove/clear) for on-chain transactions.
  */
 const SendNumberPad = (): ReactElement => {
-	const snapPoints = useMemo(() => [375], []);
+	const snapPoints = useMemo(() => [425], []);
 	const [decimalMode, setDecimalMode] = useState(false);
 	const [prefixZeros, setPrefixZeros] = useState(0);
 
@@ -220,9 +220,10 @@ const SendNumberPad = (): ReactElement => {
 
 	return (
 		<BottomSheetWrapper
+			view="numberPadSend"
 			snapPoints={snapPoints}
 			backdrop={false}
-			view="numberPadSend">
+			backgroundStartColor="black">
 			<NumberPad showDot={showDot} onPress={onPress} onRemove={onRemove}>
 				<AmountButtonRow
 					onDone={(): void => {

--- a/src/screens/Wallets/SendOnChainTransaction/SendNumberPad.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/SendNumberPad.tsx
@@ -10,6 +10,7 @@ import { useSelector } from 'react-redux';
 import {
 	getTransactionOutputValue,
 	updateAmount,
+	sendMax,
 } from '../../../utils/wallet/transactions';
 import AmountButtonRow from '../AmountButtonRow';
 import NumberPad from '../../../components/NumberPad';
@@ -226,6 +227,9 @@ const SendNumberPad = (): ReactElement => {
 			backgroundStartColor="black">
 			<NumberPad showDot={showDot} onPress={onPress} onRemove={onRemove}>
 				<AmountButtonRow
+					onMaxPress={(): void => {
+						sendMax({});
+					}}
 					onDone={(): void => {
 						toggleView({ view: 'numberPadSend', data: { isOpen: false } });
 					}}

--- a/src/screens/Wallets/SendOnChainTransaction/SendNumberPad.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/SendNumberPad.tsx
@@ -12,7 +12,7 @@ import {
 	updateAmount,
 	sendMax,
 } from '../../../utils/wallet/transactions';
-import AmountButtonRow from '../AmountButtonRow';
+import NumberPadButtons from '../NumberPadButtons';
 import NumberPad from '../../../components/NumberPad';
 import BottomSheetWrapper from '../../../components/BottomSheetWrapper';
 import { toggleView } from '../../../store/actions/user';
@@ -226,7 +226,7 @@ const SendNumberPad = (): ReactElement => {
 			backdrop={false}
 			backgroundStartColor="black">
 			<NumberPad showDot={showDot} onPress={onPress} onRemove={onRemove}>
-				<AmountButtonRow
+				<NumberPadButtons
 					onMaxPress={(): void => {
 						sendMax({});
 					}}

--- a/src/screens/Wallets/SendOnChainTransaction/Tags.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/Tags.tsx
@@ -2,12 +2,9 @@ import React, { memo, ReactElement, useState } from 'react';
 import { StyleSheet, View, Alert } from 'react-native';
 import { useSelector } from 'react-redux';
 
-import {
-	BottomSheetTextInput,
-	Caption13Up,
-	View as ThemedView,
-} from '../../../styles/components';
+import { BottomSheetTextInput, Caption13Up } from '../../../styles/components';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
 import Tag from '../../../components/Tag';
 import Store from '../../../store/types';
 import { addTxTag } from '../../../store/actions/wallet';
@@ -44,7 +41,7 @@ const AddressAndAmount = ({ navigation }): ReactElement => {
 	};
 
 	return (
-		<ThemedView color="onSurface" style={styles.container}>
+		<GradientView style={styles.container}>
 			<BottomSheetNavigationHeader title="Add Tag" />
 			<View style={styles.content}>
 				{lastUsedTags.length !== 0 && (
@@ -77,7 +74,7 @@ const AddressAndAmount = ({ navigation }): ReactElement => {
 					returnKeyType="done"
 				/>
 			</View>
-		</ThemedView>
+		</GradientView>
 	);
 };
 

--- a/src/store/shapes/user.ts
+++ b/src/store/shapes/user.ts
@@ -26,7 +26,6 @@ export const defaultUserShape = {
 		PINPrompt: { ...defaultViewController },
 		PINNavigation: { ...defaultViewController },
 		numberPadSend: { ...defaultViewController },
-		numberPadFee: { ...defaultViewController },
 		numberPadReceive: { ...defaultViewController },
 		boostPrompt: { ...defaultViewController },
 		activityTagsPrompt: { ...defaultViewController },

--- a/src/store/types/user.ts
+++ b/src/store/types/user.ts
@@ -5,7 +5,6 @@ export type TViewController =
 	| 'sendNavigation'
 	| 'receiveNavigation'
 	| 'numberPadSend'
-	| 'numberPadFee'
 	| 'numberPadReceive'
 	| 'backupPrompt'
 	| 'backupNavigation'

--- a/src/utils/todos/index.ts
+++ b/src/utils/todos/index.ts
@@ -173,7 +173,7 @@ export const handleOnPress = ({
 	try {
 		switch (type) {
 			case 'activateBackup':
-				navigation.navigate('Settings', { screen: 'BackupSettings' });
+				navigation.navigate('Settings', { screen: 'BackupData' });
 				break;
 			case 'pin':
 				toggleView({


### PR DESCRIPTION
### Changes
- fix BottomSheets background gradients
- move `FeeNumberPad` out of its own BottomSheet (as per design)
- fix NumberPadLightning top button styles
- fix Online Backup Todo link
- rename `BackupMenu` -> `BackupSettings` for consistency

### Preview
<img src="https://user-images.githubusercontent.com/8538369/192512896-1ef1c76b-c750-4e3a-9f16-38017e113b58.png" width="33%" />
<img src="https://user-images.githubusercontent.com/8538369/192548202-a104a9c0-9920-4d75-8bd2-c41fc6a4261e.png" width="33%" />
<img src="https://user-images.githubusercontent.com/8538369/192548212-02329069-fe4b-4cfa-8304-5e7119efbe42.png" width="33%" />

