### PR TITLE
fix: use skia@156 when running e2e tests on iOS

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Activate react-native-skia-stup
         run: |
-          yarn add git+ssh://git@github.com/limpbrains/react-native-skia-stub
+          yarn add @shopify/react-native-skia@0.1.156 git+ssh://git@github.com/limpbrains/react-native-skia-stub
           patch -p1 < .github/workflows/react-native-skia-stub.patch
 
       - name: Cache Pods


### PR DESCRIPTION
v156 works fine on iOS, but not on Android, that is why we are using it for tests