### PR TITLE
feat(wallet): Display Available Amount

### DIFF
--- a/src/components/AmountToggle.tsx
+++ b/src/components/AmountToggle.tsx
@@ -16,6 +16,7 @@ const AmountToggle = ({
 	reverse = false,
 	space = 0, // space between the rows
 	disable = false,
+	children,
 }: {
 	sats: number;
 	style?: object;
@@ -23,6 +24,7 @@ const AmountToggle = ({
 	reverse?: boolean;
 	space?: number;
 	disable?: boolean;
+	children?: ReactElement;
 }): ReactElement => {
 	const primary = useSelector((state: Store) => state.settings.unitPreference);
 
@@ -60,6 +62,7 @@ const AmountToggle = ({
 	return (
 		<Pressable onPress={_onPress} color="transparent" style={style}>
 			{components}
+			{children}
 		</Pressable>
 	);
 };

--- a/src/screens/Wallets/Send/SendNumberPad.tsx
+++ b/src/screens/Wallets/Send/SendNumberPad.tsx
@@ -211,7 +211,7 @@ const SendNumberPad = ({ onDone }: { onDone: () => void }): ReactElement => {
 		<NumberPad showDot={showDot} onPress={onPress} onRemove={onRemove}>
 			<NumberPadButtons
 				onMaxPress={(): void => {
-					sendMax({});
+					sendMax({ selectedWallet, selectedNetwork });
 				}}
 				onDone={onDone}
 			/>

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -1479,10 +1479,7 @@ export const sendMax = ({
 		const outputs = transaction?.outputs ?? [];
 		// No address specified, attempt to assign the address currently specified in the current output index.
 		if (!address) {
-			address = outputs[index]?.address;
-		}
-		if (!address) {
-			return err('No address provided.');
+			address = outputs[index]?.address ?? '';
 		}
 
 		const inputTotal = getTransactionInputValue({


### PR DESCRIPTION
This PR:
- Displays the available amount for either an on-chain or lightning payment when creating a transaction.
- This closes #492.
- Fixes the `sendMax` method to work as expected when an address is not yet set.

Notes:
- It is only visible when the number pad is open.
- It will default to the on-chain balance if no address or lightning invoice is set.
- If a lightning invoice is set, it will display the available lightning amount accordingly. Otherwise, it will display the available on-chain amount minus the base tx fee.
- The available amount unit preference toggles to the preferred unit/value as expected.

![Simulator Screen Shot - iPhone 13 - 2022-10-12 at 13 04 58](https://user-images.githubusercontent.com/8532651/195407809-198a257b-5a0b-4fb2-b30d-626de3061cd9.png)
