### PR TITLE
fix(wallet): Update Broadcast Params

### DIFF
--- a/src/screens/Blocktank/Payment.tsx
+++ b/src/screens/Blocktank/Payment.tsx
@@ -30,6 +30,7 @@ import { hasEnabledAuthentication } from '../../utils/settings';
 import NavigationHeader from '../../components/NavigationHeader';
 import SafeAreaView from '../../components/SafeAreaView';
 import { RootStackParamList } from '../../navigation/types';
+import { refreshWallet } from '../../utils/wallet';
 
 type Props = StackScreenProps<RootStackParamList, 'BlocktankPayment'>;
 
@@ -140,6 +141,7 @@ const BlocktankPayment = (props: Props): ReactElement => {
 		const res = await broadcastTransaction({
 			rawTx,
 			selectedNetwork,
+			subscribeToOutputAddress: false,
 		});
 
 		if (res.isErr()) {
@@ -163,6 +165,7 @@ const BlocktankPayment = (props: Props): ReactElement => {
 
 		await resetStore();
 		onClose();
+		refreshWallet({ onchain: true, lightning: false }).then();
 	};
 
 	const resetStore = async (): Promise<void> => {

--- a/src/store/actions/blocktank.ts
+++ b/src/store/actions/blocktank.ts
@@ -17,6 +17,7 @@ import {
 	getBalance,
 	getSelectedNetwork,
 	getSelectedWallet,
+	refreshWallet,
 } from '../../utils/wallet';
 import { EAvailableNetworks, TAvailableNetworks } from '../../utils/networks';
 import { sleep } from '../../utils/helpers';
@@ -489,6 +490,7 @@ export const confirmChannelPurchase = async ({
 	const broadcastResponse = await broadcastTransaction({
 		rawTx: rawTx.value.hex,
 		selectedNetwork,
+		subscribeToOutputAddress: false,
 	});
 	if (broadcastResponse.isErr()) {
 		showErrorNotification({
@@ -511,5 +513,6 @@ export const confirmChannelPurchase = async ({
 		description: 'Ready in ±20min',
 	};
 	addTodo(todo);
+	refreshWallet({ onchain: true, lightning: false }).then();
 	return ok(broadcastResponse.value);
 };

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -145,6 +145,7 @@ export const setupLdk = async ({
 				rawTx,
 				selectedNetwork,
 				selectedWallet,
+				subscribeToOutputAddress: false,
 			});
 			if (res.isErr()) {
 				return '';
@@ -166,6 +167,7 @@ export const setupLdk = async ({
 			broadcastTransaction: _broadcastTransaction,
 			getTransactionData,
 			network,
+			feeRate: 0,
 		});
 
 		if (lmStart.isErr()) {

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -871,7 +871,7 @@ export const broadcastTransaction = async ({
 		if (transaction.isErr()) {
 			return err(transaction.error.message);
 		}
-		const address = transaction.value.outputs?.[0].address;
+		const address = transaction.value.outputs?.[0]?.address;
 		if (address) {
 			const scriptHash = await getScriptHash(address, selectedNetwork);
 			if (scriptHash) {
@@ -884,7 +884,6 @@ export const broadcastTransaction = async ({
 	}
 
 	const broadcastResponse = await electrum.broadcastTransaction({
-		id: 1,
 		rawTx,
 		network: selectedNetwork,
 	});


### PR DESCRIPTION
This PR:
- Sets `subscribeToOutputAddress` to `false` where needed.
- Improves check condition for address in `broadcastTransaction` method.
- Sets `feeRate` to `0` to prevent fee rate consensus conflicts on channel close.