### PR TITLE
Fix json

### DIFF
--- a/src/hooks/slashtags.ts
+++ b/src/hooks/slashtags.ts
@@ -1,10 +1,13 @@
 import { useEffect, useMemo, useState } from 'react';
 import { SDK, SlashURL } from '@synonymdev/slashtags-sdk';
-import c from 'compact-encoding';
 
 import { useSlashtags, useSlashtagsSDK } from '../components/SlashtagsProvider';
 import { BasicProfile, IRemote } from '../store/types/slashtags';
-import { closeDriveSession, getSelectedSlashtag } from '../utils/slashtags';
+import {
+	closeDriveSession,
+	decodeJSON,
+	getSelectedSlashtag,
+} from '../utils/slashtags';
 
 export type Slashtag = ReturnType<SDK['slashtag']>;
 
@@ -64,7 +67,7 @@ export const useProfile = (
 		async function resolve(): Promise<void> {
 			const _profile = await drive
 				.get('/profile.json')
-				.then((buf: Uint8Array) => buf && c.decode(c.json, buf))
+				.then(decodeJSON)
 				.catch(noop);
 
 			set(_profile);

--- a/src/screens/Profile/ProfileAddLink.tsx
+++ b/src/screens/Profile/ProfileAddLink.tsx
@@ -2,18 +2,17 @@ import React, { useMemo, ReactElement, useCallback } from 'react';
 import { View, StyleSheet, TouchableOpacity } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import c from 'compact-encoding';
 
 import { View as ThemedView, Text02S, Text02B } from '../../styles/components';
 import Button from '../../components/Button';
 import { useProfile, useSelectedSlashtag } from '../../hooks/slashtags';
 import LabeledInput from '../../components/LabeledInput';
 import { RootStackScreenProps } from '../../navigation/types';
-import { BasicProfile } from '../../store/types/slashtags';
 import Store from '../../store/types';
 import { updateProfileLink } from '../../store/actions/ui';
 import NavigationHeader from '../../components/NavigationHeader';
 import SafeAreaInsets from '../../components/SafeAreaInsets';
+import { saveProfile } from '../../utils/slashtags';
 
 export const ProfileAddLinkForm = ({
 	navigation,
@@ -23,14 +22,6 @@ export const ProfileAddLinkForm = ({
 	const { url, slashtag } = useSelectedSlashtag();
 	const { profile } = useProfile(url);
 
-	const saveProfile = useCallback(
-		(data: BasicProfile) => {
-			const publicDrive = slashtag?.drivestore.get();
-			return publicDrive.put('/profile.json', c.encode(c.json, data));
-		},
-		[slashtag],
-	);
-
 	const buttonContainerStyles = useMemo(
 		() => ({
 			...styles.buttonContainer,
@@ -39,16 +30,16 @@ export const ProfileAddLinkForm = ({
 		[insets.bottom],
 	);
 
-	const saveLink = (): void => {
+	const saveLink = useCallback((): void => {
 		const prevLinks = profile?.links ?? [];
-		saveProfile({
+		saveProfile(slashtag, {
 			...profile,
 			links: [...prevLinks, { title: form.title, url: form.url }],
 		});
 
 		updateProfileLink({ title: '', url: '' });
 		navigation.goBack();
-	};
+	}, [profile, form.title, form.url, navigation, slashtag]);
 
 	const isValid = form.title?.length > 0 && form.url?.length > 0;
 

--- a/src/screens/Settings/PaymentPreference/index.tsx
+++ b/src/screens/Settings/PaymentPreference/index.tsx
@@ -51,7 +51,7 @@ const PaymentPreference = (): ReactElement => {
 				],
 			},
 		],
-		[receivePreference, enableOfflinePayments],
+		[receivePreference, enableOfflinePayments, sdk],
 	);
 
 	return (


### PR DESCRIPTION
`compact-encoding` is not the same ase `Buffer.from(JSON.stringify(json))`, but the later is expected for `.json` files.

Reverting to using the later instead of `compact-encoding`, while temporarily support old `x.json` files created by Bitkit in previous test sessions.

Should backward compatibility code should be removed before the launch but it is not really adding much overhead!