### PR TITLE
fix(send): pasting payment data without amount sets amount to 0

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,4 +1,7 @@
-import { removeKeysFromObject } from '../src/utils/helpers';
+import {
+	removeKeysFromObject,
+	mergeArrayOfObjects,
+} from '../src/utils/helpers';
 
 describe('removeKeysFromObject', () => {
 	it('takes a string, removes a single key from the object and returns the result', () => {
@@ -29,6 +32,60 @@ describe('removeKeysFromObject', () => {
 		};
 
 		const result = removeKeysFromObject(input, ['a', 'b']);
+		expect(result).toEqual(expected);
+	});
+});
+
+describe('mergeArrayOfObjects', () => {
+	const array1 = [
+		{
+			id: 1,
+			address: 'address1',
+		},
+	];
+	const array2 = [
+		{
+			id: 1,
+			address: 'address2',
+			value: 10000,
+		},
+	];
+	const array3 = [
+		{
+			id: 2,
+			address: 'address3',
+			value: 30000,
+		},
+	];
+
+	it('takes two arrays with the same id, merges them and returns the result', () => {
+		const expected = [
+			{
+				id: 1,
+				address: 'address2',
+				value: 10000,
+			},
+		];
+
+		const result = mergeArrayOfObjects([array1, array2], 'id');
+		expect(result).toEqual(expected);
+	});
+
+	it('takes three arrays with different ids, merges them and returns the result', () => {
+		const expected = [
+			{
+				id: 1,
+				address: 'address2',
+				value: 10000,
+			},
+			{
+				id: 2,
+				address: 'address3',
+				value: 30000,
+			},
+		];
+
+		const result = mergeArrayOfObjects([array1, array2, array3], 'id');
 		expect(result).toEqual(expected);
 	});
 });

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -7,7 +7,7 @@ import {
 	ICreateWallet,
 	IFormattedTransaction,
 	IKeyDerivationPath,
-	IBitcoinTransactionData,
+	IBitcoinTransactionUpdateData,
 	IUtxo,
 	TAddressType,
 	IBoostedTransaction,
@@ -774,7 +774,7 @@ export const setupOnChainTransaction = async ({
 	inputTxHashes?: string[]; // Used to pre-specify inputs to use by tx_hash
 	rbf?: boolean; // Enable or disable rbf.
 	submitDispatch?: boolean; //Should we dispatch this and update the store.
-} = {}): Promise<Result<IBitcoinTransactionData>> => {
+} = {}): Promise<Result<IBitcoinTransactionUpdateData>> => {
 	try {
 		if (!selectedNetwork) {
 			selectedNetwork = getSelectedNetwork();
@@ -909,7 +909,7 @@ export const updateBitcoinTransaction = async ({
 	selectedWallet,
 	selectedNetwork,
 }: {
-	transaction: IBitcoinTransactionData;
+	transaction: IBitcoinTransactionUpdateData;
 	selectedWallet?: string;
 	selectedNetwork?: TAvailableNetworks;
 }): Promise<void> => {
@@ -922,7 +922,7 @@ export const updateBitcoinTransaction = async ({
 		}
 
 		//Add output if specified
-		if (transaction?.outputs) {
+		if (transaction.outputs) {
 			let outputs =
 				getStore().wallet.wallets[selectedWallet].transaction[selectedNetwork]
 					.outputs || [];

--- a/src/store/reducers/wallet.ts
+++ b/src/store/reducers/wallet.ts
@@ -2,9 +2,11 @@ import actions from '../actions/actions';
 import {
 	defaultBitcoinTransactionData,
 	EOutput,
+	IBitcoinTransactionData,
 	IWallet,
 } from '../types/wallet';
 import { defaultWalletStoreShape } from '../shapes/wallet';
+import { mergeArrayOfObjects } from '../../utils/helpers';
 
 const wallet = (state: IWallet = defaultWalletStoreShape, action): IWallet => {
 	let selectedWallet = state.selectedWallet;
@@ -207,7 +209,16 @@ const wallet = (state: IWallet = defaultWalletStoreShape, action): IWallet => {
 			};
 
 		case actions.UPDATE_ON_CHAIN_TRANSACTION:
-			const transaction = action.payload.transaction;
+			const transaction: IBitcoinTransactionData = action.payload.transaction;
+			const currentTransactionOutputs =
+				state.wallets[selectedWallet].transaction[selectedNetwork].outputs;
+
+			// soft merge outputs by index
+			const mergedOutputs = mergeArrayOfObjects(
+				[currentTransactionOutputs, transaction.outputs],
+				'index',
+			);
+
 			return {
 				...state,
 				wallets: {
@@ -219,6 +230,7 @@ const wallet = (state: IWallet = defaultWalletStoreShape, action): IWallet => {
 							[selectedNetwork]: {
 								...state.wallets[selectedWallet].transaction[selectedNetwork],
 								...transaction,
+								outputs: mergedOutputs,
 							},
 						},
 					},

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -198,6 +198,28 @@ export interface IFormattedTransaction {
 }
 
 export interface IBitcoinTransactionData {
+	outputs: IOutput[];
+	inputs: IUtxo[];
+	changeAddress: string;
+	fiatAmount: number;
+	fee: number; //Total fee in sats
+	satsPerByte: number;
+	selectedFeeId: EFeeIds;
+	transactionSize: number; //In bytes (250 is about normal)
+	message: string; // OP_RETURN data for a given transaction.
+	label: string; // User set label for a given transaction.
+	rbf: boolean;
+	boostType: EBoost;
+	minFee: number; // (sats) Used for RBF/CPFP transactions where the fee needs to be greater than the original.
+	max: boolean; // If the user intends to send the max amount.
+	tags: string[];
+	slashTagsUrl: string;
+	lightningInvoice: string;
+}
+
+// When we're updating transaction data we
+// don't want to have to provide every field
+export interface IBitcoinTransactionUpdateData {
 	outputs?: IOutput[];
 	inputs?: IUtxo[];
 	changeAddress?: string;
@@ -233,6 +255,7 @@ export const defaultBitcoinTransactionData: IBitcoinTransactionData = {
 	minFee: 1,
 	max: false,
 	tags: [],
+	slashTagsUrl: '',
 	lightningInvoice: '',
 };
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -300,6 +300,27 @@ export const removeKeysFromObject = (
 };
 
 /**
+ * Takes an array of arrays of objects and (soft) merges them using a object field as identifier
+ * @param arrays
+ * @param key
+ * @return { object[] }
+ */
+export const mergeArrayOfObjects = (
+	arrays: object[][],
+	key: string,
+): object[] => {
+	const merged = {};
+
+	arrays.forEach((arr) => {
+		arr.forEach((item) => {
+			merged[item[key]] = Object.assign({}, merged[item[key]], item);
+		});
+	});
+
+	return Object.values(merged);
+};
+
+/**
  * Returns the new value and abbreviation of the provided number for display.
  * @param value
  * @return { newValue: string; abbreviation: string }

--- a/src/utils/types/bip21.ts
+++ b/src/utils/types/bip21.ts
@@ -1,0 +1,10 @@
+// what bip21.decode() returns
+// amount is number, rest are strings
+export type Bip21DecodeResult = {
+	address: string;
+	options: {
+		amount: number;
+		message: string;
+		lightning: string;
+	};
+};

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -21,7 +21,7 @@ import {
 	IDefaultWalletShape,
 	IFormattedTransaction,
 	IKeyDerivationPath,
-	IBitcoinTransactionData,
+	IBitcoinTransactionUpdateData,
 	IOutput,
 	IUtxo,
 	TAddressType,
@@ -1883,7 +1883,7 @@ export const getRbfData = async ({
  */
 export const formatRbfData = async (
 	data: IRbfData,
-): Promise<IBitcoinTransactionData> => {
+): Promise<IBitcoinTransactionUpdateData> => {
 	const { selectedWallet, inputs, outputs, fee, selectedNetwork, message } =
 		data;
 


### PR DESCRIPTION
### Changes
- add a type `IBitcoinTransactionUpdateData` for updating
- only check if onchain uri is payable if it contains an amount
- add helper `mergeArraysOfObjects`

### Preview
#### Without amount, doesn't overwrite amount
https://user-images.githubusercontent.com/8538369/197512905-cc50cd4e-0970-4bf4-85b9-9d07dc4c79f0.mp4

#### With amount of 0, sets amount to 0
https://user-images.githubusercontent.com/8538369/197512915-fd8e331a-d2d7-4b4c-bea7-85057292b83a.mp4

#### With amount of non 0, sets amount as specified
https://user-images.githubusercontent.com/8538369/197512911-cf03aa5c-fd9a-4049-b81b-5b10279fe75c.mp4

