### PR TITLE
chore: use sdk.joinSeeders api

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",
-    "@synonymdev/slashtags-sdk": "1.0.0-alpha.35",
+    "@synonymdev/slashtags-sdk": "1.0.0-alpha.36",
     "assert": "^2.0.0",
     "backpack-client": "git+ssh://git@github.com/synonymdev/bitkit-backup-client",
     "bip21": "^2.0.3",

--- a/src/components/SlashtagsProvider.tsx
+++ b/src/components/SlashtagsProvider.tsx
@@ -14,7 +14,6 @@ import {
 	onSDKError,
 } from '../utils/slashtags';
 import { updateSeederMaybe } from '../store/actions/slashtags';
-import { SLASHTAGS_SEEDER_TOPIC } from '@env';
 import { seedHashSelector } from '../store/reselect/wallet';
 
 export const RAWS = RAWSFactory({
@@ -160,8 +159,7 @@ export const SlashtagsProvider = ({ children }): JSX.Element => {
 
 			// Hardcode a single topic to connect to the seeder
 			// seeder this way won't need to announce O(n) topics.
-			const topic = b4a.from(SLASHTAGS_SEEDER_TOPIC, 'hex');
-			sdk.join(topic, { server: false, client: true });
+			sdk.joinSeeders();
 
 			// Increase swarm sockets max event listeners
 			sdk.swarm.on('connection', (socket: any) => socket.setMaxListeners(1000));

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,10 +2095,10 @@
     b4a "^1.6.0"
     protomux-rpc "^1.3.0"
 
-"@synonymdev/slashtags-sdk@1.0.0-alpha.35":
-  version "1.0.0-alpha.35"
-  resolved "https://registry.yarnpkg.com/@synonymdev/slashtags-sdk/-/slashtags-sdk-1.0.0-alpha.35.tgz#5ad4f627e226e01d886736e330c6606d13e247f2"
-  integrity sha512-hl9TOjT8SOPlrAcvLTCmxH4Mu1EMuAx48xw1khMVlLiDiCxR/nLpLpmG6aFrUXZEBAjSf1dHWtRqanr8XwOdMg==
+"@synonymdev/slashtags-sdk@1.0.0-alpha.36":
+  version "1.0.0-alpha.36"
+  resolved "https://registry.yarnpkg.com/@synonymdev/slashtags-sdk/-/slashtags-sdk-1.0.0-alpha.36.tgz#d47b60bbaf8b55259034d4aa36be6af062c9cdc2"
+  integrity sha512-7G6cLINKjaJ/28n7zj8F7RFkusGkIJ3XzUWZtIopomjwTvLYdYrFyFjwL/mIyiuNtK/9OeLNp1NIVw7KpX+ULQ==
   dependencies:
     "@hyperswarm/dht" "^6.2.1"
     "@hyperswarm/dht-relay" "^0.3.0"


### PR DESCRIPTION
This connects to the production topic... maybe not be desirable if we need to debug something on a different topic, take it or leave it really.