### PR TITLE
fix: getNextAvailableAddress

### DIFF
--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -978,16 +978,15 @@ export const getNextAvailableAddress = async ({
 			}
 
 			//Store all addresses that are to be searched and used in this method.
-			let allAddresses: IAddressContent[] = Object.values(addresses).slice(
-				addressIndex.index,
-				addressCount,
+			let allAddresses: IAddressContent[] = Object.values(addresses).filter(
+				({ index }) => index >= addressIndex.index,
 			);
 			let addressesToScan = allAddresses;
 
 			//Store all change addresses that are to be searched and used in this method.
 			let allChangeAddresses: IAddressContent[] = Object.values(
 				changeAddresses,
-			).slice(changeAddressIndex.index, changeAddressCount);
+			).filter(({ index }) => index >= changeAddressIndex.index);
 			let changeAddressesToScan = allChangeAddresses;
 
 			//Prep for batch request


### PR DESCRIPTION
Array.slice should not be used over array, generated from Object. There is no garantee that it will be sorted by address.index. That is why I've replaced  Array.slice with Array.filter to exclude arresses that should not be scanned for transactions

This bug is the reason why receiving address has not been updated on Receive screen and in Slashpay