### PR TITLE
fix(wallet): Fix max_chan_spending Error

### DIFF
--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -83,7 +83,7 @@ const QuickSetup = ({
 	useEffect(() => {
 		setTotalBalance(spendingLimit);
 	}, [
-		blocktankService.max_chan_spending,
+		blocktankService?.max_chan_spending,
 		currentBalance.satoshis,
 		spendingLimit,
 	]);


### PR DESCRIPTION
This PR:
- Adds optional chaining operator to `blocktankService` in `QuickSetup`'s `useEffect` dependency array.