### PR TITLE
fix(lightning): Fix getPendingOrders Method

### DIFF
--- a/src/store/actions/blocktank.ts
+++ b/src/store/actions/blocktank.ts
@@ -120,6 +120,7 @@ export const refreshOrder = async (
 				}
 			}
 
+			// blocktank-client code reference: https://github.com/synonymdev/blocktank-client/blob/f8a20c35a4953435cecf8f718ee555e311e1db9b/src/services/client.ts#L15
 			// update suggestions cards
 			if ([150, 300, 400, 410, 450, 500].includes(getOrderRes.value.state)) {
 				removeTodo('lightningSettingUp');
@@ -130,14 +131,11 @@ export const refreshOrder = async (
 			}
 		}
 
-		const storedOrder = getBlocktankStore().orders.filter(
+		const storedOrder = getBlocktankStore().orders.find(
 			(o) =>
 				o._id === orderId || (orderResponse && orderResponse._id === o._id),
 		);
-		if (
-			storedOrder.length > 0 &&
-			storedOrder[0].state === orderResponse.state
-		) {
+		if (storedOrder && storedOrder.state === orderResponse.state) {
 			return ok(orderResponse);
 		}
 

--- a/src/utils/blocktank/index.ts
+++ b/src/utils/blocktank/index.ts
@@ -180,18 +180,14 @@ export const watchPendingOrders = (): void => {
 };
 
 /**
- * Return orders that are below the specified state and not expired.
+ * Return orders that are less than or equal to the specified order state.
  * @param pendingOrderState
  */
 export const getPendingOrders = (
 	pendingOrderState = 300,
 ): IGetOrderResponse[] => {
 	const orders = getBlocktankStore().orders;
-	return orders.filter(
-		(order) =>
-			order.state <= pendingOrderState &&
-			order.order_expiry > new Date().getTime(),
-	);
+	return orders.filter((order) => order.state <= pendingOrderState);
 };
 
 /**


### PR DESCRIPTION
This PR:
- Removes `order_expiry` condition from `getPendingOrders` method.
  - This resolves an issue where a paid, yet expired Blocktank order would not get returned and finalized.