### PR TITLE
fix: recreate wallet from seed if we have it in Keystore

### DIFF
--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -137,16 +137,20 @@ export const startWalletServices = async ({
 
 			const walletExists = await checkWalletExists();
 			const walletKeys = Object.keys(wallets);
-			if (
-				!walletExists ||
-				!wallets[walletKeys[0]] ||
-				!wallets[walletKeys[0]]?.id
-			) {
+			if (!walletExists) {
+				// generate new wallet if no exsits
 				const mnemonic = await generateMnemonic();
 				if (!mnemonic) {
 					return err('Unable to generate mnemonic.');
 				}
 				await createWallet({ mnemonic });
+			} else if (!wallets[walletKeys[0]]?.id) {
+				// if we have a mnemonic in store, but not in redux, we need to init it
+				const mnemonic = await getMnemonicPhrase();
+				if (mnemonic.isErr()) {
+					return err('Unable to get mnemonic.');
+				}
+				await createWallet({ mnemonic: mnemonic.value });
 			}
 
 			// We need to start Electrum if either onchain or lightning is true.


### PR DESCRIPTION
I'm trying to fix an issue when app gets reinstalled on iOS device. Currently it generates new seed and instantly opens main screen skipping onboarding.

I think expected behavior would be to recover the wallet, since we have it in Keystore.

Another option would be to check if we have any wallets in redux. If no, then it is a fresh install and we can just wipe Keystore.