### PR TITLE
fix(lightning): Remove setupLdk error notification

### DIFF
--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -140,11 +140,6 @@ export const startWalletServices = async ({
 				});
 				if (setupResponse.isOk()) {
 					keepLdkSynced({ selectedNetwork }).then();
-				} else {
-					showErrorNotification({
-						title: 'Unable to start LDK.',
-						message: setupResponse.error.message,
-					});
 				}
 			}
 


### PR DESCRIPTION
This PR:
- Removes the `setupLdk` error notification.