### PR TITLE
chore(wallet): Update Android NDK Version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,14 +9,7 @@ buildscript {
         compileSdkVersion = 31
         targetSdkVersion = 31
         kotlin_version = '1.7.10'
-
-        if (System.properties['os.arch'] == "aarch64") {
-            // For M1 Users we need to use the NDK 24 which added support for aarch64
-            ndkVersion = "24.0.8215888"
-        } else {
-            // Otherwise we default to the side-by-side NDK version from AGP.
-            ndkVersion = "21.4.7075529"
-        }
+        ndkVersion = "25.1.8937393"
     }
     repositories {
         google()


### PR DESCRIPTION
This PR:
- Removes `ndkVersion` condition from `build.gradle`.
- Bumps `ndkVersion` to `25.1.8937393`.