### PR TITLE
fix(lightning): Fix Navigation

### DIFF
--- a/src/navigation/lightning/LightningNavigator.tsx
+++ b/src/navigation/lightning/LightningNavigator.tsx
@@ -30,7 +30,9 @@ export type LightningStackParamList = {
 		orderId: string;
 	};
 	Result: undefined;
-	QuickSetup: undefined;
+	QuickSetup: {
+		headerTitle: string;
+	};
 	QuickConfirm: {
 		spendingAmount: number;
 		total: number;

--- a/src/navigation/lightning/LightningNavigator.tsx
+++ b/src/navigation/lightning/LightningNavigator.tsx
@@ -30,9 +30,7 @@ export type LightningStackParamList = {
 		orderId: string;
 	};
 	Result: undefined;
-	QuickSetup: {
-		headerTitle: string;
-	} | undefined;
+	QuickSetup: { headerTitle: string } | undefined;
 	QuickConfirm: {
 		spendingAmount: number;
 		total: number;

--- a/src/navigation/lightning/LightningNavigator.tsx
+++ b/src/navigation/lightning/LightningNavigator.tsx
@@ -32,7 +32,7 @@ export type LightningStackParamList = {
 	Result: undefined;
 	QuickSetup: {
 		headerTitle: string;
-	};
+	} | undefined;
 	QuickConfirm: {
 		spendingAmount: number;
 		total: number;

--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -55,6 +55,7 @@ export const Percentage = ({ value, type }): ReactElement => {
 
 const QuickSetup = ({
 	navigation,
+	route,
 }: LightningScreenProps<'QuickSetup'>): ReactElement => {
 	const colors = useColors();
 	const [keybrd, setKeybrd] = useState(false);
@@ -76,6 +77,11 @@ const QuickSetup = ({
 	);
 	const selectedCurrency = useSelector(
 		(state: Store) => state.settings.selectedCurrency,
+	);
+
+	const headerTitle = useMemo(
+		() => route.params?.headerTitle ?? 'Add Instant Payments',
+		[route.params?.headerTitle],
 	);
 
 	const savingsAmount = totalBalance - spendingAmount;
@@ -162,7 +168,7 @@ const QuickSetup = ({
 		<GlowingBackground topLeft={colors.purple}>
 			<SafeAreaInsets type="top" />
 			<NavigationHeader
-				title="Add Instant Payments"
+				title={headerTitle}
 				onClosePress={(): void => {
 					navigation.navigate('Tabs');
 				}}

--- a/src/screens/Wallets/WalletsDetail/BitcoinBreakdown.tsx
+++ b/src/screens/Wallets/WalletsDetail/BitcoinBreakdown.tsx
@@ -1,4 +1,10 @@
-import React, { memo, ReactElement, useEffect, useState } from 'react';
+import React, {
+	memo,
+	ReactElement,
+	useCallback,
+	useEffect,
+	useState,
+} from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 
@@ -72,6 +78,21 @@ const BitcoinBreakdown = (): ReactElement => {
 		});
 	}, []);
 
+	const onRebalancePress = useCallback(() => {
+		if (hasLightning && !isGeoBlocked) {
+			navigation.navigate('LightningRoot', {
+				screen: 'QuickSetup',
+				params: {
+					headerTitle: 'Rebalance Funds',
+				},
+			});
+		} else {
+			navigation.navigate('LightningRoot', {
+				screen: 'Introduction',
+			});
+		}
+	}, [hasLightning, isGeoBlocked, navigation]);
+
 	return (
 		<View color="transparent" style={styles.container}>
 			<NetworkRow
@@ -83,15 +104,7 @@ const BitcoinBreakdown = (): ReactElement => {
 			/>
 			<View color="transparent" style={styles.transferRow}>
 				<View color="gray4" style={styles.line} />
-				<TouchableOpacity
-					onPress={(): void => {
-						navigation.navigate('LightningRoot', {
-							screen:
-								hasLightning && !isGeoBlocked
-									? 'RebalanceSetup'
-									: 'Introduction',
-						});
-					}}>
+				<TouchableOpacity onPress={onRebalancePress}>
 					<View style={styles.transferButton} color="white08">
 						<TransferIcon height={13} color="white" />
 					</View>


### PR DESCRIPTION
This PR:
- Replaces `RebalanceSetup` with `QuickSetup` in `BitcoinBreakdown.tsx`.
- Fixes unnecessary `useEffect` calls in `AddressAndAmount.tsx`.