### PR TITLE
fix(lightning): Update payWithTimeout Method

### DIFF
--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -440,7 +440,7 @@ const Channels = ({ navigation }): ReactElement => {
 													setPayingInvoice(false);
 													showSuccessNotification({
 														title: 'Invoice Payment Success',
-														message: response.value,
+														message: `Fee: ${response.value.fee_paid_sat} sats`,
 													});
 												}}
 											/>

--- a/src/screens/Wallets/Send/ReviewAndSend.tsx
+++ b/src/screens/Wallets/Send/ReviewAndSend.tsx
@@ -260,8 +260,6 @@ const ReviewAndSend = ({
 			return;
 		}
 
-		//TODO: Add lightning transaction to activity list.
-
 		// save tags to metadata
 		updateMetaTxTags(transaction.lightningInvoice, transaction.tags);
 		// save Slashtags contact to metadata


### PR DESCRIPTION
This PR:
- Updates `payWithTimeout` usage in `payLightningInvoice`.
- Updates response type for `payLightningInvoice`.
- Passes lightning tx fees to notification and activity object.
- Bumps lightning payment timeout to 30 seconds.
- This addresses #708