### PR TITLE
feat(send): auto parse clipboard payment data on App open

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,27 +10,19 @@ import React, {
 } from 'react';
 import { Platform, UIManager, NativeModules } from 'react-native';
 import { useSelector } from 'react-redux';
-import NetInfo from '@react-native-community/netinfo';
 import Toast from 'react-native-toast-message';
-
 import { ThemeProvider } from 'styled-components/native';
-import { SafeAreaProvider } from './styles/components';
-import { StatusBar } from './styles/components';
-import RootNavigator from './navigation/root/RootNavigator';
+
+import { SafeAreaProvider, StatusBar } from './styles/components';
 import Store from './store/types';
-import { closeAllViews, updateUser } from './store/actions/user';
 import themes from './styles/themes';
-import './utils/translations';
+import { TTheme } from './store/types/settings';
 import OnboardingNavigator from './navigation/onboarding/OnboardingNavigator';
-import { checkWalletExists, startWalletServices } from './utils/startup';
 import { SlashtagsProvider } from './components/SlashtagsProvider';
-import { electrumConnection } from './utils/electrum';
-import {
-	showErrorNotification,
-	showSuccessNotification,
-} from './utils/notifications';
 import { toastConfig } from './components/Toast';
-import { unsubscribeFromLightningSubscriptions } from './utils/lightning';
+import AppOnboarded from './AppOnboarded';
+
+import './utils/translations';
 
 if (Platform.OS === 'android') {
 	if (UIManager.setLayoutAnimationEnabledExperimental) {
@@ -39,93 +31,23 @@ if (Platform.OS === 'android') {
 }
 
 const App = (): ReactElement => {
-	const isOnline = useSelector((state: Store) => state.user.isOnline);
-	const isConnectedToElectrum = useSelector(
-		(state: Store) => state.user.isConnectedToElectrum,
-	);
 	const walletExists = useSelector((state: Store) => state.wallet.walletExists);
 	const theme = useSelector((state: Store) => state.settings.theme);
 
+	// on App start
 	useEffect(() => {
-		// close all BottomSheets & Modals in case user closed the app while any were open
-		closeAllViews();
-
 		// hide splash screen on android
 		if (Platform.OS === 'android') {
 			setTimeout(NativeModules.SplashScreenModule.hide, 100);
 		}
-
-		// launch wallet services
-		(async (): Promise<void> => {
-			const _walletExists = await checkWalletExists();
-			if (_walletExists) {
-				await startWalletServices({});
-			}
-		})();
-
-		return () => {
-			unsubscribeFromLightningSubscriptions();
-		};
 	}, []);
 
-	useEffect(() => {
-		const unsubscribeElectrum = electrumConnection.subscribe((isConnected) => {
-			if (!isConnectedToElectrum && isConnected) {
-				updateUser({ isConnectedToElectrum: isConnected });
-				// showSuccessNotification({
-				// 	title: 'Bitkit Connection Restored',
-				// 	message: 'Successfully reconnected to Electrum Server.',
-				// });
-			}
-
-			if (isConnectedToElectrum && !isConnected) {
-				updateUser({ isConnectedToElectrum: isConnected });
-				// showErrorNotification({
-				// 	title: 'Bitkit Is Reconnecting',
-				// 	message: 'Lost connection to server, trying to reconnect...',
-				// });
-			}
-		});
-
-		return () => {
-			unsubscribeElectrum();
-		};
-	}, [isConnectedToElectrum]);
-
-	useEffect(() => {
-		// subscribe to connection information
-		const unsubscribeNetInfo = NetInfo.addEventListener(({ isConnected }) => {
-			if (isConnected) {
-				// prevent toast from showing on startup
-				if (isOnline !== isConnected) {
-					showSuccessNotification({
-						title: 'You’re Back Online!',
-						message: 'Successfully reconnected to the Internet.',
-					});
-				}
-				updateUser({ isOnline: isConnected });
-			} else {
-				showErrorNotification({
-					title: 'Internet Connectivity Issues',
-					message: 'Please check your network connection.',
-				});
-				updateUser({ isOnline: isConnected });
-			}
-		});
-
-		return () => {
-			unsubscribeNetInfo();
-		};
-	}, [isOnline]);
-
-	const currentTheme = useMemo(() => {
-		return themes[theme];
-	}, [theme]);
+	const currentTheme: TTheme = useMemo(() => themes[theme], [theme]);
 
 	const RootComponent = useCallback((): ReactElement => {
 		return walletExists ? (
 			<SlashtagsProvider>
-				<RootNavigator />
+				<AppOnboarded />
 			</SlashtagsProvider>
 		) : (
 			<OnboardingNavigator />

--- a/src/AppOnboarded.tsx
+++ b/src/AppOnboarded.tsx
@@ -1,0 +1,145 @@
+import React, { memo, ReactElement, useEffect, useRef } from 'react';
+import { Platform, NativeModules, AppState } from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
+
+import RootNavigator from './navigation/root/RootNavigator';
+import { useSlashtagsSDK } from './components/SlashtagsProvider';
+import { closeAllViews, updateUser } from './store/actions/user';
+import { useAppSelector } from './hooks/redux';
+import { useBalance } from './hooks/wallet';
+import { startWalletServices } from './utils/startup';
+import { electrumConnection } from './utils/electrum';
+import { readClipboardInvoice } from './utils/send';
+import { unsubscribeFromLightningSubscriptions } from './utils/lightning';
+import {
+	showErrorNotification,
+	showSuccessNotification,
+} from './utils/notifications';
+
+const AppOnboarded = (): ReactElement => {
+	const appState = useRef(AppState.currentState);
+	const sdk = useSlashtagsSDK();
+	const { satoshis: onChainBalance } = useBalance({ onchain: true });
+	const { satoshis: lightningBalance } = useBalance({ lightning: true });
+	const enableAutoReadClipboard = useAppSelector(
+		(state) => state.settings.enableAutoReadClipboard,
+	);
+	const isOnline = useAppSelector((state) => state.user.isOnline);
+	const isConnectedToElectrum = useAppSelector(
+		(state) => state.user.isConnectedToElectrum,
+	);
+
+	// on App start
+	useEffect(() => {
+		// close all BottomSheets & Modals in case user closed the app while any were open
+		closeAllViews();
+
+		// hide splash screen on android
+		if (Platform.OS === 'android') {
+			setTimeout(NativeModules.SplashScreenModule.hide, 100);
+		}
+
+		// launch wallet services
+		(async (): Promise<void> => {
+			await startWalletServices({});
+
+			// check clipboard for payment data
+			if (enableAutoReadClipboard) {
+				// hack to wait for BottomSheet to be ready(?)
+				setTimeout(() => {
+					readClipboardInvoice({ onChainBalance, lightningBalance, sdk });
+				}, 100);
+			}
+		})();
+
+		return () => {
+			unsubscribeFromLightningSubscriptions();
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	// on AppState change
+	useEffect(() => {
+		const subscription = AppState.addEventListener('change', (nextAppState) => {
+			// on App to foreground
+			if (
+				appState.current.match(/inactive|background/) &&
+				nextAppState === 'active'
+			) {
+				// check clipboard for payment data
+				if (enableAutoReadClipboard) {
+					// timeout needed otherwise clipboard is empty
+					setTimeout(() => {
+						readClipboardInvoice({ onChainBalance, lightningBalance, sdk });
+					}, 1000);
+				}
+			}
+
+			// on App to background
+			if (appState.current === 'active' && nextAppState === 'background') {
+				// do something when the app goes to background
+			}
+
+			appState.current = nextAppState;
+		});
+
+		return () => {
+			subscription.remove();
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	useEffect(() => {
+		const unsubscribeElectrum = electrumConnection.subscribe((isConnected) => {
+			if (!isConnectedToElectrum && isConnected) {
+				updateUser({ isConnectedToElectrum: isConnected });
+				// showSuccessNotification({
+				// 	title: 'Bitkit Connection Restored',
+				// 	message: 'Successfully reconnected to Electrum Server.',
+				// });
+			}
+
+			if (isConnectedToElectrum && !isConnected) {
+				updateUser({ isConnectedToElectrum: isConnected });
+				// showErrorNotification({
+				// 	title: 'Bitkit Is Reconnecting',
+				// 	message: 'Lost connection to server, trying to reconnect...',
+				// });
+			}
+		});
+
+		return () => {
+			unsubscribeElectrum();
+		};
+	}, [isConnectedToElectrum]);
+
+	useEffect(() => {
+		// subscribe to connection information
+		const unsubscribeNetInfo = NetInfo.addEventListener(({ isConnected }) => {
+			if (isConnected) {
+				// prevent toast from showing on startup
+				if (isOnline !== isConnected) {
+					showSuccessNotification({
+						title: 'You’re Back Online!',
+						message: 'Successfully reconnected to the Internet.',
+					});
+				}
+				updateUser({ isOnline: isConnected });
+			} else {
+				showErrorNotification({
+					title: 'Internet Connectivity Issues',
+					message: 'Please check your network connection.',
+				});
+				updateUser({ isOnline: isConnected });
+			}
+		});
+
+		return () => {
+			unsubscribeNetInfo();
+		};
+	}, [isOnline]);
+
+	return <RootNavigator />;
+};
+
+export default memo(AppOnboarded);

--- a/src/navigation/root/RootNavigator.tsx
+++ b/src/navigation/root/RootNavigator.tsx
@@ -58,7 +58,7 @@ const navigationRef =
 /**
  * Helper function to navigate from utils.
  */
-export const navigate = (name: keyof RootStackParamList, params): void => {
+export const navigate = (name: keyof RootStackParamList, params?): void => {
 	navigationRef.current?.navigate(name, params);
 };
 

--- a/src/screens/Settings/Security/index.tsx
+++ b/src/screens/Settings/Security/index.tsx
@@ -20,7 +20,7 @@ const SecuritySettings = ({
 }: SettingsScreenProps<'SecuritySettings'>): ReactElement => {
 	const [biometryData, setBiometricData] = useState<IsSensorAvailableResult>();
 	const {
-		allowClipboard,
+		enableAutoReadClipboard,
 		enableSendAmountWarning,
 		pin,
 		biometrics,
@@ -46,9 +46,11 @@ const SecuritySettings = ({
 					{
 						title: 'Read clipboard for ease of use',
 						type: 'switch',
-						enabled: allowClipboard,
+						enabled: enableAutoReadClipboard,
 						onPress: (): void => {
-							updateSettings({ allowClipboard: !allowClipboard });
+							updateSettings({
+								enableAutoReadClipboard: !enableAutoReadClipboard,
+							});
 						},
 					},
 					{
@@ -130,7 +132,7 @@ const SecuritySettings = ({
 			},
 		],
 		[
-			allowClipboard,
+			enableAutoReadClipboard,
 			enableSendAmountWarning,
 			isBiometrySupported,
 			biometrics,

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -65,7 +65,7 @@ const defaultReceivePreference = [
 export const defaultSettingsShape: ISettings = {
 	loading: false,
 	error: false,
-	allowClipboard: false,
+	enableAutoReadClipboard: false,
 	enableSendAmountWarning: false,
 	pin: false,
 	pinOnLaunch: true,

--- a/src/store/types/settings.ts
+++ b/src/store/types/settings.ts
@@ -1,6 +1,6 @@
 import { IWalletItem, TBitcoinUnit, TBalanceUnit } from './wallet';
 
-type TTheme = 'dark' | 'light' | 'blue';
+export type TTheme = 'dark' | 'light' | 'blue';
 export type TProtocol = 'ssl' | 'tcp' | string;
 
 type TTransactionSpeed = 'normal' | 'fast' | 'slow';
@@ -27,7 +27,7 @@ type TReceiveOption = {
 export interface ISettings {
 	loading: boolean;
 	error: boolean;
-	allowClipboard: boolean;
+	enableAutoReadClipboard: boolean;
 	enableSendAmountWarning: boolean;
 	pin: boolean;
 	pinOnLaunch: boolean;

--- a/src/utils/send/index.ts
+++ b/src/utils/send/index.ts
@@ -28,6 +28,7 @@ export const readClipboardInvoice = async ({
 
 	const result = await decodeQRData(clipboardData);
 
+	// TODO: refactor processInputData to be reused here
 	if (result.isOk() && result.value.length) {
 		const { qrDataType, address, network, sats } = result.value[0];
 

--- a/src/utils/send/index.ts
+++ b/src/utils/send/index.ts
@@ -1,0 +1,77 @@
+import Clipboard from '@react-native-clipboard/clipboard';
+import SDK from '@synonymdev/slashtags-sdk';
+
+import { navigate } from '../../navigation/root/RootNavigator';
+import { toggleView } from '../../store/actions/user';
+import { updateBitcoinTransaction } from '../../store/actions/wallet';
+import { getStore } from '../../store/helpers';
+import { showSuccessNotification } from '../notifications';
+import { decodeQRData } from '../scanner';
+
+export const readClipboardInvoice = async ({
+	onChainBalance,
+	lightningBalance,
+	sdk,
+}: {
+	onChainBalance: number;
+	lightningBalance: number;
+	sdk: SDK;
+}): Promise<void> => {
+	const state = getStore();
+	const selectedNetwork = state.wallet.selectedNetwork;
+
+	const clipboardData = await Clipboard.getString();
+
+	if (!clipboardData) {
+		return;
+	}
+
+	const result = await decodeQRData(clipboardData);
+
+	if (result.isOk() && result.value.length) {
+		const { qrDataType, address, network, sats } = result.value[0];
+
+		if (network !== selectedNetwork) {
+			return;
+		}
+
+		if (!sats || sats === 0) {
+			return;
+		}
+
+		if (qrDataType === 'lightningPaymentRequest') {
+			if (lightningBalance < sats) {
+				return;
+			}
+
+			// TODO: not handled yet
+			return;
+		}
+
+		if (qrDataType === 'slashURL') {
+			console.log('sdk', sdk);
+			// TODO(?): not handled yet
+			return;
+		}
+
+		if (qrDataType === 'bitcoinAddress') {
+			if (onChainBalance < sats) {
+				return;
+			}
+
+			updateBitcoinTransaction({
+				transaction: { outputs: [{ address, value: sats, index: 0 }] },
+			});
+		}
+
+		navigate('Tabs');
+		toggleView({
+			view: 'sendNavigation',
+			data: { isOpen: true },
+		});
+		showSuccessNotification({
+			title: 'Clipboard Data Detected',
+			message: 'Bitkit redirected you to the payment screen.',
+		});
+	}
+};


### PR DESCRIPTION
### Changes
- split up `App.tsx` into `AppOnboarded.tsx` that has a wallet and the `SlashtagsContext`
- add Settings option to `enableAutoReadClipboard` on App start (and when it comes back to the foreground)
- `readClipboardInvoice` to parse clipboard payment data and navigate to Send flow

### Notes
Only on-chain for now. Couldn't test on iOS because clipboard + simulator is weird on M1. 

### Preview

https://user-images.githubusercontent.com/8538369/196679368-4b7838c0-1ccc-4877-8724-42d8c2641bf7.mov


