### PR TITLE
Feat: add bip39 passphrase support

### DIFF
--- a/nodejs-assets/nodejs-project/bitcoin-actions.js
+++ b/nodejs-assets/nodejs-project/bitcoin-actions.js
@@ -11,7 +11,7 @@ const {
 class BitcoinActions {
     constructor() {
         this.mnemonic = '';
-        this.password = '';
+        this.bip39Passphrase = '';
         this.seed = '';
         this.root = '';
         this.selectedNetwork = '';
@@ -22,7 +22,7 @@ class BitcoinActions {
         method = 'setup',
         data: {
             mnemonic = this.mnemonic,
-            password = this.password,
+            bip39Passphrase = this.bip39Passphrase,
             selectedNetwork = this.selectedNetwork,
         }
     }) {
@@ -36,8 +36,8 @@ class BitcoinActions {
                 }
                 this.mnemonic = mnemonic;
                 this.selectedNetwork = selectedNetwork;
-                this.password = password;
-                this.seed = await bip39.mnemonicToSeed(mnemonic, password);
+                this.bip39Passphrase = bip39Passphrase;
+                this.seed = await bip39.mnemonicToSeed(mnemonic, bip39Passphrase);
                 const network = networks[selectedNetwork];
                 this.root = bip32.fromSeed(this.seed, network);
                 return resolve({ id, method, error: false, value: 'Successfully setup bitcoin-actions.' });
@@ -68,7 +68,7 @@ class BitcoinActions {
         method = 'getPrivateKey',
         data: {
             mnemonic = this.mnemonic,
-            password = this.password,
+            bip39Passphrase = this.bip39Passphrase,
             path = '',
             selectedNetwork = this.selectedNetwork,
         }}) {
@@ -77,7 +77,7 @@ class BitcoinActions {
                 if (!this.root || !this.seed) {
                     await this.setup({
                         selectedNetwork,
-                        data: { mnemonic , password }
+                        data: { mnemonic , bip39Passphrase }
                     });
                 }
 
@@ -104,7 +104,7 @@ class BitcoinActions {
             if (!this.root || !this.seed) {
                 await this.setup({
                     selectedNetwork: this.selectedNetwork,
-                    data: { mnemonic: this.mnemonic , password: this.password }
+                    data: { mnemonic: this.mnemonic , bip39Passphrase: this.bip39Passphrase }
                 });
             }
             if (!path) {

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "react-native-screens": "^3.18.2",
     "react-native-share": "^7.4.1",
     "react-native-svg": "^12.3.0",
-    "react-native-swiper": "^1.6.0",
     "react-native-tcp-socket": "^5.6.2",
     "react-native-toast-message": "^2.1.5",
     "react-native-touch-id": "^4.4.1",

--- a/src/components/BetaWarning.tsx
+++ b/src/components/BetaWarning.tsx
@@ -4,80 +4,13 @@ import { Canvas, LinearGradient, Rect, vec } from '@shopify/react-native-skia';
 import { FadeOut } from 'react-native-reanimated';
 import { useSelector } from 'react-redux';
 
-import {
-	Caption13M,
-	Caption13Up,
-	Text01M,
-	View,
-	XIcon,
-	AnimatedView,
-} from '../styles/components';
+import { Caption13M, Text01M, XIcon, AnimatedView } from '../styles/components';
 import useColors from '../hooks/colors';
 import Store from '../store/types';
 import { updateSettings } from '../store/actions/settings';
+import Flag from '../components/Flag';
 
-const FLAG_HEIGHT = 26;
 const BETA_HEIGHT = 100;
-
-const Flag = ({
-	style,
-	text,
-}: {
-	style?: object;
-	text: string;
-}): ReactElement => {
-	return (
-		<View style={[stylesFlag.root, style]} color="transparent">
-			<View color="brand" style={[stylesFlag.box, stylesFlag.box3]} />
-			<View style={stylesFlag.row} color="transparent">
-				<View color="brand" style={[stylesFlag.box, stylesFlag.box1]} />
-				<View color="brand" style={[stylesFlag.box, stylesFlag.box2]} />
-				<View color="brand" style={stylesFlag.text}>
-					<Caption13Up>{text}</Caption13Up>
-				</View>
-			</View>
-		</View>
-	);
-};
-
-const stylesFlag = StyleSheet.create({
-	root: {
-		height: FLAG_HEIGHT * 1.5,
-		overflow: 'hidden',
-	},
-	row: {
-		height: FLAG_HEIGHT,
-		overflow: 'hidden',
-		paddingLeft: FLAG_HEIGHT / 2,
-		position: 'relative',
-	},
-	box: {
-		height: FLAG_HEIGHT,
-		width: FLAG_HEIGHT,
-		position: 'absolute',
-	},
-	box1: {
-		transform: [{ skewY: '45deg' }],
-		top: -FLAG_HEIGHT / 2,
-	},
-	box2: {
-		transform: [{ skewY: '-45deg' }],
-		top: +FLAG_HEIGHT / 2,
-	},
-	box3: {
-		transform: [{ skewY: '45deg' }],
-		right: -FLAG_HEIGHT / 2,
-		top: FLAG_HEIGHT / 2,
-		opacity: 0.5,
-	},
-	text: {
-		height: FLAG_HEIGHT,
-		paddingLeft: 6,
-		paddingRight: 12,
-		justifyContent: 'center',
-		alignItems: 'center',
-	},
-});
 
 const BetaSoftware = (): ReactElement => {
 	const colors = useColors();

--- a/src/components/Flag.tsx
+++ b/src/components/Flag.tsx
@@ -1,0 +1,68 @@
+import React, { memo, ReactElement } from 'react';
+import { StyleSheet } from 'react-native';
+
+import { Caption13Up, View } from '../styles/components';
+
+const FLAG_HEIGHT = 26;
+
+const Flag = ({
+	style,
+	text,
+}: {
+	style?: object;
+	text: string;
+}): ReactElement => {
+	return (
+		<View style={[styles.root, style]} color="transparent">
+			<View color="brand" style={[styles.box, styles.box3]} />
+			<View style={styles.row} color="transparent">
+				<View color="brand" style={[styles.box, styles.box1]} />
+				<View color="brand" style={[styles.box, styles.box2]} />
+				<View color="brand" style={styles.text}>
+					<Caption13Up>{text}</Caption13Up>
+				</View>
+			</View>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	root: {
+		height: FLAG_HEIGHT * 1.5,
+		overflow: 'hidden',
+	},
+	row: {
+		height: FLAG_HEIGHT,
+		overflow: 'hidden',
+		paddingLeft: FLAG_HEIGHT / 2,
+		position: 'relative',
+	},
+	box: {
+		height: FLAG_HEIGHT,
+		width: FLAG_HEIGHT,
+		position: 'absolute',
+	},
+	box1: {
+		transform: [{ skewY: '45deg' }],
+		top: -FLAG_HEIGHT / 2,
+	},
+	box2: {
+		transform: [{ skewY: '-45deg' }],
+		top: +FLAG_HEIGHT / 2,
+	},
+	box3: {
+		transform: [{ skewY: '45deg' }],
+		right: -FLAG_HEIGHT / 2,
+		top: FLAG_HEIGHT / 2,
+		opacity: 0.5,
+	},
+	text: {
+		height: FLAG_HEIGHT,
+		paddingLeft: 6,
+		paddingRight: 12,
+		justifyContent: 'center',
+		alignItems: 'center',
+	},
+});
+
+export default memo(Flag);

--- a/src/components/GlowingBackground.tsx
+++ b/src/components/GlowingBackground.tsx
@@ -1,4 +1,10 @@
-import React, { memo, ReactElement, useState, useEffect } from 'react';
+import React, {
+	memo,
+	ReactElement,
+	ReactNode,
+	useState,
+	useEffect,
+} from 'react';
 import { StyleSheet } from 'react-native';
 import { useWindowDimensions } from 'react-native';
 import { useSelector } from 'react-redux';
@@ -65,7 +71,7 @@ const GlowingBackground = ({
 	topLeft,
 	bottomRight,
 }: {
-	children: ReactElement | ReactElement[];
+	children: ReactNode;
 	topLeft?: string;
 	bottomRight?: string;
 }): ReactElement => {

--- a/src/components/SeedInput.tsx
+++ b/src/components/SeedInput.tsx
@@ -1,27 +1,34 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useMemo } from 'react';
 import { StyleSheet, View, TextInputProps } from 'react-native';
 import { Text01S, TextInput } from '../styles/components';
 
-type SeedInputProps = TextInputProps & { index: number; valid: boolean };
+type SeedInputProps = TextInputProps & { index?: number; valid?: boolean };
 
 const SeedInput = forwardRef(
 	({ index, valid, ...props }: SeedInputProps, ref) => {
+		const inputStyle = useMemo(
+			() => [styles.input, { paddingLeft: index !== undefined ? 45 : 16 }],
+			[index],
+		);
+
 		return (
 			<View style={styles.inputWrapper}>
 				<TextInput
 					ref={ref}
-					style={styles.input}
+					style={inputStyle}
 					color={valid ? 'white' : 'red'}
 					autoCapitalize="none"
 					autoCorrect={false}
 					returnKeyType="done"
 					{...props}
 				/>
-				<View style={styles.index}>
-					<Text01S color={valid ? 'white5' : 'red'} style={styles.indexText}>
-						{index + 1}.
-					</Text01S>
-				</View>
+				{index !== undefined && (
+					<View style={styles.index}>
+						<Text01S color={valid ? 'white5' : 'red'} style={styles.indexText}>
+							{index + 1}.
+						</Text01S>
+					</View>
+				)}
 			</View>
 		);
 	},

--- a/src/components/TodoCarousel.tsx
+++ b/src/components/TodoCarousel.tsx
@@ -1,5 +1,4 @@
 import React, {
-	useRef,
 	memo,
 	ReactElement,
 	useMemo,
@@ -23,7 +22,6 @@ import type { RootNavigationProp } from '../navigation/types';
 const TodoCarousel = (): ReactElement => {
 	const navigation = useNavigation<RootNavigationProp>();
 	const { width } = useWindowDimensions();
-	const ref = useRef(null);
 	const [index, setIndex] = useState(0);
 	const [showDialog, setShowDialog] = useState(false);
 	const todos = useSelector((state: Store) => state.todos);
@@ -108,7 +106,6 @@ const TodoCarousel = (): ReactElement => {
 			<Subtitle style={styles.title}>Suggestions</Subtitle>
 			<View style={styles.container}>
 				<Carousel
-					ref={ref}
 					style={carouselStyle}
 					data={todos}
 					defaultIndex={index}

--- a/src/navigation/bottom-sheet/BackupNavigation.tsx
+++ b/src/navigation/bottom-sheet/BackupNavigation.tsx
@@ -8,7 +8,9 @@ import {
 
 import BottomSheetWrapper from '../../components/BottomSheetWrapper';
 import ShowMnemonic from '../../screens/Settings/Backup/ShowMnemonic';
+import ShowPassphrase from '../../screens/Settings/Backup/ShowPassphrase';
 import ConfirmMnemonic from '../../screens/Settings/Backup/ConfirmMnemonic';
+import ConfirmPassphrase from '../../screens/Settings/Backup/ConfirmPassphrase';
 import Result from '../../screens/Settings/Backup/Result';
 import Warning from '../../screens/Settings/Backup/Warning';
 import Metadata from '../../screens/Settings/Backup/Metadata';
@@ -21,7 +23,9 @@ export type BackupNavigationProp =
 
 export type BackupStackParamList = {
 	ShowMnemonic: undefined;
-	ConfirmMnemonic: undefined;
+	ShowPassphrase: { seed: string[]; bip39Passphrase: string };
+	ConfirmMnemonic: { seed: string[]; bip39Passphrase: string };
+	ConfirmPassphrase: { bip39Passphrase: string };
 	Result: undefined;
 	Warning: undefined;
 	Metadata: undefined;
@@ -45,7 +49,12 @@ const BackupNavigation = (): ReactElement => {
 				<Stack.Navigator screenOptions={navOptions}>
 					<Stack.Group screenOptions={navOptions}>
 						<Stack.Screen name="ShowMnemonic" component={ShowMnemonic} />
+						<Stack.Screen name="ShowPassphrase" component={ShowPassphrase} />
 						<Stack.Screen name="ConfirmMnemonic" component={ConfirmMnemonic} />
+						<Stack.Screen
+							name="ConfirmPassphrase"
+							component={ConfirmPassphrase}
+						/>
 						<Stack.Screen name="Result" component={Result} />
 						<Stack.Screen name="Warning" component={Warning} />
 						<Stack.Screen name="Metadata" component={Metadata} />

--- a/src/navigation/onboarding/OnboardingNavigator.tsx
+++ b/src/navigation/onboarding/OnboardingNavigator.tsx
@@ -8,6 +8,7 @@ import TermsOfUse from '../../screens/Onboarding/TermsOfUse';
 import WelcomeScreen from '../../screens/Onboarding/Welcome';
 import SlideshowScreen from '../../screens/Onboarding/Slideshow';
 import RestoreFromSeed from '../../screens/Onboarding/RestoreFromSeed';
+import Passphrase from '../../screens/Onboarding/Passphrase';
 import { NavigationContainer } from '../../styles/components';
 
 export type OnboardingNavigationProp =
@@ -16,8 +17,9 @@ export type OnboardingNavigationProp =
 export type OnboardingStackParamList = {
 	TermsOfUse: undefined;
 	Welcome: undefined;
-	Slideshow: { skipIntro?: boolean } | undefined;
+	Slideshow: { skipIntro?: boolean; bip39Passphrase?: string } | undefined;
 	RestoreFromSeed: undefined;
+	Passphrase: undefined;
 };
 
 const Stack = createNativeStackNavigator<OnboardingStackParamList>();
@@ -49,6 +51,11 @@ const OnboardingNavigator = (): ReactElement => {
 				<Stack.Screen
 					name="RestoreFromSeed"
 					component={RestoreFromSeed}
+					options={navOptionHandler}
+				/>
+				<Stack.Screen
+					name="Passphrase"
+					component={Passphrase}
 					options={navOptionHandler}
 				/>
 			</Stack.Navigator>

--- a/src/screens/Onboarding/Passphrase.tsx
+++ b/src/screens/Onboarding/Passphrase.tsx
@@ -1,0 +1,148 @@
+import React, { ReactElement, memo, useState, useMemo } from 'react';
+import {
+	Image,
+	KeyboardAvoidingView,
+	Platform,
+	ScrollView,
+	StyleSheet,
+	View,
+	useWindowDimensions,
+} from 'react-native';
+
+import { Display, Text01S, TextInput } from '../../styles/components';
+import SafeAreaInsets from '../../components/SafeAreaInsets';
+import GlowingBackground from '../../components/GlowingBackground';
+import NavigationHeader from '../../components/NavigationHeader';
+import Button from '../../components/Button';
+import Flag from '../../components/Flag';
+import type { OnboardingStackScreenProps } from '../../navigation/types';
+import { useScreenSize } from '../../hooks/screen';
+
+const imageSrc = require('../../assets/illustrations/padlock2.png');
+
+const Passphrase = ({
+	navigation,
+}: OnboardingStackScreenProps<'Passphrase'>): ReactElement => {
+	const [bip39Passphrase, setPassphrase] = useState<string>('');
+	const { isSmallScreen } = useScreenSize();
+
+	const dimensions = useWindowDimensions();
+	const illustrationStyles = useMemo(
+		() => ({
+			...styles.image,
+			width: dimensions.width * (isSmallScreen ? 0.6 : 0.7),
+			height: dimensions.width * (isSmallScreen ? 0.6 : 0.7),
+			...(isSmallScreen ? { marginTop: -30 } : {}),
+		}),
+		[dimensions.width, isSmallScreen],
+	);
+
+	return (
+		<GlowingBackground topLeft="brand">
+			<KeyboardAvoidingView
+				style={styles.slide}
+				behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+				<ScrollView
+					bounces={false}
+					contentContainerStyle={styles.scrollContent}
+					showsVerticalScrollIndicator={false}>
+					<SafeAreaInsets type="top" />
+					<View style={styles.navigationContainer}>
+						<NavigationHeader />
+						<Flag text="Advanced" style={styles.flag} />
+					</View>
+					<View style={styles.imageContainer}>
+						<Image style={illustrationStyles} source={imageSrc} />
+					</View>
+					<View style={styles.textContent}>
+						<Display>
+							Secure with <Display color="brand">Passphrase</Display>
+						</Display>
+						<Text01S color="gray1" style={styles.text}>
+							You can add a secret passphrase to the 12-word recovery phrase. If
+							you do, make sure you don’t forget.
+						</Text01S>
+
+						<TextInput
+							style={styles.input}
+							value={bip39Passphrase}
+							onChangeText={setPassphrase}
+							returnKeyType="done"
+							autoCapitalize="none"
+							autoCompleteType="off"
+							autoCorrect={false}
+							placeholder="Passphrase"
+						/>
+					</View>
+
+					<View style={styles.buttonContainer}>
+						<Button
+							text="Create New Wallet"
+							size="large"
+							style={[styles.button, styles.customButton]}
+							onPress={(): void => {
+								navigation.navigate('Slideshow', { bip39Passphrase });
+							}}
+						/>
+					</View>
+					<SafeAreaInsets type="bottom" />
+				</ScrollView>
+			</KeyboardAvoidingView>
+		</GlowingBackground>
+	);
+};
+
+const styles = StyleSheet.create({
+	scrollContent: {
+		flexGrow: 1,
+	},
+	slide: {
+		flex: 1,
+		justifyContent: 'space-between',
+		alignItems: 'stretch',
+		marginBottom: 16,
+	},
+	navigationContainer: {
+		position: 'relative',
+	},
+	flag: {
+		position: 'absolute',
+		top: 17,
+		right: 0,
+	},
+	imageContainer: {
+		flex: 2.8,
+		alignItems: 'center',
+		marginBottom: 32,
+		justifyContent: 'flex-end',
+	},
+	image: {
+		resizeMode: 'contain',
+	},
+	textContent: {
+		// line up Welcome screen content with Slideshow
+		flex: Platform.OS === 'ios' ? 3.2 : 3.5,
+		paddingHorizontal: 48,
+	},
+	text: {
+		marginTop: 8,
+	},
+	input: {
+		marginTop: 24,
+		marginBottom: 16,
+	},
+	buttonContainer: {
+		flexDirection: 'row',
+		justifyContent: 'center',
+		marginTop: 'auto',
+		paddingHorizontal: 48,
+	},
+	button: {
+		flex: 1,
+	},
+	customButton: {
+		marginLeft: 6,
+	},
+});
+
+export default memo(Passphrase);

--- a/src/screens/Settings/Backup/ConfirmMnemonic.tsx
+++ b/src/screens/Settings/Backup/ConfirmMnemonic.tsx
@@ -7,6 +7,7 @@ import Button from '../../../components/Button';
 import { shuffleArray } from '../../../utils/helpers';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
 import GradientView from '../../../components/GradientView';
+import type { BackupScreenProps } from '../../../navigation/types';
 
 const Word = ({
 	number,
@@ -25,8 +26,11 @@ const Word = ({
 	);
 };
 
-const ConfirmMnemonic = ({ navigation, route }): ReactElement => {
-	const origSeed = route.params.seed;
+const ConfirmMnemonic = ({
+	navigation,
+	route,
+}: BackupScreenProps<'ConfirmMnemonic'>): ReactElement => {
+	const { seed: origSeed, bip39Passphrase } = route.params;
 	const [seed, setSeed] = useState(Array(origSeed.length).fill(undefined));
 	const [pressed, setPressed] = useState(Array(origSeed.length).fill(false));
 	const shuffled = useMemo(() => shuffleArray(origSeed), [origSeed]);
@@ -125,7 +129,13 @@ const ConfirmMnemonic = ({ navigation, route }): ReactElement => {
 					<Button
 						size="large"
 						text="Continue"
-						onPress={(): void => navigation.navigate('Result')}
+						onPress={(): void => {
+							if (bip39Passphrase) {
+								navigation.navigate('ConfirmPassphrase', { bip39Passphrase });
+							} else {
+								navigation.navigate('Result');
+							}
+						}}
 					/>
 				)}
 			</View>

--- a/src/screens/Settings/Backup/ConfirmPassphrase.tsx
+++ b/src/screens/Settings/Backup/ConfirmPassphrase.tsx
@@ -1,0 +1,82 @@
+import React, { memo, ReactElement, useMemo, useState } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Text01S, BottomSheetTextInput } from '../../../styles/components';
+import Button from '../../../components/Button';
+import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
+import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
+import type { BackupScreenProps } from '../../../navigation/types';
+
+const ConfirmPassphrase = ({
+	navigation,
+	route,
+}: BackupScreenProps<'ConfirmPassphrase'>): ReactElement => {
+	const { bip39Passphrase: origPass } = route.params;
+	const [bip39Passphrase, setPassphrase] = useState<string>('');
+
+	const insets = useSafeAreaInsets();
+	const nextButtonContainer = useMemo(
+		() => ({
+			...styles.nextButtonContainer,
+			paddingBottom: insets.bottom + 16,
+		}),
+		[insets.bottom],
+	);
+
+	useBottomSheetBackPress('backupNavigation');
+
+	return (
+		<GradientView style={styles.gradient}>
+			<BottomSheetNavigationHeader title="Confirm Passphrase" />
+			<View style={styles.container}>
+				<Text01S color="gray1">
+					Enter the passphrase you added while setting up and creating your
+					wallet.
+				</Text01S>
+
+				<View style={styles.input}>
+					<BottomSheetTextInput
+						value={bip39Passphrase}
+						placeholder="Passphrase"
+						returnKeyType="done"
+						onChangeText={setPassphrase}
+						autoCapitalize="none"
+						autoCompleteType="off"
+						autoCorrect={false}
+					/>
+				</View>
+
+				<View style={nextButtonContainer}>
+					<Button
+						disabled={bip39Passphrase !== origPass}
+						size="large"
+						text="Continue"
+						onPress={(): void => navigation.navigate('Result')}
+					/>
+				</View>
+			</View>
+		</GradientView>
+	);
+};
+
+const styles = StyleSheet.create({
+	gradient: {
+		flex: 1,
+	},
+	container: {
+		flex: 1,
+		paddingHorizontal: 32,
+	},
+	input: {
+		marginTop: 32,
+		flex: 1,
+	},
+	nextButtonContainer: {
+		marginTop: 22,
+		width: '100%',
+	},
+});
+
+export default memo(ConfirmPassphrase);

--- a/src/screens/Settings/Backup/ShowMnemonic.tsx
+++ b/src/screens/Settings/Backup/ShowMnemonic.tsx
@@ -10,10 +10,11 @@ import {
 } from '../../../styles/components';
 import Button from '../../../components/Button';
 import BlurView from '../../../components/BlurView';
-import { getMnemonicPhrase } from '../../../utils/wallet';
+import { getMnemonicPhrase, getBip39Passphrase } from '../../../utils/wallet';
 import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
 import { showErrorNotification } from '../../../utils/notifications';
+import type { BackupScreenProps } from '../../../navigation/types';
 
 // Android doesn't have blur so we put a dummy mnemonic
 const dummySeed = Array.from({ length: 12 }, () => 'secret');
@@ -33,9 +34,12 @@ const Word = ({
 	);
 };
 
-const ShowMnemonic = ({ navigation }): ReactElement => {
+const ShowMnemonic = ({
+	navigation,
+}: BackupScreenProps<'ShowMnemonic'>): ReactElement => {
 	const [show, setShow] = useState(false);
 	const [seed, setSeed] = useState<string[]>([]);
+	const [bip39Passphrase, setPassphrase] = useState<string>('');
 	const insets = useSafeAreaInsets();
 	const nextButtonContainer = useMemo(
 		() => ({
@@ -58,6 +62,7 @@ const ShowMnemonic = ({ navigation }): ReactElement => {
 			}
 			setSeed(res.value.split(' '));
 		});
+		getBip39Passphrase().then(setPassphrase);
 	}, []);
 
 	const seedToShow = Platform.OS === 'android' && !show ? dummySeed : seed;
@@ -117,9 +122,15 @@ const ShowMnemonic = ({ navigation }): ReactElement => {
 					<Button
 						size="large"
 						text="Continue"
-						onPress={(): void =>
-							navigation.navigate('ConfirmMnemonic', { seed })
-						}
+						onPress={(): void => {
+							navigation.navigate(
+								bip39Passphrase ? 'ShowPassphrase' : 'ConfirmMnemonic',
+								{
+									seed,
+									bip39Passphrase,
+								},
+							);
+						}}
 					/>
 				)}
 			</View>

--- a/src/screens/Settings/Backup/ShowPassphrase.tsx
+++ b/src/screens/Settings/Backup/ShowPassphrase.tsx
@@ -1,0 +1,94 @@
+import React, { memo, ReactElement, useMemo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+
+import {
+	View as ThemedView,
+	Text01S,
+	Text01M,
+	Text02S,
+} from '../../../styles/components';
+import Button from '../../../components/Button';
+import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
+import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import GradientView from '../../../components/GradientView';
+import type { BackupScreenProps } from '../../../navigation/types';
+
+const ShowPassphrase = ({
+	navigation,
+	route,
+}: BackupScreenProps<'ShowPassphrase'>): ReactElement => {
+	const { bip39Passphrase, seed } = route.params;
+	const insets = useSafeAreaInsets();
+	const nextButtonContainer = useMemo(
+		() => ({
+			...styles.nextButtonContainer,
+			paddingBottom: insets.bottom + 16,
+		}),
+		[insets.bottom],
+	);
+
+	useBottomSheetBackPress('backupNavigation');
+
+	return (
+		<GradientView style={styles.gradient}>
+			<BottomSheetNavigationHeader title="Your Passphrase" />
+			<View style={styles.container}>
+				<Text01S color="gray1">
+					You added a passphrase to your recovery phrase during wallet setup.
+				</Text01S>
+
+				<ThemedView color="gray324" style={styles.passphrase}>
+					<BottomSheetScrollView>
+						<Text01M color="white5" style={styles.p}>
+							passphrase
+						</Text01M>
+						<Text01M>{bip39Passphrase}</Text01M>
+					</BottomSheetScrollView>
+				</ThemedView>
+
+				<Text02S color="gray1">
+					We recommend remembering and/or writing down this passphrase.{' '}
+					<Text02S color="brand">Never share</Text02S> your passphrase with
+					anyone.
+				</Text02S>
+
+				<View style={nextButtonContainer}>
+					<Button
+						size="large"
+						text="Continue"
+						onPress={(): void =>
+							navigation.navigate('ConfirmMnemonic', { seed, bip39Passphrase })
+						}
+					/>
+				</View>
+			</View>
+		</GradientView>
+	);
+};
+
+const styles = StyleSheet.create({
+	gradient: {
+		flex: 1,
+	},
+	container: {
+		flex: 1,
+		paddingHorizontal: 32,
+	},
+	passphrase: {
+		marginVertical: 32,
+		padding: 32,
+		borderRadius: 16,
+		flex: 1,
+	},
+	p: {
+		marginBottom: 8,
+	},
+	nextButtonContainer: {
+		marginTop: 22,
+		width: '100%',
+	},
+});
+
+export default memo(ShowPassphrase);

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -79,6 +79,7 @@ export const updateWallet = (payload): Promise<Result<string>> => {
  * @param {number} [addressAmount]
  * @param {number} [changeAddressAmount]
  * @param {string} [mnemonic]
+ * @param {string} [bip39Passphrase]
  * @param {IAddressType} [addressTypes]
  * @return {Promise<Result<string>>}
  */
@@ -87,6 +88,7 @@ export const createWallet = async ({
 	addressAmount = GENERATE_ADDRESS_AMOUNT,
 	changeAddressAmount = GENERATE_ADDRESS_AMOUNT,
 	mnemonic = '',
+	bip39Passphrase = '',
 	addressTypes,
 }: ICreateWallet): Promise<Result<string>> => {
 	if (!addressTypes) {
@@ -98,6 +100,7 @@ export const createWallet = async ({
 			addressAmount,
 			changeAddressAmount,
 			mnemonic,
+			bip39Passphrase,
 			addressTypes,
 		});
 		if (response.isErr()) {

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -155,6 +155,7 @@ export interface IAddress {
 export interface ICreateWallet {
 	walletName?: string;
 	mnemonic?: string;
+	bip39Passphrase?: string;
 	addressAmount?: number;
 	changeAddressAmount?: number;
 	addressTypes?: IAddressType;

--- a/src/utils/nodejs-mobile/index.ts
+++ b/src/utils/nodejs-mobile/index.ts
@@ -3,6 +3,7 @@ import { TAvailableNetworks } from '../networks';
 import nodejs from 'nodejs-mobile-react-native';
 import {
 	getMnemonicPhrase,
+	getBip39Passphrase,
 	getSelectedNetwork,
 	getSelectedWallet,
 } from '../wallet';
@@ -118,6 +119,7 @@ export const setupNodejsMobile = async ({
 	let setupShape = DefaultNodeJsMethodsShape.setup();
 	setupShape.data.selectedNetwork = selectedNetwork;
 	setupShape.data.mnemonic = mnemonic;
+	setupShape.data.bip39Passphrase = await getBip39Passphrase();
 	await invokeNodeJsMethod(setupShape);
 	isSetup = true;
 	return ok('');

--- a/src/utils/nodejs-mobile/shapes.ts
+++ b/src/utils/nodejs-mobile/shapes.ts
@@ -15,7 +15,7 @@ export const DefaultNodeJsMethodsShape = {
 			method: ENodeJsMethods.setup,
 			data: {
 				mnemonic: '',
-				password: '',
+				bip39Passphrase: '',
 				selectedNetwork: undefined,
 			},
 		};
@@ -45,7 +45,7 @@ export const DefaultNodeJsMethodsShape = {
 			method: ENodeJsMethods.getPrivateKey,
 			data: {
 				mnemonic: '',
-				password: '',
+				bip39Passphrase: '',
 				path: '',
 				selectedNetwork: undefined,
 			},

--- a/src/utils/nodejs-mobile/types.ts
+++ b/src/utils/nodejs-mobile/types.ts
@@ -24,7 +24,7 @@ export interface INodeJsSetup {
 	method: ENodeJsMethods.setup;
 	data: {
 		mnemonic: string;
-		password?: string;
+		bip39Passphrase?: string;
 		selectedNetwork?: TAvailableNetworks;
 	};
 }
@@ -42,7 +42,7 @@ export interface INodeJsGetPrivateKey {
 	method: ENodeJsMethods.getPrivateKey;
 	data: {
 		mnemonic: string;
-		password: string;
+		bip39Passphrase: string;
 		path: string;
 		selectedNetwork?: TAvailableNetworks;
 	};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9042,7 +9042,7 @@ prompts@^2.0.1, prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@*, prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@*, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -9563,13 +9563,6 @@ react-native-svg@^12.3.0:
   dependencies:
     css-select "^5.1.0"
     css-tree "^1.1.3"
-
-react-native-swiper@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-swiper/-/react-native-swiper-1.6.0.tgz#59fdbdf95addee49630312f27077622c27776819"
-  integrity sha512-OnkTTZi+9uZUgy0uz1I9oYDhCU3z36lZn+LFsk9FXPRelxb/KeABzvPs3r3SrHWy1aA67KGtSFj0xNK2QD0NJQ==
-  dependencies:
-    prop-types "^15.5.10"
 
 react-native-tcp-socket@^5.6.2:
   version "5.6.2"


### PR DESCRIPTION
- create new wallet + passphrase
- recover wallet + passphrase
- backup flow with passphrase
- react-native-swiper replaced with react-native-reanimated-carousel

Also I've renamed `password` to `bip39Passphrase` in a few places to make code more consistent

And I removed wallet generation logic from `startWalletServices` or `createDefaultWallet`. It was super confusing to have it in a few places. Now there is only one `generateMnemonic()` call in the app