### PR TITLE
fix: 0 onchain balance Rebalance flow

### DIFF
--- a/src/components/FancySlider.tsx
+++ b/src/components/FancySlider.tsx
@@ -16,6 +16,7 @@ import useColors from '../hooks/colors';
 
 const CIRCLE_SIZE = 32;
 const GRAB_SIZE = 64;
+const SNAP_POINT_SIZE = 5;
 
 const valueToX = (
 	value: number,
@@ -163,7 +164,7 @@ const FancySlider = ({
 				}
 
 				// handle snapPoint
-				if (snapPoint) {
+				if (snapPoint !== undefined) {
 					const delta = maximumValue - minimumValue;
 					const snapPointX = (endPosition / delta) * snapPoint;
 
@@ -198,9 +199,13 @@ const FancySlider = ({
 		outputRange: [0, endPosition],
 	});
 
-	const snapPointTranslateX = snapPoint
-		? (containerWidth / maximumValue - minimumValue) * snapPoint
-		: null;
+	let snapPointTranslateX;
+	if (containerWidth > 0 && snapPoint !== undefined) {
+		snapPointTranslateX =
+			SNAP_POINT_SIZE / 2 +
+			((containerWidth - SNAP_POINT_SIZE * 2) / maximumValue - minimumValue) *
+				snapPoint;
+	}
 
 	const minTrackWidth = pan.x.interpolate({
 		inputRange: [0, endPosition],
@@ -252,7 +257,7 @@ const FancySlider = ({
 						},
 					]}
 				/>
-				{snapPointTranslateX ? (
+				{snapPointTranslateX !== undefined ? (
 					<Animated.View
 						style={[
 							styles.snapPoint,
@@ -340,7 +345,7 @@ const styles = StyleSheet.create({
 		position: 'absolute',
 		left: 0,
 		height: 16,
-		width: 5,
+		width: SNAP_POINT_SIZE,
 	},
 	glow: {
 		position: 'absolute',

--- a/src/screens/Transfer/Setup.tsx
+++ b/src/screens/Transfer/Setup.tsx
@@ -14,7 +14,6 @@ import Percentage from '../../components/Percentage';
 import FancySlider from '../../components/FancySlider';
 import NumberPadLightning from '../Lightning/NumberPadLightning';
 import { useBalance } from '../../hooks/wallet';
-import { useLightningBalance } from '../../hooks/lightning';
 import { showErrorNotification } from '../../utils/notifications';
 import { startChannelPurchase } from '../../store/actions/blocktank';
 import { useSelector } from 'react-redux';
@@ -35,11 +34,11 @@ import { selectedCurrencySelector } from '../../store/reselect/settings';
 import { EBitcoinUnit } from '../../store/types/wallet';
 
 const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
-	const balance = useBalance({ onchain: true, lightning: true });
-	const { localBalance: currentSpendingAmount } = useLightningBalance();
+	const { satoshis: onChainBalance } = useBalance({ onchain: true });
+	const { satoshis: lightningBalance } = useBalance({ lightning: true });
 	const [keybrd, setKeybrd] = useState(false);
 	const [loading, setLoading] = useState(false);
-	const [spendingAmount, setSpendingAmount] = useState(currentSpendingAmount);
+	const [spendingAmount, setSpendingAmount] = useState(lightningBalance);
 
 	const selectedNetwork = useSelector(selectedNetworkSelector);
 	const selectedWallet = useSelector(selectedWalletSelector);
@@ -58,9 +57,8 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 	);
 
 	const spendingLimit = useMemo(() => {
-		const spendableBalance = Math.round(
-			balance.satoshis / SPENDING_LIMIT_RATIO,
-		);
+		const spendableBalance =
+			Math.round(onChainBalance / SPENDING_LIMIT_RATIO) + lightningBalance;
 
 		const convertedUnit = convertCurrency({
 			amount: 999,
@@ -72,14 +70,15 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 			bitcoinUnit: EBitcoinUnit.satoshi,
 		});
 
-		return Math.min(spendableBalance, maxSpendingLimit);
-	}, [balance.satoshis, selectedCurrency]);
+		const min = Math.min(spendableBalance, maxSpendingLimit);
+		return min < lightningBalance ? lightningBalance : min;
+	}, [selectedCurrency, lightningBalance, onChainBalance]);
 
 	const savingsAmount = spendingLimit - spendingAmount;
 	const spendingPercentage = Math.round((spendingAmount / spendingLimit) * 100);
 	const savingsPercentage = Math.round((savingsAmount / spendingLimit) * 100);
-	const isTransferringToSavings = spendingAmount < currentSpendingAmount;
-	const isButtonDisabled = spendingAmount === currentSpendingAmount;
+	const isTransferringToSavings = spendingAmount < lightningBalance;
+	const isButtonDisabled = spendingAmount === lightningBalance;
 
 	const handleChange = useCallback((value: number) => {
 		setSpendingAmount(Math.round(value));
@@ -94,7 +93,7 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 		} else {
 			// buy an additional channel from Blocktank with the difference
 			setLoading(true);
-			const remoteBalance = spendingAmount - currentSpendingAmount;
+			const remoteBalance = spendingAmount - lightningBalance;
 			const localBalance =
 				Math.round(remoteBalance * 1.1) > blocktankService.min_channel_size
 					? Math.round(remoteBalance * 1.1)
@@ -126,7 +125,7 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 	}, [
 		blocktankService,
 		isTransferringToSavings,
-		currentSpendingAmount,
+		lightningBalance,
 		spendingAmount,
 		spendingLimit,
 		selectedNetwork,
@@ -174,7 +173,7 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 										minimumValue={0}
 										maximumValue={spendingLimit}
 										value={spendingAmount}
-										snapPoint={currentSpendingAmount}
+										snapPoint={lightningBalance}
 										onValueChange={handleChange}
 									/>
 								</View>


### PR DESCRIPTION
Fix calculations on Rebalance screen for a case, when onchain balance is 0
Also small adjustments for FancySlider snap point position calculation


Before 

![image](https://user-images.githubusercontent.com/155891/212742056-16b2a113-e2ae-421e-a9c5-946b9c125261.png)

After

![image](https://user-images.githubusercontent.com/155891/212741993-eca1f867-16be-423a-bef2-b8a4dea51d4d.png)
