### PR TITLE
fix(wallet): Limit Address Scanning

### DIFF
--- a/src/screens/Lightning/CustomConfirm.tsx
+++ b/src/screens/Lightning/CustomConfirm.tsx
@@ -73,7 +73,7 @@ const CustomConfirm = ({
 	}, [fiatTransactionFee.fiatValue, blocktankPurchaseFee.fiatValue]);
 
 	const handleConfirm = async (): Promise<void> => {
-		if (Platform.OS === 'ios') {
+		if (Platform.OS === 'ios' && selectedNetwork === 'bitcoin') {
 			setLoading(false);
 			Alert.alert(
 				'Temporarily Unavailable',

--- a/src/screens/Lightning/QuickConfirm.tsx
+++ b/src/screens/Lightning/QuickConfirm.tsx
@@ -79,7 +79,7 @@ const QuickConfirm = ({
 	const savingsPercentage = Math.round((savingsAmount / total) * 100);
 
 	const handleConfirm = async (): Promise<void> => {
-		if (Platform.OS === 'ios') {
+		if (Platform.OS === 'ios' && selectedNetwork === 'bitcoin') {
 			setLoading(false);
 			Alert.alert(
 				'Temporarily Unavailable',

--- a/src/screens/Wallets/index.tsx
+++ b/src/screens/Wallets/index.tsx
@@ -47,7 +47,7 @@ const Wallets = ({ navigation }: TabScreenProps<'Wallets'>): ReactElement => {
 	const onRefresh = async (): Promise<void> => {
 		setRefreshing(true);
 		//Refresh wallet and then update activity list
-		await Promise.all([refreshWallet({})]);
+		await Promise.all([refreshWallet({ scanAllAddresses: true })]);
 		setRefreshing(false);
 	};
 

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -448,11 +448,13 @@ export const addAddresses = async ({
  * 2. Update the available balance for a given wallet and network.
  */
 export const updateUtxos = ({
-	selectedWallet = undefined,
-	selectedNetwork = undefined,
+	selectedWallet,
+	selectedNetwork,
+	scanAllAddresses = false,
 }: {
-	selectedWallet?: string | undefined;
-	selectedNetwork?: TAvailableNetworks | undefined;
+	selectedWallet?: string;
+	selectedNetwork?: TAvailableNetworks;
+	scanAllAddresses?: boolean;
 }): Promise<Result<{ utxos: IUtxo[]; balance: number }>> => {
 	return new Promise(async (resolve) => {
 		if (!selectedNetwork) {
@@ -462,7 +464,11 @@ export const updateUtxos = ({
 			selectedWallet = getSelectedWallet();
 		}
 
-		const utxoResponse = await getUtxos({ selectedWallet, selectedNetwork });
+		const utxoResponse = await getUtxos({
+			selectedWallet,
+			selectedNetwork,
+			scanAllAddresses,
+		});
 		if (utxoResponse.isErr()) {
 			return resolve(err(utxoResponse.error));
 		}
@@ -525,11 +531,13 @@ export interface ITransactionData {
 }
 
 export const updateTransactions = ({
-	selectedWallet = undefined,
-	selectedNetwork = undefined,
+	selectedWallet,
+	selectedNetwork,
+	scanAllAddresses = false,
 }: {
-	selectedWallet?: string | undefined;
-	selectedNetwork?: TAvailableNetworks | undefined;
+	selectedWallet?: string;
+	selectedNetwork?: TAvailableNetworks;
+	scanAllAddresses?: boolean;
 }): Promise<Result<IFormattedTransaction>> => {
 	return new Promise(async (resolve) => {
 		if (!selectedNetwork) {
@@ -546,6 +554,7 @@ export const updateTransactions = ({
 		const history = await getAddressHistory({
 			selectedNetwork,
 			selectedWallet,
+			scanAllAddresses,
 		});
 
 		if (history.isErr()) {

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -149,6 +149,7 @@ export const startWalletServices = async ({
 					refreshWallet({
 						onchain: isConnectedToElectrum,
 						lightning: isConnectedToElectrum,
+						scanAllAddresses: restore,
 						updateAllAddressTypes: restore,
 					}),
 				]);

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -95,10 +95,12 @@ import { setupTodos } from '../todos';
 export const refreshWallet = async ({
 	onchain = true,
 	lightning = true,
+	scanAllAddresses = false, // If set to false, on-chain scanning will adhere to the gap limit (20).
 	updateAllAddressTypes = false, // If set to true, Bitkit will generate, check and update all available address types.
 }: {
 	onchain?: boolean;
 	lightning?: boolean;
+	scanAllAddresses?: boolean;
 	updateAllAddressTypes?: boolean;
 }): Promise<Result<string>> => {
 	try {
@@ -126,10 +128,12 @@ export const refreshWallet = async ({
 					updateUtxos({
 						selectedWallet,
 						selectedNetwork,
+						scanAllAddresses,
 					}),
 					updateTransactions({
 						selectedWallet,
 						selectedNetwork,
+						scanAllAddresses,
 					}),
 				]);
 			}


### PR DESCRIPTION
This PR:
- Adds `scanAllAddresses` param to several methods.
- Setting `scanAllAddresses` to `false` will force adherence to the set gap limit (20 at the moment) in order to limit scanning all addresses every time the user refreshes.
- Adds condition to `QuickConfirm` & `CustomConfirm` components to enable lightning testing on iOS devices for `regtest` and `testnet` networks.
