### PR TITLE
fix: Android flickering

### DIFF
--- a/src/navigation/bottom-sheet/BackupNavigation.tsx
+++ b/src/navigation/bottom-sheet/BackupNavigation.tsx
@@ -31,7 +31,6 @@ const Stack = createNativeStackNavigator<BackupStackParamList>();
 
 const navOptions: NativeStackNavigationOptions = {
 	headerShown: false,
-	gestureEnabled: true,
 };
 
 const BackupNavigation = (): ReactElement => {

--- a/src/navigation/bottom-sheet/PINNavigation.tsx
+++ b/src/navigation/bottom-sheet/PINNavigation.tsx
@@ -26,7 +26,6 @@ const Stack = createNativeStackNavigator<PinStackParamList>();
 
 const navOptions: NativeStackNavigationOptions = {
 	headerShown: false,
-	gestureEnabled: true,
 };
 
 const PINNavigation = (): ReactElement => {

--- a/src/navigation/bottom-sheet/ReceiveNavigation.tsx
+++ b/src/navigation/bottom-sheet/ReceiveNavigation.tsx
@@ -27,7 +27,6 @@ const Stack = createNativeStackNavigator<ReceiveStackParamList>();
 
 const navOptions: NativeStackNavigationOptions = {
 	headerShown: false,
-	gestureEnabled: true,
 };
 
 const ReceiveNavigation = (): ReactElement => {

--- a/src/navigation/bottom-sheet/SendNavigation.tsx
+++ b/src/navigation/bottom-sheet/SendNavigation.tsx
@@ -48,7 +48,6 @@ export type SendStackParamList = {
 const Stack = createNativeStackNavigator<SendStackParamList>();
 const navOptions: NativeStackNavigationOptions = {
 	headerShown: false,
-	gestureEnabled: true,
 };
 
 const SendNavigation = (): ReactElement => {

--- a/src/navigation/lightning/LightningNavigator.tsx
+++ b/src/navigation/lightning/LightningNavigator.tsx
@@ -48,7 +48,6 @@ const Stack = createNativeStackNavigator<LightningStackParamList>();
 
 const navOptions: NativeStackNavigationOptions = {
 	headerShown: false,
-	gestureEnabled: true,
 };
 
 const LightningStack = (): ReactElement => {

--- a/src/navigation/onboarding/OnboardingNavigator.tsx
+++ b/src/navigation/onboarding/OnboardingNavigator.tsx
@@ -22,7 +22,6 @@ const Stack = createNativeStackNavigator<OnboardingStackParamList>();
 
 const navOptionHandler = {
 	headerShown: false,
-	gestureEnabled: true,
 	detachPreviousScreen: false,
 };
 

--- a/src/navigation/root/RootNavigator.tsx
+++ b/src/navigation/root/RootNavigator.tsx
@@ -49,7 +49,6 @@ const Stack = createStackNavigator<RootStackParamList>();
 
 const navOptions: StackNavigationOptions = {
 	headerShown: false,
-	gestureEnabled: true,
 	...TransitionPresets.SlideFromRightIOS,
 };
 

--- a/src/navigation/settings/SettingsNavigator.tsx
+++ b/src/navigation/settings/SettingsNavigator.tsx
@@ -1,4 +1,6 @@
 import React, { ReactElement } from 'react';
+import { Platform } from 'react-native';
+import { NavigatorScreenParams } from '@react-navigation/native';
 import {
 	createStackNavigator,
 	StackNavigationOptions,
@@ -42,7 +44,6 @@ import ResetAndRestore from '../../screens/Settings/Backup/ResetAndRestore';
 import LightningNavigator, {
 	LightningStackParamList,
 } from '../lightning/LightningNavigator';
-import { NavigatorScreenParams } from '@react-navigation/native';
 import SlashtagsSettings from '../../screens/Settings/SlashtagsSettings';
 
 export type SettingsNavigationProp =
@@ -89,76 +90,75 @@ export type SettingsStackParamList = {
 
 const Stack = createStackNavigator<SettingsStackParamList>();
 
-const navOptions: StackNavigationOptions = {
-	headerShown: false,
+const screenOptions: StackNavigationOptions = {
+	// prevent flickering issue on Android
+	presentation: Platform.OS === 'ios' ? 'card' : 'transparentModal',
 	gestureEnabled: true,
+	headerShown: false,
 };
 
 const SettingsNavigator = (): ReactElement => {
 	return (
-		<Stack.Navigator screenOptions={navOptions} initialRouteName="SettingsMenu">
-			<Stack.Group screenOptions={navOptions}>
-				<Stack.Screen name="AuthCheck" component={AuthCheck} />
-				<Stack.Screen name="SettingsMenu" component={SettingsMenu} />
-				<Stack.Screen name="GeneralSettings" component={GeneralSettings} />
-				<Stack.Screen name="SecuritySettings" component={SecuritySettings} />
-				<Stack.Screen name="ChangePin" component={ChangePin} />
-				<Stack.Screen name="ChangePin2" component={ChangePin2} />
-				<Stack.Screen name="PinChanged" component={PinChanged} />
-				<Stack.Screen name="DisablePin" component={DisablePin} />
-				<Stack.Screen name="BackupSettings" component={BackupSettings} />
-				<Stack.Screen name="NetworksSettings" component={NetworksSettings} />
-				<Stack.Screen name="AdvancedSettings" component={AdvancedSettings} />
-				<Stack.Screen name="AboutSettings" component={AboutSettings} />
-				<Stack.Screen name="EasterEgg" component={EasterEgg} />
-				<Stack.Screen
-					name="CurrenciesSettings"
-					component={CurrenciesSettings}
-				/>
-				<Stack.Screen
-					name="BitcoinUnitSettings"
-					component={BitcoinUnitSettings}
-				/>
-				<Stack.Screen
-					name="TransactionSpeedSettings"
-					component={TransactionSpeedSettings}
-				/>
-				<Stack.Screen name="BlocktankOrders" component={BlocktankOrders} />
-				<Stack.Screen
-					name="BlocktankOrderDetails"
-					component={BlocktankOrderDetails}
-				/>
-				<Stack.Screen name="ElectrumConfig" component={ElectrumConfig} />
-				<Stack.Screen
-					name="CoinSelectPreference"
-					component={CoinSelectPreference}
-				/>
-				<Stack.Screen name="PaymentPreference" component={PaymentPreference} />
-				<Stack.Screen
-					name="AddressTypePreference"
-					component={AddressTypePreference}
-				/>
-				<Stack.Screen name="DevSettings" component={DevSettings} />
-				<Stack.Screen name="BackupData" component={BackupData} />
-				<Stack.Screen name="ExportToPhone" component={ExportToPhone} />
-				<Stack.Screen name="ResetAndRestore" component={ResetAndRestore} />
-				<Stack.Screen
-					name="BitcoinNetworkSelection"
-					component={BitcoinNetworkSelection}
-				/>
-				<Stack.Screen name="LightningNodeInfo" component={LightningNodeInfo} />
-				<Stack.Screen name="ManageSeedPhrase" component={ManageSeedPhrase} />
-				<Stack.Screen name="Channels" component={Channels} />
-				<Stack.Screen name="ChannelDetails" component={ChannelDetails} />
-				<Stack.Screen name="CloseConnection" component={CloseConnection} />
-				<Stack.Screen name="LightningAddConnection" component={AddConnection} />
-				<Stack.Screen
-					name="LightningAddConnectionResult"
-					component={AddConnectionResult}
-				/>
-				<Stack.Screen name="LightningRoot" component={LightningNavigator} />
-				<Stack.Screen name="SlashtagsSettings" component={SlashtagsSettings} />
-			</Stack.Group>
+		<Stack.Navigator
+			screenOptions={screenOptions}
+			initialRouteName="SettingsMenu">
+			<Stack.Screen name="AuthCheck" component={AuthCheck} />
+			<Stack.Screen name="SettingsMenu" component={SettingsMenu} />
+			<Stack.Screen name="GeneralSettings" component={GeneralSettings} />
+			<Stack.Screen name="SecuritySettings" component={SecuritySettings} />
+			<Stack.Screen name="ChangePin" component={ChangePin} />
+			<Stack.Screen name="ChangePin2" component={ChangePin2} />
+			<Stack.Screen name="PinChanged" component={PinChanged} />
+			<Stack.Screen name="DisablePin" component={DisablePin} />
+			<Stack.Screen name="BackupSettings" component={BackupSettings} />
+			<Stack.Screen name="NetworksSettings" component={NetworksSettings} />
+			<Stack.Screen name="AdvancedSettings" component={AdvancedSettings} />
+			<Stack.Screen name="AboutSettings" component={AboutSettings} />
+			<Stack.Screen name="EasterEgg" component={EasterEgg} />
+			<Stack.Screen name="CurrenciesSettings" component={CurrenciesSettings} />
+			<Stack.Screen
+				name="BitcoinUnitSettings"
+				component={BitcoinUnitSettings}
+			/>
+			<Stack.Screen
+				name="TransactionSpeedSettings"
+				component={TransactionSpeedSettings}
+			/>
+			<Stack.Screen name="BlocktankOrders" component={BlocktankOrders} />
+			<Stack.Screen
+				name="BlocktankOrderDetails"
+				component={BlocktankOrderDetails}
+			/>
+			<Stack.Screen name="ElectrumConfig" component={ElectrumConfig} />
+			<Stack.Screen
+				name="CoinSelectPreference"
+				component={CoinSelectPreference}
+			/>
+			<Stack.Screen name="PaymentPreference" component={PaymentPreference} />
+			<Stack.Screen
+				name="AddressTypePreference"
+				component={AddressTypePreference}
+			/>
+			<Stack.Screen name="DevSettings" component={DevSettings} />
+			<Stack.Screen name="BackupData" component={BackupData} />
+			<Stack.Screen name="ExportToPhone" component={ExportToPhone} />
+			<Stack.Screen name="ResetAndRestore" component={ResetAndRestore} />
+			<Stack.Screen
+				name="BitcoinNetworkSelection"
+				component={BitcoinNetworkSelection}
+			/>
+			<Stack.Screen name="LightningNodeInfo" component={LightningNodeInfo} />
+			<Stack.Screen name="ManageSeedPhrase" component={ManageSeedPhrase} />
+			<Stack.Screen name="Channels" component={Channels} />
+			<Stack.Screen name="ChannelDetails" component={ChannelDetails} />
+			<Stack.Screen name="CloseConnection" component={CloseConnection} />
+			<Stack.Screen name="LightningAddConnection" component={AddConnection} />
+			<Stack.Screen
+				name="LightningAddConnectionResult"
+				component={AddConnectionResult}
+			/>
+			<Stack.Screen name="LightningRoot" component={LightningNavigator} />
+			<Stack.Screen name="SlashtagsSettings" component={SlashtagsSettings} />
 		</Stack.Navigator>
 	);
 };

--- a/src/navigation/settings/SettingsNavigator.tsx
+++ b/src/navigation/settings/SettingsNavigator.tsx
@@ -93,7 +93,6 @@ const Stack = createStackNavigator<SettingsStackParamList>();
 const screenOptions: StackNavigationOptions = {
 	// prevent flickering issue on Android
 	presentation: Platform.OS === 'ios' ? 'card' : 'transparentModal',
-	gestureEnabled: true,
 	headerShown: false,
 };
 

--- a/src/navigation/tabs/TabNavigator.tsx
+++ b/src/navigation/tabs/TabNavigator.tsx
@@ -40,7 +40,6 @@ const Stack = createNativeStackNavigator<TabStackParamList>();
 
 const navOptions: NativeStackNavigationOptions = {
 	headerShown: false,
-	gestureEnabled: true,
 };
 
 const screenOptions = {

--- a/src/navigation/widgets/WidgetsNavigator.tsx
+++ b/src/navigation/widgets/WidgetsNavigator.tsx
@@ -26,7 +26,6 @@ const Stack = createNativeStackNavigator<WidgetsStackParamList>();
 
 const navOptions: NativeStackNavigationOptions = {
 	headerShown: false,
-	gestureEnabled: true,
 };
 
 const WidgetsNavigator = (): ReactElement => {


### PR DESCRIPTION
### Changes
- fix flickering when navigating Settings on Android
- disable navigation gestures (swipe to go back) on Android 

### Notes
Sets `gestureEnabled` back to defaults (iOS: `true`, Android: `false`) to fix issue with "double" swipe gesture on Android.

### Preview

https://user-images.githubusercontent.com/8538369/197540791-2c4a4169-5124-4225-8f56-cb7d41f75f6c.mov

