### PR TITLE
fix(wallet): Update Dust Limit Logic

### DIFF
--- a/src/screens/Wallets/Send/Result.tsx
+++ b/src/screens/Wallets/Send/Result.tsx
@@ -84,6 +84,11 @@ const Result = ({
 				data: { isOpen: false },
 			});
 		} else {
+			/*
+				TODO: Add ability to distinguish between errors sent to this component.
+				 If unable to connect to or broadcast through Electrum, attempt to broadcast using the Blocktank api.
+				 If unable to properly create a valid transaction for any reason, reset the tx state as done below.
+			*/
 			//If unable to broadcast for any reason, reset the transaction object and try again.
 			await resetOnChainTransaction({ selectedWallet, selectedNetwork });
 			await setupOnChainTransaction({
@@ -91,7 +96,9 @@ const Result = ({
 				selectedNetwork,
 				rbf: false,
 			});
-			navigation.navigate('ReviewAndSend');
+			// The transaction was reset due to an unknown broadcast or construction error.
+			// Navigate back to the main send screen to re-enter information.
+			navigation.navigate('AddressAndAmount');
 		}
 	};
 

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -87,6 +87,7 @@ export enum EOutput {
 export enum ETransactionDefaults {
 	recommendedBaseFee = 256, //Total recommended tx base fee in sats
 	baseTransactionSize = 250, //In bytes (250 is about normal)
+	dustLimit = 546, //Minimum value in sats for an output. Outputs below the dust limit may not be processed because the fees required to include them in a block would be greater than the value of the transaction itself.
 }
 
 export enum EKeyDerivationAccount {


### PR DESCRIPTION
This PR:
- Updates `createPsbtFromTransactionData` method to remove dust outputs and apply them to the fee.
- Updates `createPsbtFromTransactionData` method to generate a `changeAddress` on the fly in the event there are additional sats when constructing a transaction.
- Creates `removeDustOutputs` & `getChangeAddress` methods.
- Implements `removeDustOutputs` in `createTransaction` method.
- Adds `dustLimit` value to `ETransactionDefaults`.

To Test:
  - Create an on-chain transaction where you are sending 200 sats shy of your max amount. (Toggle the "Max" button on, toggle "Max" button off, and remove 200 sats from the total value).
  - Send the transaction.
  - The on-chain transaction should apply what would have been a dust amount of 200 sats to the fee upon inspection.