### PR TITLE
fix(widgets): crash when adding widget

### DIFF
--- a/src/screens/Widgets/WidgetFeedEdit.tsx
+++ b/src/screens/Widgets/WidgetFeedEdit.tsx
@@ -176,13 +176,13 @@ export const WidgetFeedEdit = ({
 
 	const headerTitle = savedSelectedField ? 'Change Widget Feed' : 'Widget Feed';
 	const buttonText = savedSelectedField ? 'Save' : 'Save Widget';
-	const previewWidget = config.fields && {
+	const previewWidget = config?.fields && {
 		feed: {
 			name: config.name ?? '',
 			description: config.description ?? '',
 			icon: config.icon ?? '',
 			type: config.type ?? '',
-			field: config.fields?.find((f) => f.name === selectedField)!,
+			field: config.fields.find((f) => f.name === selectedField)!,
 		},
 	};
 


### PR DESCRIPTION
Fixes a crash when first opening the WidgetEdit screen.

![image](https://user-images.githubusercontent.com/8538369/201709705-2c55729f-d75a-4f06-9928-e3e463748c0b.png)
