### PR TITLE
fix: add migration for todos

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import createDebugger from 'redux-flipper';
 import logger from 'redux-logger';
 import {
 	persistReducer,
+	createMigrate,
 	FLUSH,
 	REHYDRATE,
 	PAUSE,
@@ -18,6 +19,7 @@ import {
 
 import mmkvStorage from './mmkv-storage';
 import reducers from './reducers';
+import migrations from './migrations';
 
 const __JEST__ = process.env.JEST_WORKER_ID !== undefined;
 const __enableDebugger__ = ENABLE_REDUX_FLIPPER
@@ -38,7 +40,13 @@ const devMiddleware = [
 
 const enhancers = [];
 
-const persistConfig = { key: 'root', storage: mmkvStorage };
+const persistConfig = {
+	key: 'root',
+	storage: mmkvStorage,
+	// increase version after store shape changes
+	version: 0,
+	migrate: createMigrate(migrations, { debug: false }),
+};
 const persistedReducer = persistReducer(persistConfig, reducers);
 
 const store = configureStore({

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -1,0 +1,15 @@
+import { PersistedState } from 'redux-persist';
+import { defaultTodosShape } from '../shapes/todos';
+
+// add migrations for every persisted store version change
+
+const migrations = {
+	0: (state): PersistedState => {
+		return {
+			...state,
+			todos: defaultTodosShape,
+		};
+	},
+};
+
+export default migrations;


### PR DESCRIPTION
Sets up versioning and migrations for `redux-persist`. First migration is an appendix to https://github.com/synonymdev/bitkit/pull/670