### PR TITLE
fix: try to close the app after Wipe App action

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -331,6 +331,8 @@ PODS:
     - React-Core
   - react-native-randombytes (3.6.1):
     - React-Core
+  - react-native-restart (0.0.24):
+    - React-Core
   - react-native-safe-area-context (4.3.3):
     - RCT-Folly
     - RCTRequired
@@ -568,6 +570,7 @@ DEPENDENCIES:
   - react-native-mmkv (from `../node_modules/react-native-mmkv`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-randombytes (from `../node_modules/react-native-randombytes`)
+  - react-native-restart (from `../node_modules/react-native-restart`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-skia (from `../node_modules/@shopify/react-native-skia`)"
   - react-native-tcp-socket (from `../node_modules/react-native-tcp-socket`)
@@ -691,6 +694,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-randombytes:
     :path: "../node_modules/react-native-randombytes"
+  react-native-restart:
+    :path: "../node_modules/react-native-restart"
   react-native-safe-area-context:
     :path: "../node_modules/react-native-safe-area-context"
   react-native-skia:
@@ -761,7 +766,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: 023a2028f218d648b588348bfa9261b4914b93db
   FBReactNativeSpec: 9f4902cc009389d3704ff75de2aa513dee34d5c2
   Flipper: 1cdd72ffa916071754a41e9684fb9bcaa4b690bf
@@ -774,7 +779,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
   FlipperKit: 87dd306eef9927220672f98266e68bdab6c7cd69
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 476ee3e89abb49e07f822b48323c51c57124b572
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
   hermes-engine: 84e3af1ea01dd7351ac5d8689cbbea1f9903ffc3
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   lottie-ios: 8f97d3271e155c2d688875c29cd3c74908aef5f8
@@ -808,6 +813,7 @@ SPEC CHECKSUMS:
   react-native-mmkv: 1265a348a4711097ba29c8bcefd5971f48220f2b
   react-native-netinfo: 1a6035d3b9780221d407c277ebfb5722ace00658
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
+  react-native-restart: 45c8dca02491980f2958595333cbccd6877cb57e
   react-native-safe-area-context: b456e1c40ec86f5593d58b275bd0e9603169daca
   react-native-skia: 0bd524b32fb96b4f7b7ceeddd90b7be14e64701d
   react-native-tcp-socket: c1b7297619616b4c9caae6889bcb0aba78086989

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "react-native-rate": "^1.2.9",
     "react-native-reanimated": "2.12.0",
     "react-native-reanimated-carousel": "3.0.6",
+    "react-native-restart": "0.0.24",
     "react-native-safe-area-context": "^4.2.5",
     "react-native-screens": "^3.18.2",
     "react-native-share": "^7.4.1",

--- a/src/store/actions/settings.ts
+++ b/src/store/actions/settings.ts
@@ -1,6 +1,9 @@
+import RNRestart from 'react-native-restart';
+import { err, ok, Result } from '@synonymdev/result';
+import { Platform, BackHandler } from 'react-native';
+
 import actions from './actions';
 import { getDispatch } from '../helpers';
-import { err, ok, Result } from '@synonymdev/result';
 import { getSelectedNetwork, getSelectedWallet } from '../../utils/wallet';
 import { resetKeychainValue } from '../../utils/helpers';
 import { wipeLdkStorage } from '../../utils/lightning';
@@ -60,6 +63,13 @@ export const wipeApp = async ({
 			message: 'All app data has been reset.',
 		});
 
+		// BackHandler.exitApp() works fine on Android and closes the app
+		// for iOS we are using react-native-restart to restart the app
+		if (Platform.OS === 'android') {
+			BackHandler.exitApp();
+		} else {
+			RNRestart.Restart();
+		}
 		return ok('');
 	} catch (e) {
 		console.log(e);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9585,6 +9585,11 @@ react-native-reanimated@2.12.0:
     setimmediate "^1.0.5"
     string-hash-64 "^1.0.3"
 
+react-native-restart@0.0.24:
+  version "0.0.24"
+  resolved "https://registry.yarnpkg.com/react-native-restart/-/react-native-restart-0.0.24.tgz#c7036f25d900d9221b84d3e5129b02d4289d4e94"
+  integrity sha512-pvJNU3NwQk6bCG2gOWcQpZ4IxhtELB0K9gzmtixfsaTFbW1UXXHkJNjk1kHazcbH5hrD7QbUkR63fsAVh8X4VQ==
+
 react-native-safe-area-context@^4.2.5:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.3.3.tgz#a0f1e3116ded39efc1b78a46a6d89c71169827e4"


### PR DESCRIPTION
Because running async actions can mutate state after Wipe App action, we need to try to close it, if that is possible.
BackHandler.exitApp(); works on Android, but not on iOS, so there we just show warning, explainin that app needs to be restarted