### PR TITLE
fix(lightning): Reset Channel-Open Transactions

### DIFF
--- a/src/screens/Lightning/CustomSetup.tsx
+++ b/src/screens/Lightning/CustomSetup.tsx
@@ -28,7 +28,10 @@ import NumberPadLightning from './NumberPadLightning';
 import type { LightningScreenProps } from '../../navigation/types';
 import Store from '../../store/types';
 import { useBalance } from '../../hooks/wallet';
-import { setupOnChainTransaction } from '../../store/actions/wallet';
+import {
+	resetOnChainTransaction,
+	setupOnChainTransaction,
+} from '../../store/actions/wallet';
 import {
 	fiatToBitcoinUnit,
 	getFiatDisplayValues,
@@ -179,6 +182,15 @@ const CustomSetup = ({
 	}, [currentBalance.fiatValue, selectedCurrency]);
 
 	useEffect(() => {
+		resetOnChainTransaction({ selectedNetwork, selectedWallet });
+		setupOnChainTransaction({
+			selectedNetwork,
+			selectedWallet,
+			rbf: false,
+		}).then();
+	}, [selectedNetwork, selectedWallet]);
+
+	useEffect(() => {
 		const rates = { small: 0, medium: 0, big: 0 };
 		const receiveRates = { small: 0, medium: 0, big: 0 };
 
@@ -254,8 +266,6 @@ const CustomSetup = ({
 		});
 		setAvailableReceivingPackages(availReceivingPackages);
 		setReceivePkgRates(receiveRates);
-
-		setupOnChainTransaction({ rbf: false }).then();
 	}, [
 		blocktankService.max_chan_receiving,
 		blocktankService.max_chan_receiving_usd,

--- a/src/screens/Lightning/CustomSetup.tsx
+++ b/src/screens/Lightning/CustomSetup.tsx
@@ -40,6 +40,7 @@ import { btcToSats } from '../../utils/helpers';
 import { showErrorNotification } from '../../utils/notifications';
 import { startChannelPurchase } from '../../store/actions/blocktank';
 import { convertCurrency } from '../../utils/blocktank';
+import { useFocusEffect } from '@react-navigation/native';
 
 type TPackages = {
 	id: string;
@@ -181,14 +182,16 @@ const CustomSetup = ({
 			: maxSpendingLimit.fiatValue;
 	}, [currentBalance.fiatValue, selectedCurrency]);
 
-	useEffect(() => {
-		resetOnChainTransaction({ selectedNetwork, selectedWallet });
-		setupOnChainTransaction({
-			selectedNetwork,
-			selectedWallet,
-			rbf: false,
-		}).then();
-	}, [selectedNetwork, selectedWallet]);
+	useFocusEffect(
+		useCallback(() => {
+			resetOnChainTransaction({ selectedNetwork, selectedWallet });
+			setupOnChainTransaction({
+				selectedNetwork,
+				selectedWallet,
+				rbf: false,
+			}).then();
+		}, [selectedNetwork, selectedWallet]),
+	);
 
 	useEffect(() => {
 		const rates = { small: 0, medium: 0, big: 0 };

--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -38,6 +38,7 @@ import { startChannelPurchase } from '../../store/actions/blocktank';
 import { showErrorNotification } from '../../utils/notifications';
 import { fiatToBitcoinUnit } from '../../utils/exchange-rate';
 import { convertCurrency } from '../../utils/blocktank';
+import { useFocusEffect } from '@react-navigation/native';
 
 export const Percentage = ({ value, type }): ReactElement => {
 	return (
@@ -125,14 +126,16 @@ const QuickSetup = ({
 		spendingLimit,
 	]);
 
-	useEffect(() => {
-		resetOnChainTransaction({ selectedNetwork, selectedWallet });
-		setupOnChainTransaction({
-			selectedNetwork,
-			selectedWallet,
-			rbf: false,
-		}).then();
-	}, [selectedNetwork, selectedWallet]);
+	useFocusEffect(
+		useCallback(() => {
+			resetOnChainTransaction({ selectedNetwork, selectedWallet });
+			setupOnChainTransaction({
+				selectedNetwork,
+				selectedWallet,
+				rbf: false,
+			}).then();
+		}, [selectedNetwork, selectedWallet]),
+	);
 
 	const onContinuePress = useCallback(async (): Promise<void> => {
 		setLoading(true);

--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -30,7 +30,10 @@ import type { LightningScreenProps } from '../../navigation/types';
 
 import Store from '../../store/types';
 import { useBalance } from '../../hooks/wallet';
-import { setupOnChainTransaction } from '../../store/actions/wallet';
+import {
+	resetOnChainTransaction,
+	setupOnChainTransaction,
+} from '../../store/actions/wallet';
 import { startChannelPurchase } from '../../store/actions/blocktank';
 import { showErrorNotification } from '../../utils/notifications';
 import { fiatToBitcoinUnit } from '../../utils/exchange-rate';
@@ -123,8 +126,13 @@ const QuickSetup = ({
 	]);
 
 	useEffect(() => {
-		setupOnChainTransaction({ rbf: false }).then();
-	}, []);
+		resetOnChainTransaction({ selectedNetwork, selectedWallet });
+		setupOnChainTransaction({
+			selectedNetwork,
+			selectedWallet,
+			rbf: false,
+		}).then();
+	}, [selectedNetwork, selectedWallet]);
 
 	const onContinuePress = useCallback(async (): Promise<void> => {
 		setLoading(true);


### PR DESCRIPTION
This PR:
- Adds `resetOnChainTransaction` method to both `CustomSetup` & `QuickSetup` components.
- This closes #655