### PR TITLE
feat: send to slashtag url

### DIFF
--- a/src/screens/Scanner/MainScanner.tsx
+++ b/src/screens/Scanner/MainScanner.tsx
@@ -10,6 +10,7 @@ import { showErrorNotification } from '../../utils/notifications';
 import ScannerComponent from './ScannerComponent';
 import type { RootStackScreenProps } from '../../navigation/types';
 import DetectSwipe from '../../components/DetectSwipe';
+import { useSlashtagsSDK } from '../../components/SlashtagsProvider';
 
 const ScannerScreen = ({
 	navigation,
@@ -22,6 +23,7 @@ const ScannerScreen = ({
 	const selectedWallet = useSelector(
 		(state: Store) => state.wallet.selectedWallet,
 	);
+	const sdk = useSlashtagsSDK();
 
 	const onSwipeRight = (): void => {
 		navigation.navigate('Tabs');
@@ -45,6 +47,8 @@ const ScannerScreen = ({
 
 		processInputData({
 			data,
+			source: 'mainScanner',
+			sdk,
 			selectedNetwork,
 			selectedWallet,
 		}).then();

--- a/src/screens/Wallets/SendOnChainTransaction/AddressOrSlashpay.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/AddressOrSlashpay.tsx
@@ -47,6 +47,7 @@ const AddressOrSlashpay = ({
 				autoCapitalize="none"
 				autoCorrect={false}
 				blurOnSubmit={true}
+				returnKeyType="done"
 				{...props}
 			/>
 			<View style={styles.inputActions}>{children}</View>

--- a/src/screens/Wallets/SendOnChainTransaction/Scanner.tsx
+++ b/src/screens/Wallets/SendOnChainTransaction/Scanner.tsx
@@ -7,7 +7,7 @@ import Store from '../../../store/types';
 import NavigationHeader from '../../../components/NavigationHeader';
 import ScannerComponent from '../../Scanner/ScannerComponent';
 import { showErrorNotification } from '../../../utils/notifications';
-import { updateBitcoinTransaction } from '../../../store/actions/wallet';
+import { useSlashtagsSDK } from '../../../components/SlashtagsProvider';
 
 const ScannerScreen = ({ navigation }): ReactElement => {
 	const selectedNetwork = useSelector(
@@ -16,6 +16,7 @@ const ScannerScreen = ({ navigation }): ReactElement => {
 	const selectedWallet = useSelector(
 		(state: Store) => state.wallet.selectedWallet,
 	);
+	const sdk = useSlashtagsSDK();
 
 	const onRead = async (data): Promise<void> => {
 		if (!data) {
@@ -26,16 +27,10 @@ const ScannerScreen = ({ navigation }): ReactElement => {
 			return;
 		}
 		navigation.pop();
-		// remove slashtagsurl on scan
-		await updateBitcoinTransaction({
-			selectedWallet,
-			selectedNetwork,
-			transaction: {
-				slashTagsUrl: undefined,
-			},
-		});
 		processInputData({
 			data,
+			source: 'sendScanner',
+			sdk,
 			selectedNetwork,
 			selectedWallet,
 		}).then();

--- a/src/utils/slashtags/index.ts
+++ b/src/utils/slashtags/index.ts
@@ -321,3 +321,15 @@ function checkClosed(slashtag: Slashtag): boolean {
 		return false;
 	}
 }
+
+export const validateSlashtagURL = (url: string): boolean => {
+	try {
+		const parsed = SlashURL.parse(url);
+		if (parsed.protocol === 'slash:') {
+			return true;
+		}
+		return false;
+	} catch (error) {
+		return false;
+	}
+};


### PR DESCRIPTION
Because the way we handle slashtag url now depends on the context (if you scan it from main screen, contact will be open, if you scan it from send form, we will try to get slash pay and send to it) processInputData now accepts new parameter - `source`. It also now accepts slashtagssdk, so we can resolve slashpay of remote profiles.

All other places where slashtags is used are now also use `processInputData`, this allows unified workflow

https://user-images.githubusercontent.com/155891/192774316-ee19954e-71d4-4976-8e0b-cf38514b340a.mp4

