### PR TITLE
docs: add missing iphone app testflight link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 
 **⚠️ Bitkit is still in beta. Please use at your own risk.**
 
-[⬇ Download latest APK](https://github.com/synonymdev/bitkit/releases)
+[⬇ Android - Download latest APK](https://github.com/synonymdev/bitkit/releases)
+[⬇ iPhone - Download latest TestFlight app](https://testflight.apple.com/join/lGXhnwcC)
 
 ---
 


### PR DESCRIPTION
Link to iPhone TestFlight: https://testflight.apple.com/join/lGXhnwcC

Preview: 
![image](https://user-images.githubusercontent.com/5798170/212564424-fbbf8b56-9150-4d36-ae08-2a9fb96af6ca.png)
