### PR TITLE
fix: sort activity by timestamp and txType

### DIFF
--- a/src/store/actions/activity.ts
+++ b/src/store/actions/activity.ts
@@ -48,7 +48,7 @@ export const updateOnChainActivityList = (): Promise<Result<string>> => {
 			return resolve(ok(''));
 		}
 
-		await dispatch({
+		dispatch({
 			type: actions.UPDATE_ACTIVITY_ENTRIES,
 			payload: onChainTransactionsToActivityItems(
 				currentWallet.transactions[selectedNetwork],

--- a/src/utils/activity/index.ts
+++ b/src/utils/activity/index.ts
@@ -76,7 +76,14 @@ export const mergeActivityItems = (
 			),
 	);
 	const mergedItems = reduced.concat(newItems);
-	const sortedItems = mergedItems.sort((a, b) => b.timestamp - a.timestamp);
+
+	// Receive should be before Sent if they have same timestamp
+	const sortOrder = ['received', 'sent'];
+	const sortedItems = mergedItems.sort(
+		(a, b) =>
+			b.timestamp - a.timestamp ||
+			sortOrder.indexOf(b.txType) - sortOrder.indexOf(a.txType),
+	);
 
 	return sortedItems;
 };


### PR DESCRIPTION
If 2 transactions happend to be confirmed in one block, they have same timestamp. In this case we should show incoming transaction as a first one, because otherwise it might be confusing.