### PR TITLE
perf(ui): improve WalletScreen render time

### DIFF
--- a/src/navigation/bottom-sheet/AppUpdatePrompt.tsx
+++ b/src/navigation/bottom-sheet/AppUpdatePrompt.tsx
@@ -35,7 +35,7 @@ const appStoreUrl =
 const ASK_INTERVAL = 1000 * 60 * 60 * 12; // 12h - how long this prompt will be hidden if user taps Later
 const CHECK_DELAY = 2500; // how long user needs to stay on Wallets screen before he will see this prompt
 
-const AppUpdatePrompt = (): ReactElement => {
+const AppUpdatePrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
 	const snapPoints = useSnapPoints('large');
 	const insets = useSafeAreaInsets();
 	const viewControllers = useAppSelector(viewControllersSelector);
@@ -64,8 +64,13 @@ const AppUpdatePrompt = (): ReactElement => {
 	// and user on "Wallets" screen for CHECK_DELAY
 	const showBottomSheet = useMemo(() => {
 		const isTimeoutOver = Number(new Date()) - ignoreTimestamp > ASK_INTERVAL;
-		return updateType === 'optional' && isTimeoutOver && !anyBottomSheetIsOpen;
-	}, [updateType, ignoreTimestamp, anyBottomSheetIsOpen]);
+		return (
+			enabled &&
+			updateType === 'optional' &&
+			isTimeoutOver &&
+			!anyBottomSheetIsOpen
+		);
+	}, [enabled, updateType, ignoreTimestamp, anyBottomSheetIsOpen]);
 
 	useEffect(() => {
 		if (!showBottomSheet) {

--- a/src/navigation/bottom-sheet/HighBalanceWarning.tsx
+++ b/src/navigation/bottom-sheet/HighBalanceWarning.tsx
@@ -53,7 +53,11 @@ const aStyles = StyleSheet.create({
 	},
 });
 
-const HighBalanceWarning = (): ReactElement => {
+const HighBalanceWarning = ({
+	enabled,
+}: {
+	enabled: boolean;
+}): ReactElement => {
 	const snapPoints = useSnapPoints('medium');
 	const insets = useSafeAreaInsets();
 	const balance = useBalance({ onchain: true, lightning: true });
@@ -100,12 +104,14 @@ const HighBalanceWarning = (): ReactElement => {
 		const belowMaxWarnings = count < MAX_WARNINGS;
 		const isTimeoutOver = Number(new Date()) - ignoreTimestamp > ASK_INTERVAL;
 		return (
+			enabled &&
 			thresholdReached &&
 			belowMaxWarnings &&
 			isTimeoutOver &&
 			!anyBottomSheetIsOpen
 		);
 	}, [
+		enabled,
 		fiatValue,
 		balance.satoshis,
 		count,

--- a/src/navigation/wallet/WalletNavigator.tsx
+++ b/src/navigation/wallet/WalletNavigator.tsx
@@ -58,14 +58,11 @@ const WalletsStack = ({
 
 			<TabBar navigation={navigation} />
 
-			{/* only render these when 'Wallets' screen is in focus so timers run correctly */}
-			{isWalletsScreenFocused && (
-				<>
-					<BackupPrompt />
-					<HighBalanceWarning />
-					<AppUpdatePrompt />
-				</>
-			)}
+			{/* Put these here so they appear above the TabBar (zIndex) */}
+			{/* Should only ever show when user is on the main wallet screen */}
+			<BackupPrompt enabled={isWalletsScreenFocused} />
+			<HighBalanceWarning enabled={isWalletsScreenFocused} />
+			<AppUpdatePrompt enabled={isWalletsScreenFocused} />
 		</>
 	);
 };

--- a/src/screens/Settings/Backup/BackupPrompt.tsx
+++ b/src/screens/Settings/Backup/BackupPrompt.tsx
@@ -47,7 +47,7 @@ const handleBackup = (): void => {
 	});
 };
 
-const BackupPrompt = (): ReactElement => {
+const BackupPrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
 	const snapPoints = useSnapPoints('medium');
 	const insets = useSafeAreaInsets();
 	const { satoshis: balance } = useBalance({ onchain: true, lightning: true });
@@ -79,8 +79,14 @@ const BackupPrompt = (): ReactElement => {
 	// and user on "Wallets" screen for CHECK_DELAY
 	const showBottomSheet = useMemo(() => {
 		const isTimeoutOver = Number(new Date()) - ignoreTimestamp > ASK_INTERVAL;
-		return !backupVerified && !empty && isTimeoutOver && !anyBottomSheetIsOpen;
-	}, [backupVerified, empty, ignoreTimestamp, anyBottomSheetIsOpen]);
+		return (
+			enabled &&
+			!backupVerified &&
+			!empty &&
+			isTimeoutOver &&
+			!anyBottomSheetIsOpen
+		);
+	}, [enabled, backupVerified, empty, ignoreTimestamp, anyBottomSheetIsOpen]);
 
 	useEffect(() => {
 		if (!showBottomSheet) {


### PR DESCRIPTION
Performance was bad on Android when navigating back to the main WalletScreen so instead of mounting and unmounting we now pass a prop to the timed BottomSheets.