### PR TITLE
fix(lightning): Update getAccount

### DIFF
--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -246,21 +246,27 @@ export const setAccount = async ({
 
 /**
  * Retrieve LDK account info from storage.
- * @param selectedWallet
+ * @param {string} [selectedWallet]
+ * @param {TAvailableNetworks} [selectedNetwork]
  */
 export const getAccount = async ({
 	selectedWallet,
+	selectedNetwork,
 }: {
 	selectedWallet?: string;
+	selectedNetwork?: TAvailableNetworks;
 }): Promise<Result<TAccount>> => {
 	if (!selectedWallet) {
 		selectedWallet = getSelectedWallet();
+	}
+	if (!selectedNetwork) {
+		selectedNetwork = getSelectedNetwork();
 	}
 	const mnemonicPhrase = await getMnemonicPhrase(selectedWallet);
 	if (mnemonicPhrase.isErr()) {
 		return err(mnemonicPhrase.error.message);
 	}
-	const name = `${selectedWallet}${LDK_ACCOUNT_SUFFIX}`;
+	const name = `${selectedWallet}${selectedNetwork}${LDK_ACCOUNT_SUFFIX}`;
 	try {
 		let result = await Keychain.getGenericPassword({ service: name });
 		if (result && result?.password) {


### PR DESCRIPTION
This PR:
- Adds `selectedNetwork` to `getAccount` to separate each Bitcoin network's LDK storage from each other.