### PR TITLE
feat(contacts): fix ContactSmall profile

### DIFF
--- a/src/components/ContactSmall.tsx
+++ b/src/components/ContactSmall.tsx
@@ -2,7 +2,7 @@ import React, { memo } from 'react';
 import { StyleSheet } from 'react-native';
 
 import { Text02M, TouchableOpacity } from '../styles/components';
-import { useSlashtags } from '../components/SlashtagsProvider';
+import { useProfile } from '../hooks/slashtags';
 import ProfileImage from './ProfileImage';
 
 export const ContactSmall = ({
@@ -12,7 +12,7 @@ export const ContactSmall = ({
 	url: string;
 	onPress?: Function;
 }): JSX.Element => {
-	const profile = useSlashtags().contacts[url];
+	const { profile } = useProfile(url);
 
 	return (
 		<TouchableOpacity

--- a/src/components/ContactsList.tsx
+++ b/src/components/ContactsList.tsx
@@ -21,10 +21,6 @@ const ContactItem = ({
 }): JSX.Element => {
 	const { profile } = useProfile(contact.url);
 
-	const name = useMemo(() => {
-		return contact?.name ?? profile?.name ?? ' ';
-	}, [contact?.name, profile?.name]);
-
 	return (
 		<TouchableOpacity
 			activeOpacity={0.8}
@@ -34,7 +30,7 @@ const ContactItem = ({
 			<ThemedView style={cstyles.container}>
 				<ProfileImage url={contact.url} image={profile?.image} size={48} />
 				<View style={cstyles.column}>
-					<Text01M style={cstyles.name}>{name}</Text01M>
+					<Text01M style={cstyles.name}>{profile?.name || ' '}</Text01M>
 					<SlashtagURL
 						color="gray"
 						url={contact.url}

--- a/src/hooks/slashtags.ts
+++ b/src/hooks/slashtags.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { SDK, SlashURL } from '@synonymdev/slashtags-sdk';
 import c from 'compact-encoding';
 
@@ -23,6 +23,7 @@ export const useSelectedSlashtag = (): {
 
 /**
  * Watchs the public profile of a local or remote slashtag by its url.
+ * Overrides name property if it is saved as a contact record!
  */
 export const useProfile = (
 	url: string,
@@ -31,6 +32,13 @@ export const useProfile = (
 	const cached = useSlashtags().profiles[url];
 	const [profile, setProfile] = useState<BasicProfile>(cached || {});
 	const [resolving, setResolving] = useState(true);
+
+	const contactRecord = useSlashtags().contacts[url];
+	const withContactRecord = useMemo(() => {
+		return contactRecord?.name
+			? { ...profile, name: contactRecord.name }
+			: profile;
+	}, [profile, contactRecord]);
 
 	const sdk = useSlashtagsSDK();
 
@@ -82,7 +90,7 @@ export const useProfile = (
 
 	return {
 		resolving,
-		profile,
+		profile: withContactRecord,
 	};
 };
 


### PR DESCRIPTION
Now `useProfile()` hook does the contact name override to make it simple to use everywhere.