### PR TITLE
fix: legacy address history and recover issues

### DIFF
--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -67,8 +67,10 @@ const QuickSetup = ({
 		(state: Store) => state.blocktank.serviceList[0],
 	);
 	const savingsAmount = totalBalance - spendingAmount;
-	const spendingPercentage = Math.round((spendingAmount / totalBalance) * 100);
-	const savingsPercentage = Math.round((savingsAmount / totalBalance) * 100);
+	const spendingPercentage =
+		totalBalance > 0 ? Math.round((spendingAmount / totalBalance) * 100) : 0;
+	const savingsPercentage =
+		totalBalance > 0 ? Math.round((savingsAmount / totalBalance) * 100) : 0;
 
 	const handleChange = useCallback((v) => {
 		setSpendingAmount(Math.round(v));

--- a/src/screens/Lightning/RebalanceSetup.tsx
+++ b/src/screens/Lightning/RebalanceSetup.tsx
@@ -63,8 +63,10 @@ const RebalanceSetup = ({
 		(state: Store) => state.settings.unitPreference,
 	);
 	const savingsAmount = totalBalance - spendingAmount;
-	const spendingPercentage = Math.round((spendingAmount / totalBalance) * 100);
-	const savingsPercentage = Math.round((savingsAmount / totalBalance) * 100);
+	const spendingPercentage =
+		totalBalance > 0 ? Math.round((spendingAmount / totalBalance) * 100) : 0;
+	const savingsPercentage =
+		totalBalance > 0 ? Math.round((savingsAmount / totalBalance) * 100) : 0;
 
 	const handleChange = useCallback((v) => {
 		setSpendingAmount(Math.round(v));

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -64,7 +64,7 @@ export const restoreWallet = async ({
 	if (res.isErr()) {
 		return res;
 	}
-	return await startWalletServices({});
+	return await startWalletServices({ restore: true });
 };
 
 /*
@@ -88,9 +88,11 @@ const ENABLE_SERVICES = true;
 export const startWalletServices = async ({
 	onchain = ENABLE_SERVICES,
 	lightning = ENABLE_SERVICES,
+	restore = false,
 }: {
 	onchain?: boolean;
 	lightning?: boolean;
+	restore?: boolean;
 }): Promise<Result<string>> => {
 	try {
 		InteractionManager.runAfterInteractions(async () => {
@@ -144,7 +146,8 @@ export const startWalletServices = async ({
 			if (onchain || lightning) {
 				await Promise.all([
 					updateOnchainFeeEstimates({ selectedNetwork }),
-					refreshWallet({ lightning }),
+					// if we restore wallet, we need to generate addresses for all types
+					refreshWallet({ lightning, updateAllAddressTypes: restore }),
 				]);
 
 				// Setup LDK


### PR DESCRIPTION
- fix `getAddressHistory` to work with different addresses types. 
- pass `updateAllAddressTypes: true` to `refreshWallet` on wallet recovery, so that we generate all address types, otherwise user might not see his bitcoin, if he sent them to legacy address.
- fix NaN on LN screens