### PR TITLE
fix: address generation on address type switch

### DIFF
--- a/src/screens/Settings/AddressTypePreference/index.tsx
+++ b/src/screens/Settings/AddressTypePreference/index.tsx
@@ -9,6 +9,7 @@ import { capitalize } from '../../../utils/helpers';
 import { updateSelectedAddressType } from '../../../store/actions/wallet';
 import { TAddressType } from '../../../store/types/wallet';
 import { updateSettings } from '../../../store/actions/settings';
+import { updateAddressIndexes } from '../../../store/actions/wallet';
 
 const AddressTypeSettings = ({ navigation }): ReactElement => {
 	const [addressTypeState, setAddressTypeState] = useState<TAddressType>('');
@@ -81,6 +82,11 @@ const AddressTypeSettings = ({ navigation }): ReactElement => {
 						navigation.goBack();
 						updateSettings({ addressType: bitcoinUnit.value });
 						setAddressTypePreference(bitcoinUnit.value);
+						updateAddressIndexes({
+							selectedWallet,
+							selectedNetwork,
+							addressType: bitcoinUnit.value,
+						}).then();
 					},
 					hide: false,
 				})),

--- a/src/screens/Settings/General/index.tsx
+++ b/src/screens/Settings/General/index.tsx
@@ -9,6 +9,7 @@ import { updateSettings } from '../../../store/actions/settings';
 import { setupTodos } from '../../../utils/todos';
 import { resetTodo } from '../../../store/actions/todos';
 import colors from '../../../styles/colors';
+import { getSelectedAddressType } from '../../../utils/wallet';
 
 const typesDescriptions = {
 	p2wpkh: 'Bech32',
@@ -35,8 +36,12 @@ const General = ({ navigation }): ReactElement => {
 		(state: Store) => state.settings.showSuggestions,
 	);
 
-	const selectedAddressType = useSelector(
-		(store: Store) => store.settings.addressType,
+	const selectedWallet = useSelector(
+		(state: Store) => state.wallet.selectedWallet,
+	);
+
+	const selectedNetwork = useSelector(
+		(state: Store) => state.wallet.selectedNetwork,
 	);
 
 	const selectedTransactionSpeed = useSelector(
@@ -49,6 +54,15 @@ const General = ({ navigation }): ReactElement => {
 
 	const selectedBitcoinUnit = useSelector(
 		(state: Store) => state.settings.bitcoinUnit,
+	);
+
+	const selectedAddressType = useMemo(
+		(): string =>
+			getSelectedAddressType({
+				selectedWallet,
+				selectedNetwork,
+			}),
+		[selectedNetwork, selectedWallet],
 	);
 
 	const SettingsListData: IListData[] = useMemo(

--- a/src/screens/Wallets/Receive/index.tsx
+++ b/src/screens/Wallets/Receive/index.tsx
@@ -30,7 +30,10 @@ import {
 import Store from '../../../store/types';
 import { resetInvoice } from '../../../store/actions/receive';
 import { updateMetaIncTxTags } from '../../../store/actions/metadata';
-import { getReceiveAddress } from '../../../utils/wallet';
+import {
+	getReceiveAddress,
+	getSelectedAddressType,
+} from '../../../utils/wallet';
 import { getUnifiedUri } from '../../../utils/receive';
 import { refreshLdk } from '../../../utils/lightning';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
@@ -74,7 +77,14 @@ const Receive = ({ navigation }): ReactElement => {
 	const selectedNetwork = useSelector(
 		(store: Store) => store.wallet.selectedNetwork,
 	);
-	const addressType = useSelector((store: Store) => store.settings.addressType);
+	const addressType = useMemo(
+		(): string =>
+			getSelectedAddressType({
+				selectedWallet,
+				selectedNetwork,
+			}),
+		[selectedNetwork, selectedWallet],
+	);
 	const [loading, setLoading] = useState(true);
 	const [showCopy, setShowCopy] = useState(false);
 	const [receiveAddress, setReceiveAddress] = useState('');

--- a/src/screens/Wallets/Receive/index.tsx
+++ b/src/screens/Wallets/Receive/index.tsx
@@ -74,6 +74,7 @@ const Receive = ({ navigation }): ReactElement => {
 	const selectedNetwork = useSelector(
 		(store: Store) => store.wallet.selectedNetwork,
 	);
+	const addressType = useSelector((store: Store) => store.settings.addressType);
 	const [loading, setLoading] = useState(true);
 	const [showCopy, setShowCopy] = useState(false);
 	const [receiveAddress, setReceiveAddress] = useState('');
@@ -113,6 +114,7 @@ const Receive = ({ navigation }): ReactElement => {
 			const response = await generateNewReceiveAddress({
 				selectedNetwork,
 				selectedWallet,
+				addressType,
 			});
 			if (response.isOk()) {
 				console.info(`generated fresh address ${response.value.address}`);
@@ -122,13 +124,20 @@ const Receive = ({ navigation }): ReactElement => {
 			const response = getReceiveAddress({
 				selectedNetwork,
 				selectedWallet,
+				addressType,
 			});
 			if (response.isOk()) {
 				console.info(`reusing address ${response.value}`);
 				setReceiveAddress(response.value);
 			}
 		}
-	}, [amount, receiveNavigationIsOpen, selectedNetwork, selectedWallet]);
+	}, [
+		amount,
+		receiveNavigationIsOpen,
+		selectedNetwork,
+		selectedWallet,
+		addressType,
+	]);
 
 	const setInvoiceDetails = useCallback(async (): Promise<void> => {
 		if (!loading) {

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -163,7 +163,9 @@ export const updateAddressIndexes = async ({
 		);
 	}
 
-	addressTypesToCheck.map(async (addressTypeKey) => {
+	let updated = false;
+
+	const promises = addressTypesToCheck.map(async (addressTypeKey) => {
 		if (!selectedNetwork) {
 			selectedNetwork = getSelectedNetwork();
 		}
@@ -176,7 +178,7 @@ export const updateAddressIndexes = async ({
 			addressType: addressTypeKey,
 		});
 		if (response.isErr()) {
-			return err(response.error);
+			throw response.error;
 		}
 
 		const { type } = addressTypes[addressTypeKey];
@@ -226,10 +228,17 @@ export const updateAddressIndexes = async ({
 					addressType: addressTypeKey,
 				},
 			});
-			return ok('Successfully updated indexes.');
+			updated = true;
 		}
 	});
-	return ok('No update needed.');
+
+	try {
+		await Promise.all(promises);
+	} catch (e) {
+		return err(e);
+	}
+
+	return ok(updated ? 'Successfully updated indexes.' : 'No update needed.');
 };
 
 export const generateNewReceiveAddress = async ({

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -235,7 +235,7 @@ export const updateAddressIndexes = async ({
 export const generateNewReceiveAddress = async ({
 	selectedWallet,
 	selectedNetwork,
-	addressType = EWallet.addressType,
+	addressType,
 	keyDerivationPath,
 }: {
 	selectedWallet?: string;
@@ -249,6 +249,9 @@ export const generateNewReceiveAddress = async ({
 		}
 		if (!selectedNetwork) {
 			selectedNetwork = getSelectedNetwork();
+		}
+		if (!addressType) {
+			addressType = getSelectedAddressType({ selectedNetwork, selectedWallet });
 		}
 		const addressTypes = getAddressTypes();
 		const { currentWallet } = getCurrentWallet({
@@ -361,7 +364,7 @@ export const addAddresses = async ({
 	addressIndex = 0,
 	changeAddressIndex = 0,
 	selectedNetwork,
-	addressType = EWallet.addressType,
+	addressType,
 	keyDerivationPath,
 }: IGenerateAddresses): Promise<Result<IGenerateAddressesResponse>> => {
 	if (!selectedWallet) {
@@ -369,6 +372,9 @@ export const addAddresses = async ({
 	}
 	if (!selectedNetwork) {
 		selectedNetwork = getSelectedNetwork();
+	}
+	if (!addressType) {
+		addressType = getSelectedAddressType({ selectedWallet, selectedNetwork });
 	}
 	const addressTypes = getAddressTypes();
 	const { path, type } = addressTypes[addressType];

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -88,6 +88,5 @@ export const defaultSettingsShape: ISettings = {
 	hideBalance: false,
 	hideOnboardingMessage: false,
 	hideBeta: false,
-	addressType: 'p2wpkh',
 	enableDevOptions: false,
 };

--- a/src/store/types/settings.ts
+++ b/src/store/types/settings.ts
@@ -1,9 +1,4 @@
-import {
-	IWalletItem,
-	TBitcoinUnit,
-	TBalanceUnit,
-	TAddressType,
-} from './wallet';
+import { IWalletItem, TBitcoinUnit, TBalanceUnit } from './wallet';
 
 type TTheme = 'dark' | 'light' | 'blue';
 export type TProtocol = 'ssl' | 'tcp' | string;
@@ -52,7 +47,6 @@ export interface ISettings {
 	unitPreference: 'asset' | 'fiat';
 	showSuggestions: boolean;
 	transactionSpeed: TTransactionSpeed;
-	addressType: TAddressType;
 	hideBalance: boolean;
 	hideOnboardingMessage: boolean;
 	hideBeta: boolean;

--- a/src/utils/slashtags/index.ts
+++ b/src/utils/slashtags/index.ts
@@ -7,7 +7,7 @@ import debounce from 'lodash.debounce';
 import { navigate } from '../../navigation/root/RootNavigator';
 import { BasicProfile, SlashPayConfig } from '../../store/types/slashtags';
 import { showErrorNotification } from '../notifications';
-import { getReceiveAddress } from '../../utils/wallet';
+import { getReceiveAddress, getSelectedAddressType } from '../../utils/wallet';
 import { decodeLightningInvoice } from '../../utils/lightning';
 import { createLightningInvoice } from '../../store/actions/lightning';
 import { getStore } from '../../store/helpers';
@@ -164,7 +164,11 @@ export const updateSlashPayConfig = debounce(
 
 		const store = getStore();
 		const { selectedWallet, selectedNetwork } = store.wallet;
-		const { enableOfflinePayments, addressType } = store.settings;
+		const { enableOfflinePayments } = store.settings;
+		const addressType = getSelectedAddressType({
+			selectedWallet,
+			selectedNetwork,
+		});
 		const invoices =
 			store.lightning.nodes[selectedWallet].invoices[selectedNetwork];
 

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -2436,7 +2436,9 @@ export const getReceiveAddress = ({
 			return ok(receiveAddress);
 		}
 		const addresses: IAddress =
-			getStore().wallet[selectedWallet].addresses[selectedNetwork][addressType];
+			getStore().wallet?.wallets[selectedWallet].addresses[selectedNetwork][
+				addressType
+			];
 		// Check if addresses were generated, but the index has not been set yet.
 		if (
 			Object.keys(addresses).length > 0 &&


### PR DESCRIPTION
- fixing a typo `getReceiveAddress` func. It still can fail if addresses is empty. Should we run updateAddressIndexes there?
- run `updateAddressIndexes` on addressType change
- change default addressType

