### PR TITLE
fix(lightning): Use NewTxPrompt For Lightning

### DIFF
--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -155,8 +155,7 @@ export const startWalletServices = async ({
 				]);
 
 				// Setup LDK.
-				// TODO: Remove regtest condition once LDK is enabled for mainnet and testnet.
-				if (lightning && selectedNetwork === 'bitcoinRegtest') {
+				if (lightning) {
 					// Start LDK
 					const setupResponse = await setupLdk({ selectedNetwork });
 					if (setupResponse.isOk()) {


### PR DESCRIPTION
This PR:
- Switches to using the `NewTxPrompt` component when receiving lightning payments, resembling that of on-chain payments.
- Removes regtest network condition for lightning on startup.