### PR TITLE
fix(lightning): Rebroadcast LDK Transactions

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -326,7 +326,7 @@ PODS:
     - React-Core
   - react-native-image-picker (4.10.0):
     - React-Core
-  - react-native-ldk (0.0.66):
+  - react-native-ldk (0.0.68):
     - React
   - react-native-libsodium (0.0.1):
     - React-Core
@@ -794,7 +794,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: f68191637788994baed5f57d12994aa32cf8bf88
   react-native-flipper: 7eeb9b59b667dd0619372c7349cf7c78032d1de2
   react-native-image-picker: 4bc9ed38c8be255b515d8c88babbaf74973f91a8
-  react-native-ldk: 68aee1ab59756b2c7885312472772a7a62303c2b
+  react-native-ldk: 7c58505ab4c39660f12357102170a8c333a0a5e2
   react-native-libsodium: f4eba037c4ddf73f86b08075452cacb957256147
   react-native-mmkv: 1265a348a4711097ba29c8bcefd5971f48220f2b
   react-native-netinfo: 1a6035d3b9780221d407c277ebfb5722ace00658

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@reduxjs/toolkit": "^1.8.4",
     "@shopify/react-native-skia": "0.1.155",
     "@synonymdev/blocktank-client": "0.0.47",
-    "@synonymdev/react-native-ldk": "^0.0.66",
+    "@synonymdev/react-native-ldk": "0.0.68",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.4",

--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -27,6 +27,7 @@ import useColors from '../../../hooks/colors';
 import {
 	getNodeId,
 	payLightningInvoice,
+	rebroadcastAllKnownTransactions,
 	refreshLdk,
 	setupLdk,
 } from '../../../utils/lightning';
@@ -107,6 +108,7 @@ const Channels = ({ navigation }): ReactElement => {
 	const [payingInvoice, setPayingInvoice] = useState<boolean>(false);
 	const [refreshingLdk, setRefreshingLdk] = useState<boolean>(false);
 	const [restartingLdk, setRestartingLdk] = useState<boolean>(false);
+	const [rebroadcastingLdk, setRebroadcastingLdk] = useState(false);
 
 	const colors = useColors();
 	const balance = useBalance({ onchain: true });
@@ -297,6 +299,16 @@ const Channels = ({ navigation }): ReactElement => {
 									setRestartingLdk(true);
 									await setupLdk({ selectedWallet, selectedNetwork });
 									setRestartingLdk(false);
+								}}
+							/>
+							<Button
+								style={styles.button}
+								text={'Rebroadcast LDK TXS'}
+								loading={rebroadcastingLdk}
+								onPress={async (): Promise<void> => {
+									setRebroadcastingLdk(true);
+									await rebroadcastAllKnownTransactions();
+									setRebroadcastingLdk(false);
 								}}
 							/>
 							<Button

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -922,3 +922,7 @@ export const hasOpenLightningChannels = ({
 		getStore().lightning.nodes[selectedWallet].openChannelIds[selectedNetwork];
 	return availableChannels.length > 0;
 };
+
+export const rebroadcastAllKnownTransactions = async (): Promise<any> => {
+	return await lm.rebroadcastAllKnownTransactions();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1888,10 +1888,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@^0.0.66":
-  version "0.0.66"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.66.tgz#59ed6463da70f4bf4ee2304551fd277cd8666db9"
-  integrity sha512-51BwTKvZ0l4BG+HeenWbeT1d51JflbzBXMTaPxEU+6dUZUQeDoIDWV5kh9XrbLHSG4NMsjJBnX1Tlr0XpS3L/Q==
+"@synonymdev/react-native-ldk@0.0.68":
+  version "0.0.68"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.68.tgz#950c542841e86c30dbd956c9223e22d48f8dbcd5"
+  integrity sha512-e1RS7ymCOQELM3FoHYerwvWy0k2ZWt2NteH0njI7e5JJxB+XRld4rQNmAge2bqz6fd5+UrVQV1HU+MMv7wjgUw==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 


### PR DESCRIPTION
This PR:
- Bumps `react-native-ldk` to `0.0.68`.
- Adds rebroadcast method to dev options in Channels view.