### PR TITLE
Default to Mainnet

### DIFF
--- a/src/screens/Settings/Lightning/LightningNodeInfo.tsx
+++ b/src/screens/Settings/Lightning/LightningNodeInfo.tsx
@@ -23,16 +23,11 @@ const LightningNodeInfo = (): ReactElement => {
 
 	useEffect(() => {
 		(async (): Promise<void> => {
-			// TODO: Remove if condition once testnet and mainnet are enabled.
-			if (selectedNetwork === 'bitcoinRegtest') {
-				const id = await getNodeId();
-				if (id.isOk()) {
-					setNodeId(id.value);
-				} else {
-					setNodeId(id.error.message);
-				}
+			const id = await getNodeId();
+			if (id.isOk()) {
+				setNodeId(id.value);
 			} else {
-				setNodeId('LDK is only enabled for regtest at this time.');
+				setNodeId(id.error.message);
 			}
 		})();
 	}, [selectedNetwork]);
@@ -44,8 +39,6 @@ const LightningNodeInfo = (): ReactElement => {
 
 			<View style={styles.content} color="black">
 				<TouchableOpacity
-					// TODO: Remove disabled condition once testnet and mainnet are enabled.
-					disabled={selectedNetwork !== 'bitcoinRegtest'}
 					onPress={(): void => {
 						Clipboard.setString(nodeId);
 						showSuccessNotification({

--- a/src/store/reducers/settings.ts
+++ b/src/store/reducers/settings.ts
@@ -6,7 +6,7 @@ const settings = (
 	state: ISettings = defaultSettingsShape,
 	action,
 ): ISettings => {
-	let selectedNetwork = state.selectedNetwork;
+	let selectedNetwork = 'bitcoin';
 	if (action.payload?.selectedNetwork) {
 		selectedNetwork = action.payload.selectedNetwork;
 	}

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -75,7 +75,6 @@ export const defaultSettingsShape: ISettings = {
 	balanceUnit: 'satoshi', //BTC, mBTC, μBTC or satoshi
 	selectedCurrency: 'USD',
 	selectedLanguage: 'english',
-	selectedNetwork: 'bitcoinRegtest',
 	customElectrumPeers,
 	coinSelectAuto: true,
 	coinSelectPreference: 'small',

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -167,7 +167,7 @@ export const defaultWalletStoreShape: IWallet = {
 	loading: true,
 	walletExists: false,
 	error: false,
-	selectedNetwork: 'bitcoinRegtest',
+	selectedNetwork: 'bitcoin',
 	selectedWallet: EWallet.defaultWallet,
 	addressTypes: { ...addressTypes },
 	exchangeRates: {},

--- a/src/store/types/settings.ts
+++ b/src/store/types/settings.ts
@@ -42,7 +42,6 @@ export interface ISettings {
 	customElectrumPeers: IWalletItem<ICustomElectrumPeer[]> | IWalletItem<[]>;
 	selectedCurrency: string;
 	selectedLanguage: string;
-	selectedNetwork: string;
 	coinSelectAuto: boolean;
 	coinSelectPreference: TCoinSelectPreference;
 	receivePreference: TReceiveOption[];

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -70,13 +70,13 @@ export const parseOnChainPaymentRequest = (
 		if (!data) {
 			return err(data);
 		}
+		if (!selectedNetwork) {
+			selectedNetwork = getSelectedNetwork();
+		}
 
 		let validateAddressResult = validateAddress({
 			address: data,
-			selectedNetwork:
-				selectedNetwork === 'bitcoinRegtest'
-					? EAvailableNetworks[selectedNetwork]
-					: undefined,
+			selectedNetwork: EAvailableNetworks[selectedNetwork],
 		});
 
 		if (


### PR DESCRIPTION
This PR:
- Removes all mainnet restrictions throughout the app.
- Defaults app to mainnet.

If we wish to test on regtest or testnet after this PR we can do so by navigating to:
- Settings->Networks->Bitcoin Network