### PR TITLE
fix: Electrum Server connection notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,9 @@ if (Platform.OS === 'android') {
 
 const App = (): ReactElement => {
 	const isOnline = useSelector((state: Store) => state.user.isOnline);
+	const isConnectedToElectrum = useSelector(
+		(state: Store) => state.user.isConnectedToElectrum,
+	);
 	const walletExists = useSelector((state: Store) => state.wallet.walletExists);
 	const theme = useSelector((state: Store) => state.settings.theme);
 
@@ -60,27 +63,34 @@ const App = (): ReactElement => {
 			}
 		})();
 
+		return () => {
+			unsubscribeFromLightningPayments();
+		};
+	}, []);
+
+	useEffect(() => {
 		const unsubscribeElectrum = electrumConnection.subscribe((isConnected) => {
-			if (isConnected) {
+			if (!isConnectedToElectrum && isConnected) {
 				updateUser({ isConnectedToElectrum: isConnected });
-				showSuccessNotification({
-					title: 'Electrum Server Reconnected',
-					message: 'Successfully reconnected to Electrum Server.',
-				});
-			} else {
+				// showSuccessNotification({
+				// 	title: 'Bitkit Connection Restored',
+				// 	message: 'Successfully reconnected to Electrum Server.',
+				// });
+			}
+
+			if (isConnectedToElectrum && !isConnected) {
 				updateUser({ isConnectedToElectrum: isConnected });
-				showErrorNotification({
-					title: 'Electrum Connectivity Issues',
-					message: 'Lost connection to server, trying to reconnect...',
-				});
+				// showErrorNotification({
+				// 	title: 'Bitkit Is Reconnecting',
+				// 	message: 'Lost connection to server, trying to reconnect...',
+				// });
 			}
 		});
 
 		return () => {
 			unsubscribeElectrum();
-			unsubscribeFromLightningPayments();
 		};
-	}, []);
+	}, [isConnectedToElectrum]);
 
 	useEffect(() => {
 		// subscribe to connection information

--- a/src/screens/Settings/ElectrumConfig/index.tsx
+++ b/src/screens/Settings/ElectrumConfig/index.tsx
@@ -203,7 +203,7 @@ const ElectrumConfig = ({
 			} else {
 				updateUser({ isConnectedToElectrum: false });
 				showErrorNotification({
-					title: 'Unable to connect to Electrum Server.',
+					title: 'Unable to connect to Electrum Server',
 					message: connectResponse.error.message,
 				});
 			}

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -118,7 +118,7 @@ export const startWalletServices = async ({
 				});
 				if (electrumResponse.isErr()) {
 					showErrorNotification({
-						title: 'Unable to connect to Electrum Server.',
+						title: 'Unable to connect to Electrum Server',
 						message:
 							electrumResponse?.error?.message ??
 							'Unable to connect to Electrum Server',


### PR DESCRIPTION
Closes https://github.com/synonymdev/bitkit/issues/341 https://github.com/synonymdev/bitkit/issues/363

### Changes
- Add "Retry" button for "ConnectivityIndicator"
- only show Electrum Server connection notifications when the user manually tries to reconnect

### Notes
This is more of a quickfix until I can figure out how to actually reach the desired solution. Instead of spamming these toasts we now let the user discover the notification by themself by clicking the Retry button on the home screen. We still try to reconnect every few seconds in the background.
