### PR TITLE
Fix/send to seeder

### DIFF
--- a/src/components/SlashtagsProvider.tsx
+++ b/src/components/SlashtagsProvider.tsx
@@ -75,6 +75,10 @@ export const SlashtagsProvider = ({ children }): JSX.Element => {
 
 	// SDK creating and reconnecting after relay disconnect!
 	useEffect(() => {
+		if (!primaryKey) {
+			return;
+		}
+
 		let unmounted = false;
 
 		const pk = primaryKey && b4a.from(primaryKey, 'hex');

--- a/src/screens/Settings/SlashtagsSettings/index.tsx
+++ b/src/screens/Settings/SlashtagsSettings/index.tsx
@@ -155,7 +155,7 @@ const SlashtagsSettings = (): ReactElement => {
 				],
 			},
 		],
-		[profileError, driveVersion, sdk, discoveryKey, lastSeed],
+		[profileError, driveVersion, sdk, discoveryKey, lastSeed, seederStatus],
 	);
 
 	return (

--- a/src/screens/Settings/SlashtagsSettings/index.tsx
+++ b/src/screens/Settings/SlashtagsSettings/index.tsx
@@ -7,6 +7,7 @@ import { useSelector } from 'react-redux';
 import Store from '../../../store/types';
 import { useSelectedSlashtag } from '../../../hooks/slashtags';
 import { useSlashtagsSDK } from '../../../components/SlashtagsProvider';
+import { closeDriveSession } from '../../../utils/slashtags';
 
 const SlashtagsSettings = (): ReactElement => {
 	const { slashtag } = useSelectedSlashtag();
@@ -23,22 +24,44 @@ const SlashtagsSettings = (): ReactElement => {
 		(store: Store) => store.slashtags.seeder?.lastSent,
 	);
 
+	const [seederStatus, setSeederStatus] = useState({
+		seeded: false,
+		diff: 0,
+	});
+
 	useEffect(() => {
 		let unmounted = false;
 
 		(async (): Promise<void> => {
-			if (unmounted) {
-				return;
-			}
+			const drive = slashtag.drivestore.get();
 
 			try {
-				const d = slashtag.drivestore.get();
-				await d.update();
-				setDriveVersion(d.version);
-				setDiscoveryKey(d.discoveryKey);
-				await d.get('/profile.json');
+				await drive.update();
+				setDriveVersion(drive.version);
+				setDiscoveryKey(drive.discoveryKey);
+				await drive.get('/profile.json');
+
+				try {
+					const key = b4a.toString(drive.key, 'hex');
+					const firstResponse = await fetch(
+						'https://blocktank.synonym.to/seeding/hypercore/' + key,
+						{ method: 'GET' },
+					);
+					const status = await firstResponse.json();
+
+					if (!unmounted) {
+						setSeederStatus({
+							seeded: status.statusCode !== 404,
+							diff: status.length - drive.core.length,
+						});
+					}
+				} catch (error) {}
 			} catch (error) {
-				setProfileError(error.message);
+				if (!unmounted) {
+					setProfileError(error.message);
+				}
+			} finally {
+				closeDriveSession(drive);
 			}
 		})();
 
@@ -61,6 +84,14 @@ const SlashtagsSettings = (): ReactElement => {
 					{
 						title: 'last seeded',
 						value: lastSeed && new Date(lastSeed).toLocaleString(),
+						hide: false,
+						type: 'button',
+					},
+					{
+						title: 'seeder status',
+						value: seederStatus.seeded
+							? 'behind by ' + seederStatus.diff + ' blocks'
+							: 'Not Found',
 						hide: false,
 						type: 'button',
 					},

--- a/src/store/actions/slashtags.ts
+++ b/src/store/actions/slashtags.ts
@@ -1,5 +1,6 @@
 import { Slashtag } from '@synonymdev/slashtags-sdk';
 import { ok, Result } from '@synonymdev/result';
+import b4a from 'b4a';
 
 import actions from './actions';
 import { getDispatch, getStore } from '../helpers';
@@ -85,13 +86,20 @@ export const resetSlashtagsStore = (): Result<string> => {
  * Sends all relevant hypercores to the seeder once a week
  */
 export const updateSeederMaybe = async (slashtag: Slashtag): Promise<void> => {
+	const key = b4a.toString(slashtag.key, 'hex');
+	const response = await fetch(
+		'https://blocktank.synonym.to/seeding/hypercore/' + key,
+		{ method: 'GET' },
+	);
+	const status = await response.json();
+
 	const lastSent = getStore().slashtags.seeder?.lastSent || 0;
 
 	const now = Number(new Date());
 	// throttle sending to seeder to once a day
 	const passed = (now - lastSent) / 86400000;
 
-	if (passed < 1) {
+	if (passed < 1 && status.statusCode !== 404) {
 		return;
 	}
 

--- a/stpg/cache.json
+++ b/stpg/cache.json
@@ -1,1 +1,1 @@
-{"lastUsedURL":"slash:4c71h4rmdpddqroj7freshg34h59wqytde9nm654geide7yt3jqo"}
+{"lastUsedURL":"slash:m4oheo5n86e6ghoay73qi38hakcziqw47e344qf3arz9amptuz7y"}

--- a/stpg/index.js
+++ b/stpg/index.js
@@ -87,8 +87,7 @@ async function resolveProfile() {
 	const drive = sdk.drive(key);
 	console.log('Resolving public drive ...');
 	console.time('-- resolved drive in');
-	await drive.ready();
-	await drive.getBlobs();
+	await drive.update();
 	console.timeEnd('-- resolved drive in');
 
 	const profile = await drive.get('/profile.json').then(decodeJSON);


### PR DESCRIPTION
This PR does three things:
1- Skip creating SDK if the `primaryKey` is not loaded yet (should have been done before)
2- Skip throttling sending to the seeder (force sending cores to the seeder) if the seeder responded with 404 for the public drive core keys
3- Add information about the status of seeding our public core in the slashtags settings in dev tools.