### PR TITLE
fix(lightning): Disable Buttons When Funds Are Low

### DIFF
--- a/src/screens/Lightning/Introduction.tsx
+++ b/src/screens/Lightning/Introduction.tsx
@@ -10,6 +10,8 @@ import useColors from '../../hooks/colors';
 import type { LightningScreenProps } from '../../navigation/types';
 import { useSelector } from 'react-redux';
 import Store from '../../store/types';
+import { useBalance } from '../../hooks/wallet';
+import { ETransactionDefaults } from '../../store/types/wallet';
 
 const Introduction = ({
 	navigation,
@@ -17,7 +19,7 @@ const Introduction = ({
 	const isGeoBlocked = useSelector(
 		(state: Store) => state.user?.isGeoBlocked ?? false,
 	);
-
+	const balance = useBalance({ onchain: true });
 	const colors = useColors();
 
 	const txt = useMemo(() => {
@@ -30,6 +32,10 @@ const Introduction = ({
 			return 'Open a Lightning connection and \nsend or receive bitcoin instantly.';
 		}
 	}, [isGeoBlocked]);
+
+	const isDisabled = useMemo(() => {
+		return balance.satoshis <= ETransactionDefaults.recommendedBaseFee;
+	}, [balance.satoshis]);
 
 	return (
 		<GlowingBackground topLeft={colors.purple}>
@@ -62,6 +68,7 @@ const Introduction = ({
 								text="Quick Setup"
 								size="large"
 								style={[styles.button, styles.quickButton]}
+								disabled={isDisabled}
 								onPress={(): void => {
 									navigation.navigate('QuickSetup');
 								}}
@@ -72,6 +79,7 @@ const Introduction = ({
 								size="large"
 								variant="secondary"
 								style={[styles.button, styles.customButton]}
+								disabled={isDisabled}
 								onPress={(): void => {
 									navigation.navigate('CustomSetup', { spending: true });
 								}}

--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -43,6 +43,8 @@ import {
 	showSuccessNotification,
 } from '../../../utils/notifications';
 import { createLightningInvoice } from '../../../store/actions/lightning';
+import { ETransactionDefaults } from '../../../store/types/wallet';
+import { useBalance } from '../../../hooks/wallet';
 
 const Channel = memo(
 	({
@@ -107,6 +109,8 @@ const Channels = ({ navigation }): ReactElement => {
 	const [restartingLdk, setRestartingLdk] = useState<boolean>(false);
 
 	const colors = useColors();
+	const balance = useBalance({ onchain: true });
+
 	const selectedWallet = useSelector(
 		(state: Store) => state.wallet.selectedWallet,
 	);
@@ -195,10 +199,17 @@ const Channels = ({ navigation }): ReactElement => {
 		setRefreshingLdk(false);
 	}, [selectedNetwork, selectedWallet]);
 
+	const addConnectionIsDisabled = useMemo(() => {
+		return balance.satoshis <= ETransactionDefaults.recommendedBaseFee;
+	}, [balance.satoshis]);
+
 	return (
 		<ThemedView style={styles.root}>
 			<SafeAreaInsets type="top" />
-			<NavigationHeader title="Lightning Connections" onAddPress={handleAdd} />
+			<NavigationHeader
+				title="Lightning Connections"
+				onAddPress={addConnectionIsDisabled ? undefined : handleAdd}
+			/>
 			<ScrollView
 				contentContainerStyle={styles.content}
 				refreshControl={
@@ -365,7 +376,7 @@ const Channels = ({ navigation }): ReactElement => {
 						</>
 					)}
 
-					{!closed && (
+					{!closed && closedChannels.length > 0 && (
 						<Button
 							style={styles.button}
 							text="Show Closed Connections"
@@ -379,6 +390,7 @@ const Channels = ({ navigation }): ReactElement => {
 						style={styles.button}
 						text="Add New Connection"
 						size="large"
+						disabled={addConnectionIsDisabled}
 						onPress={handleAdd}
 					/>
 				</View>


### PR DESCRIPTION
This PR:
- Disables lightning buttons when sats are low.

Notes:
- Ideally, we should have verbiage attached to these views when the user's balance is too low explaining why they are not able to open a channel. This PR is simply a quick fix to prevent users from accessing the lightning flow without proper funds.