### PR TITLE
fix(scan): freeze on Android

### DIFF
--- a/src/components/HeadlinesWidget.tsx
+++ b/src/components/HeadlinesWidget.tsx
@@ -1,5 +1,5 @@
 import React, { memo, ReactElement, useEffect, useState } from 'react';
-import { Linking, StyleSheet } from 'react-native';
+import { TouchableOpacity, Linking, StyleSheet } from 'react-native';
 import { SlashURL } from '@synonymdev/slashtags-sdk';
 
 import {
@@ -14,7 +14,6 @@ import { IWidget } from '../store/types/widgets';
 import { useSlashtagsSDK } from './SlashtagsProvider';
 import { showErrorNotification } from '../utils/notifications';
 import { decodeJSON } from '../utils/slashtags';
-import { TouchableOpacity } from 'react-native-gesture-handler';
 import { navigate } from '../navigation/root/RootNavigator';
 import Button from './Button';
 import Dialog from './Dialog';

--- a/src/screens/Scanner/ScannerComponent.tsx
+++ b/src/screens/Scanner/ScannerComponent.tsx
@@ -1,7 +1,11 @@
 import React, { ReactElement, useState } from 'react';
-import { StyleSheet, View, useWindowDimensions } from 'react-native';
+import {
+	View,
+	TouchableOpacity,
+	StyleSheet,
+	useWindowDimensions,
+} from 'react-native';
 import { useSelector } from 'react-redux';
-import { TouchableOpacity } from 'react-native-gesture-handler';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
 import { launchImageLibrary } from 'react-native-image-picker';

--- a/src/screens/Widgets/WidgetsSuggestions.tsx
+++ b/src/screens/Widgets/WidgetsSuggestions.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react';
-import { StyleSheet, ScrollView } from 'react-native';
-import { TouchableOpacity } from 'react-native-gesture-handler';
+import { TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
 
 import {
 	ChartLineIcon,


### PR DESCRIPTION
Changing to correct `TouchableOpacity` imports actually fixes the camera freeze on Android. Also fixed for other components. 