### PR TITLE
fix: use default electrum server instead of reandom one

### DIFF
--- a/src/screens/Settings/ElectrumConfig/index.tsx
+++ b/src/screens/Settings/ElectrumConfig/index.tsx
@@ -17,16 +17,12 @@ import { addElectrumPeer } from '../../../store/actions/settings';
 import { ICustomElectrumPeer, TProtocol } from '../../../store/types/settings';
 import { updateUser } from '../../../store/actions/user';
 import Store from '../../../store/types';
+import { origCustomElectrumPeers } from '../../../store/shapes/settings';
 import { connectToElectrum } from '../../../utils/wallet/electrum';
 import NavigationHeader from '../../../components/NavigationHeader';
 import Button from '../../../components/Button';
-import { objectsMatch, shuffleArray } from '../../../utils/helpers';
-import {
-	defaultElectrumPorts,
-	getDefaultPort,
-	getPeers,
-	IFormattedPeerData,
-} from '../../../utils/electrum';
+import { objectsMatch } from '../../../utils/helpers';
+import { defaultElectrumPorts, getDefaultPort } from '../../../utils/electrum';
 import {
 	showErrorNotification,
 	showSuccessNotification,
@@ -87,7 +83,6 @@ const ElectrumConfig = ({
 			? savedPeer[savedPeer.protocol]
 			: getDefaultPort(selectedNetwork, protocol),
 	);
-	const [randomPeers, setRandomPeers] = useState<IFormattedPeerData[]>([]);
 
 	const [connectedPeer, setConnectedPeer] = useState<IPeerData>({
 		host: '',
@@ -103,10 +98,6 @@ const ElectrumConfig = ({
 				...peerInfo.value,
 				port: peerInfo.value.port.toString(),
 			});
-		}
-		const randomPeersResponse = await getPeers({ selectedNetwork });
-		if (randomPeersResponse.isOk()) {
-			setRandomPeers(randomPeersResponse.value);
 		}
 	};
 
@@ -181,10 +172,6 @@ const ElectrumConfig = ({
 					message: `Successfully connected to ${host}:${port}`,
 				});
 				getAndUpdateConnectedPeer();
-				const getPeersResult = await getPeers({ selectedNetwork });
-				if (getPeersResult.isOk()) {
-					setRandomPeers(getPeersResult.value);
-				}
 			} else {
 				updateUser({ isConnectedToElectrum: false });
 				showErrorNotification({
@@ -217,21 +204,11 @@ const ElectrumConfig = ({
 		}
 	};
 
-	const getRandomPeer = async (): Promise<void> => {
-		if (randomPeers?.length > 0) {
-			const shuffledArr = shuffleArray(randomPeers);
-			for (let i = 0; i < shuffledArr.length; i++) {
-				if (
-					host !== shuffledArr[i]?.host.toLowerCase() &&
-					connectedPeer.host !== shuffledArr[i]?.host.toLowerCase()
-				) {
-					const peer = shuffledArr[i];
-					setHost(peer.host.toLowerCase());
-					setPort(peer[protocol].toString().replace(/\D/g, ''));
-					break;
-				}
-			}
-		}
+	const resetToDefault = (): void => {
+		const peer = origCustomElectrumPeers[selectedNetwork][0];
+		setHost(peer.host);
+		setPort(peer[peer.protocol].toString());
+		setProtocol(peer.protocol);
 	};
 
 	useEffect(() => {
@@ -342,7 +319,7 @@ const ElectrumConfig = ({
 							text="Reset To Default"
 							variant="secondary"
 							size="large"
-							onPress={getRandomPeer}
+							onPress={resetToDefault}
 						/>
 						{!peersMatch({ host, port, protocol }) && (
 							<>

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -1,7 +1,7 @@
 import { ISettings } from '../types/settings';
 
 //TODO: Remove the public Electrum servers below once we spin up our own.
-const customElectrumPeers = {
+export const origCustomElectrumPeers = {
 	bitcoin: [
 		{
 			host: '35.187.18.233',
@@ -77,7 +77,7 @@ export const defaultSettingsShape: ISettings = {
 	balanceUnit: 'satoshi', //BTC, mBTC, μBTC or satoshi
 	selectedCurrency: 'USD',
 	selectedLanguage: 'english',
-	customElectrumPeers,
+	customElectrumPeers: origCustomElectrumPeers,
 	coinSelectAuto: true,
 	coinSelectPreference: 'small',
 	receivePreference: defaultReceivePreference,


### PR DESCRIPTION
Right now when user presses Reset To Default on Electrum Server config screen we use getPeer from rn-electrum to get one. This is confusing, we should just use default one from shapes/settings