### PR TITLE
feat(profile): add prefix to profile links if suggestions were used

### DIFF
--- a/src/screens/Profile/ProfileAddLink.tsx
+++ b/src/screens/Profile/ProfileAddLink.tsx
@@ -12,12 +12,17 @@ import { updateProfileLink } from '../../store/actions/ui';
 import NavigationHeader from '../../components/NavigationHeader';
 import SafeAreaInsets from '../../components/SafeAreaInsets';
 import { addLink } from '../../store/actions/slashtags';
+import { suggestions } from './ProfileLinkSuggestions';
 
 export const ProfileAddLinkForm = ({
 	navigation,
 }: RootStackScreenProps<'ProfileAddLink'>): ReactElement => {
 	const insets = useSafeAreaInsets();
-	const form = useSelector((state: Store) => state.ui.profileLink);
+	const form = useSelector((state: Store) => {
+		const _form = state.ui.profileLink;
+		_form.url = _form.url || suggestions[_form.title]?.prefix || '';
+		return _form;
+	});
 
 	const buttonContainerStyles = useMemo(
 		() => ({
@@ -59,7 +64,7 @@ export const ProfileAddLinkForm = ({
 				<LabeledInput
 					style={styles.input}
 					label="Link or text"
-					placeholder="https://"
+					placeholder={suggestions[form.title]?.prefix}
 					value={form.url}
 					multiline={true}
 					returnKeyType="default"

--- a/src/screens/Profile/ProfileLinkSuggestions.tsx
+++ b/src/screens/Profile/ProfileLinkSuggestions.tsx
@@ -8,30 +8,30 @@ import { updateProfileLink } from '../../store/actions/ui';
 import SafeAreaInsets from '../../components/SafeAreaInsets';
 import type { RootStackScreenProps } from '../../navigation/types';
 
-const suggestions = [
-	'Email',
-	'Phone',
-	'Website',
-	'Twitter',
-	'Telegram',
-	'Instagram',
-	'Facebook',
-	'LinkedIn',
-	'Github',
-	'Calendly',
-	'Vimeo',
-	'YouTube',
-	'Twitch',
-	'Pinterest',
-	'TikTok',
-	'Spotify',
-];
+export const suggestions = {
+	Email: { prefix: 'mailto:' },
+	Phone: { prefix: 'tel:' },
+	Website: { prefix: 'https://' },
+	Twitter: { prefix: 'https://twitter.com/' },
+	Telegram: { prefix: 'https://t.me/' },
+	Instagram: { prefix: 'https://instagram.com/' },
+	Facebook: { prefix: 'https://facebook.com/' },
+	LinkedIn: { prefix: 'https://linkedin.com/in/' },
+	Github: { prefix: 'https://github.com/' },
+	Calendly: { prefix: 'https://calendly.com/' },
+	Vimeo: { prefix: 'https://vimeo.com/' },
+	Youtube: { prefix: 'https://www.youtube.com/@' },
+	Twitch: { prefix: 'https://www.twitch.tv/' },
+	Pinterest: { prefix: 'https://pinterest.com/' },
+	TikTok: { prefix: 'https://tiktok.com/@' },
+	Spotify: { prefix: 'https://open.spotify.com/' },
+};
 
 export const ProfileLinkSuggestions = ({
 	navigation,
 }: RootStackScreenProps<'ProfileLinkSuggestions'>): ReactElement => {
 	const handleChoose = (suggestion: string): void => {
-		updateProfileLink({ title: suggestion });
+		updateProfileLink({ title: suggestion, url: '' });
 		navigation.goBack();
 	};
 
@@ -40,7 +40,7 @@ export const ProfileLinkSuggestions = ({
 			<SafeAreaInsets type="top" />
 			<NavigationHeader title="Suggestions To Add" />
 			<View style={styles.buttons}>
-				{suggestions.map((suggestion) => (
+				{Object.keys(suggestions).map((suggestion) => (
 					<Button
 						key={suggestion}
 						text={suggestion}


### PR DESCRIPTION
This PR tries to improve profile links input, without going too crazy with regex and validating every URI under the sun!

I regret that I couldn't use `useRef` to focus on the input text too.

![simulator_screenshot_4174559E-0242-4448-AAE3-27B7CFC9F3C3](https://user-images.githubusercontent.com/40009100/206230348-336457c2-114f-4669-b6df-94e18a68daff.png)
