### PR TITLE
fix(wallet): Restart Services When App Comes To Foreground

### DIFF
--- a/src/AppOnboarded.tsx
+++ b/src/AppOnboarded.tsx
@@ -66,6 +66,9 @@ const AppOnboarded = (): ReactElement => {
 				appState.current.match(/inactive|background/) &&
 				nextAppState === 'active'
 			) {
+				// App came back to foreground, lets restart our services
+				startWalletServices({}).then();
+
 				// check clipboard for payment data
 				if (enableAutoReadClipboard) {
 					// timeout needed otherwise clipboard is empty

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -143,25 +143,25 @@ export const startWalletServices = async ({
 				await createWallet({ mnemonic: mnemonic.value });
 			}
 
+			// Setup LDK
+			if (lightning) {
+				const setupResponse = await setupLdk({ selectedNetwork });
+				if (setupResponse.isOk()) {
+					keepLdkSynced({ selectedNetwork }).then();
+				} else {
+					showErrorNotification({
+						title: 'Unable to start LDK.',
+						message: setupResponse.error.message,
+					});
+				}
+			}
+
 			if (onchain || lightning) {
 				await Promise.all([
 					updateOnchainFeeEstimates({ selectedNetwork }),
 					// if we restore wallet, we need to generate addresses for all types
 					refreshWallet({ lightning, updateAllAddressTypes: restore }),
 				]);
-
-				// Setup LDK
-				if (lightning) {
-					const setupResponse = await setupLdk({ selectedNetwork });
-					if (setupResponse.isOk()) {
-						keepLdkSynced({ selectedNetwork }).then();
-					} else {
-						showErrorNotification({
-							title: 'Unable to start LDK.',
-							message: setupResponse.error.message,
-						});
-					}
-				}
 			}
 
 			if (lightning) {


### PR DESCRIPTION
This PR:
- Restarts wallet services when the app returns to the foreground. This is especially helpful for LDK.