### PR TITLE
fix: Widgets overview

### DIFF
--- a/src/components/BitfinexWidget.tsx
+++ b/src/components/BitfinexWidget.tsx
@@ -88,11 +88,13 @@ const Chart = ({
 const BitfinexWidget = ({
 	url,
 	widget,
-	editable = true,
+	isEditing = false,
+	onPress,
 }: {
 	url: string;
 	widget: IWidget;
-	editable?: boolean;
+	isEditing?: boolean;
+	onPress?: () => void;
 }): ReactElement => {
 	const { value, drive } = useFeedWidget({ url, feed: widget.feed });
 	const [pastValues, setPastValues] = useState<number[]>([]);
@@ -140,7 +142,8 @@ const BitfinexWidget = ({
 			name="Bitcoin Price"
 			label={widget.feed.field.name}
 			icon={<ChartLineIcon width={32} height={32} />}
-			editable={editable}
+			isEditing={isEditing}
+			onPress={onPress}
 			middle={<Chart color={change.color} values={pastValues} />}
 			right={
 				<View style={styles.numbers}>

--- a/src/components/BlocksWidget.tsx
+++ b/src/components/BlocksWidget.tsx
@@ -1,7 +1,7 @@
 import React, { memo, ReactElement } from 'react';
-import { StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 
-import { View, Text01M, Caption13M, CubeIcon } from '../styles/components';
+import { Text01M, Caption13M, CubeIcon } from '../styles/components';
 import { BaseFeedWidget } from './FeedWidget';
 import { IWidget } from '../store/types/widgets';
 import { useFeedWidget } from '../hooks/widgets';
@@ -9,11 +9,13 @@ import { useFeedWidget } from '../hooks/widgets';
 const BlocksWidget = ({
 	url,
 	widget,
-	editable,
+	isEditing = false,
+	onPress,
 }: {
 	url: string;
 	widget: IWidget;
-	editable?: boolean;
+	isEditing?: boolean;
+	onPress?: () => void;
 }): ReactElement => {
 	const { value } = useFeedWidget({ url, feed: widget.feed });
 
@@ -23,7 +25,8 @@ const BlocksWidget = ({
 			name="Bitcoin Blocks"
 			label={value?.height}
 			icon={<CubeIcon width={32} height={32} />}
-			editable={editable}
+			isEditing={isEditing}
+			onPress={onPress}
 			right={
 				<View style={styles.numbers}>
 					<Text01M numberOfLines={1} styles={styles.price}>

--- a/src/components/FeedWidget.tsx
+++ b/src/components/FeedWidget.tsx
@@ -26,13 +26,15 @@ export const FeedWidget = ({
 	widget,
 	icon,
 	name,
-	editable = true,
+	isEditing = false,
+	onPress,
 }: {
 	url: string;
 	widget: IWidget;
 	icon?: ReactElement;
 	name?: string;
-	editable?: boolean;
+	isEditing?: boolean;
+	onPress?: () => void;
 }): ReactElement => {
 	const { value } = useFeedWidget({ url, feed: widget.feed });
 
@@ -41,7 +43,8 @@ export const FeedWidget = ({
 			url={url}
 			name={name || widget.feed.name}
 			label={widget.feed.field.name}
-			editable={editable}
+			isEditing={isEditing}
+			onPress={onPress}
 			right={<DefaultRightComponent value={value?.toString()} />}
 			icon={
 				icon || (
@@ -64,7 +67,8 @@ export const BaseFeedWidget = ({
 	label,
 	right = <View />,
 	middle,
-	editable = true,
+	isEditing = false,
+	onPress,
 }: {
 	url: string;
 	name?: string;
@@ -72,13 +76,13 @@ export const BaseFeedWidget = ({
 	label?: string;
 	right?: ReactElement;
 	middle?: ReactElement;
-	editable?: boolean;
+	isEditing?: boolean;
+	onPress?: () => void;
 }): ReactElement => {
-	const [showButtons, setShowButtons] = useState(false);
 	const [showDialog, setShowDialog] = useState(false);
 
-	const switchShowButtons = (): void => {
-		setShowButtons((b) => !b);
+	const onEdit = (): void => {
+		navigate('WidgetFeedEdit', { url });
 	};
 
 	const onDelete = (): void => {
@@ -86,10 +90,7 @@ export const BaseFeedWidget = ({
 	};
 
 	return (
-		<TouchableOpacity
-			style={styles.root}
-			onPress={switchShowButtons}
-			activeOpacity={0.9}>
+		<TouchableOpacity style={styles.root} activeOpacity={0.9} onPress={onPress}>
 			<View style={styles.infoContainer}>
 				<View style={styles.icon}>{icon}</View>
 				<View style={styles.labelsContainer}>
@@ -100,7 +101,7 @@ export const BaseFeedWidget = ({
 				</View>
 			</View>
 
-			{editable && showButtons ? (
+			{isEditing ? (
 				<>
 					<Button
 						style={styles.deleteButton}
@@ -110,10 +111,7 @@ export const BaseFeedWidget = ({
 					<Button
 						style={styles.settingsButton}
 						icon={<GearIcon width={20} />}
-						onPress={(): void => {
-							setTimeout(() => setShowButtons(false), 0);
-							navigate('WidgetFeedEdit', { url });
-						}}
+						onPress={onEdit}
 					/>
 				</>
 			) : (
@@ -122,6 +120,7 @@ export const BaseFeedWidget = ({
 					<View style={styles.right}>{right}</View>
 				</View>
 			)}
+
 			<Dialog
 				visible={showDialog}
 				title={`Delete ${name} widget?`}

--- a/src/components/HeadlinesWidget.tsx
+++ b/src/components/HeadlinesWidget.tsx
@@ -23,13 +23,14 @@ import { deleteWidget } from '../store/actions/widgets';
 const HeadlinesWidget = ({
 	url,
 	widget,
-	editable = true,
+	isEditing = false,
+	onPress,
 }: {
 	url: string;
 	widget: IWidget;
-	editable?: boolean;
+	isEditing?: boolean;
+	onPress?: () => void;
 }): ReactElement => {
-	const [showButtons, setShowButtons] = useState(false);
 	const [showDialog, setShowDialog] = useState(false);
 	const [article, setArticle] = useState<{
 		title: string;
@@ -85,8 +86,8 @@ const HeadlinesWidget = ({
 		};
 	}, [sdk, url]);
 
-	const switchShowButtons = (): void => {
-		setShowButtons((b) => !b);
+	const onEdit = (): void => {
+		navigate('WidgetFeedEdit', { url });
 	};
 
 	const onDelete = (): void => {
@@ -97,8 +98,8 @@ const HeadlinesWidget = ({
 		<View>
 			<TouchableOpacity
 				style={styles.root}
-				onPress={switchShowButtons}
-				activeOpacity={0.9}>
+				activeOpacity={0.9}
+				onPress={onPress}>
 				<View style={styles.icon}>
 					{<NewspaperIcon width={32} height={32} />}
 				</View>
@@ -127,7 +128,7 @@ const HeadlinesWidget = ({
 				</View>
 			</TouchableOpacity>
 
-			{editable && showButtons && (
+			{isEditing && (
 				<View style={styles.buttonsContainer}>
 					<Button
 						style={styles.deleteButton}
@@ -137,10 +138,7 @@ const HeadlinesWidget = ({
 					<Button
 						style={styles.settingsButton}
 						icon={<GearIcon width={20} />}
-						onPress={(): void => {
-							setTimeout(() => setShowButtons(false), 0);
-							navigate('WidgetFeedEdit', { url });
-						}}
+						onPress={onEdit}
 					/>
 				</View>
 			)}

--- a/src/components/Widgets.tsx
+++ b/src/components/Widgets.tsx
@@ -1,4 +1,4 @@
-import React, { memo, ReactElement } from 'react';
+import React, { memo, ReactElement, useState, useCallback } from 'react';
 import { StyleSheet } from 'react-native';
 import { useSelector } from 'react-redux';
 
@@ -17,9 +17,25 @@ import FeedWidget from './FeedWidget';
 import HeadlinesWidget from './HeadlinesWidget';
 import { SUPPORTED_FEED_TYPES } from '../utils/widgets';
 import BlocksWidget from './BlocksWidget';
+import { useFocusEffect } from '@react-navigation/native';
 
 export const Widgets = (): ReactElement => {
 	const widgets = useSelector((state: Store) => state.widgets.widgets);
+	const [editing, setEditing] = useState<string | null>();
+
+	useFocusEffect(useCallback(() => setEditing(null), []));
+
+	const onPress = (url: string): void => {
+		if (editing === url) {
+			setEditing(null);
+		} else {
+			setEditing(url);
+		}
+	};
+
+	const onAdd = (): void => {
+		navigate('WidgetsRoot');
+	};
 
 	return (
 		<>
@@ -30,26 +46,52 @@ export const Widgets = (): ReactElement => {
 						((): ReactElement => {
 							switch (widget.feed.type) {
 								case SUPPORTED_FEED_TYPES.PRICE_FEED:
-									return <BitfinexWidget key={url} url={url} widget={widget} />;
+									return (
+										<BitfinexWidget
+											key={url}
+											url={url}
+											widget={widget}
+											isEditing={editing === url}
+											onPress={(): void => onPress(url)}
+										/>
+									);
 								case SUPPORTED_FEED_TYPES.HEADLINES_FEED:
 									return (
-										<HeadlinesWidget key={url} url={url} widget={widget} />
+										<HeadlinesWidget
+											key={url}
+											url={url}
+											widget={widget}
+											isEditing={editing === url}
+											onPress={(): void => onPress(url)}
+										/>
 									);
 								case SUPPORTED_FEED_TYPES.BLOCKS_FEED:
-									return <BlocksWidget key={url} url={url} widget={widget} />;
+									return (
+										<BlocksWidget
+											key={url}
+											url={url}
+											widget={widget}
+											isEditing={editing === url}
+											onPress={(): void => onPress(url)}
+										/>
+									);
 								default:
-									return <FeedWidget key={url} url={url} widget={widget} />;
+									return (
+										<FeedWidget
+											key={url}
+											url={url}
+											widget={widget}
+											isEditing={editing === url}
+											onPress={(): void => onPress(url)}
+										/>
+									);
 							}
 						})()
 					) : (
 						<AuthWidget key={url} url={url} widget={widget} />
 					),
 				)}
-				<TouchableOpacity
-					style={styles.add}
-					onPress={(): void => {
-						navigate('WidgetsRoot');
-					}}>
+				<TouchableOpacity style={styles.add} onPress={onAdd}>
 					<View color="green16" style={styles.iconCircle}>
 						<PlusIcon height={16} color="green" />
 					</View>

--- a/src/screens/Widgets/WidgetFeedEdit.tsx
+++ b/src/screens/Widgets/WidgetFeedEdit.tsx
@@ -292,7 +292,6 @@ export const WidgetFeedEdit = ({
 													url={url}
 													// @ts-ignore
 													widget={previewWidget}
-													editable={false}
 												/>
 											);
 										case SUPPORTED_FEED_TYPES.HEADLINES_FEED:
@@ -302,7 +301,6 @@ export const WidgetFeedEdit = ({
 													url={url}
 													// @ts-ignore
 													widget={previewWidget}
-													editable={false}
 												/>
 											);
 										case SUPPORTED_FEED_TYPES.BLOCKS_FEED:
@@ -312,7 +310,6 @@ export const WidgetFeedEdit = ({
 													url={url}
 													// @ts-ignore
 													widget={previewWidget}
-													editable={false}
 												/>
 											);
 										default:
@@ -322,7 +319,6 @@ export const WidgetFeedEdit = ({
 													url={url}
 													// @ts-ignore
 													widget={previewWidget}
-													editable={false}
 												/>
 											);
 									}

--- a/src/store/types/widgets.ts
+++ b/src/store/types/widgets.ts
@@ -20,7 +20,7 @@ export interface IWidget {
 		icon: string;
 		field: SlashFeedJSON['fields'][0];
 	};
-	magiclink: boolean;
+	magiclink?: boolean;
 }
 
 export interface IWidgets {


### PR DESCRIPTION
Closes https://github.com/synonymdev/bitkit/issues/669

### Changes
- only show options for one widget at a time 
- WidgetFeedEdit: only pre-select first option if none selected yet & cleanups