### PR TITLE
feat(wallet): Add Rescan Addresses

### DIFF
--- a/src/screens/Settings/AddressViewer/index.tsx
+++ b/src/screens/Settings/AddressViewer/index.tsx
@@ -680,7 +680,7 @@ const AddressViewer = ({
 			if (transactionRes.isErr()) {
 				return;
 			}
-			const receiveAddress = getReceiveAddress({
+			const receiveAddress = await getReceiveAddress({
 				selectedWallet,
 				selectedNetwork,
 			});

--- a/src/screens/Settings/Advanced/index.tsx
+++ b/src/screens/Settings/Advanced/index.tsx
@@ -1,4 +1,4 @@
-import React, { memo, ReactElement, useMemo } from 'react';
+import React, { memo, ReactElement, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 
 import { EItemType, IListData, ItemData } from '../../../components/List';
@@ -7,9 +7,11 @@ import { enableDevOptionsSelector } from '../../../store/reselect/settings';
 import { EAddressType } from '../../../store/types/wallet';
 import {
 	addressTypeSelector,
+	selectedWalletSelector,
 	selectedNetworkSelector,
 } from '../../../store/reselect/wallet';
 import type { SettingsScreenProps } from '../../../navigation/types';
+import { rescanAddresses } from '../../../utils/wallet';
 
 const typesDescriptions = {
 	[EAddressType.p2wpkh]: 'Native Segwit',
@@ -26,9 +28,12 @@ const networkLabels = {
 const AdvancedSettings = ({
 	navigation,
 }: SettingsScreenProps<'AdvancedSettings'>): ReactElement => {
+	const selectedWallet = useSelector(selectedWalletSelector);
 	const selectedNetwork = useSelector(selectedNetworkSelector);
 	const selectedAddressType = useSelector(addressTypeSelector);
 	const enableDevOptions = useSelector(enableDevOptionsSelector);
+
+	const [rescanning, setRescanning] = useState(false);
 
 	const SettingsListData: IListData[] = useMemo(() => {
 		const payments: ItemData[] = [
@@ -57,6 +62,16 @@ const AdvancedSettings = ({
 				title: 'Address Viewer',
 				type: EItemType.button,
 				onPress: (): void => navigation.navigate('AddressViewer'),
+			},
+			{
+				title: 'Rescan Addresses',
+				value: rescanning ? 'Rescanning...' : '',
+				type: EItemType.textButton,
+				onPress: async (): Promise<void> => {
+					setRescanning(true);
+					await rescanAddresses({ selectedWallet, selectedNetwork });
+					setRescanning(false);
+				},
 			},
 		];
 
@@ -97,7 +112,14 @@ const AdvancedSettings = ({
 				data: networks,
 			},
 		];
-	}, [selectedAddressType, enableDevOptions, navigation, selectedNetwork]);
+	}, [
+		selectedAddressType,
+		rescanning,
+		enableDevOptions,
+		navigation,
+		selectedWallet,
+		selectedNetwork,
+	]);
 
 	return (
 		<SettingsView

--- a/src/screens/Wallets/Receive/index.tsx
+++ b/src/screens/Wallets/Receive/index.tsx
@@ -132,7 +132,7 @@ const Receive = ({
 				setReceiveAddress(response.value.address);
 			}
 		} else {
-			const response = getReceiveAddress({
+			const response = await getReceiveAddress({
 				selectedNetwork,
 				selectedWallet,
 				addressType,

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -247,6 +247,50 @@ export const updateAddressIndexes = async ({
 	return ok(updated ? 'Successfully updated indexes.' : 'No update needed.');
 };
 
+/**
+ * Resets address indexes back to the app's default/original state.
+ * @param {TWalletName} [selectedWallet]
+ * @param {TAvailableNetworks} [selectedNetwork]
+ * @returns {void}
+ */
+export const resetAddressIndexes = ({
+	selectedWallet,
+	selectedNetwork,
+}: {
+	selectedWallet: TWalletName;
+	selectedNetwork: TAvailableNetworks;
+}): void => {
+	if (!selectedWallet) {
+		selectedWallet = getSelectedWallet();
+	}
+	if (!selectedNetwork) {
+		selectedNetwork = getSelectedNetwork();
+	}
+
+	const addressTypes = getAddressTypes();
+	const addressTypeKeys = Object.keys(addressTypes) as EAddressType[];
+	addressTypeKeys.map((addressType) => {
+		dispatch({
+			type: actions.UPDATE_ADDRESS_INDEX,
+			payload: {
+				selectedWallet,
+				selectedNetwork,
+				addressIndex:
+					defaultWalletShape.addressIndex[selectedNetwork][addressType],
+				changeAddressIndex:
+					defaultWalletShape.changeAddressIndex[selectedNetwork][addressType],
+				lastUsedAddressIndex:
+					defaultWalletShape.lastUsedAddressIndex[selectedNetwork][addressType],
+				lastUsedChangeAddressIndex:
+					defaultWalletShape.lastUsedChangeAddressIndex[selectedNetwork][
+						addressType
+					],
+				addressType,
+			},
+		});
+	});
+};
+
 export const generateNewReceiveAddress = async ({
 	selectedWallet,
 	selectedNetwork,

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -163,7 +163,7 @@ export const setupLdk = async ({
 				break;
 		}
 		const getAddress = async (): Promise<string> => {
-			const res = getReceiveAddress({ selectedNetwork, selectedWallet });
+			const res = await getReceiveAddress({ selectedNetwork, selectedWallet });
 			if (res.isOk()) {
 				return res.value;
 			}

--- a/src/utils/slashtags/index.ts
+++ b/src/utils/slashtags/index.ts
@@ -222,7 +222,10 @@ export const updateSlashPayConfig = debounce(
 		const currentAddress = payConfig.find(
 			({ type }) => type === addressType,
 		)?.value;
-		const newAddress = getReceiveAddress({ selectedWallet, selectedNetwork });
+		const newAddress = await getReceiveAddress({
+			selectedWallet,
+			selectedNetwork,
+		});
 		if (newAddress.isOk() && currentAddress !== newAddress.value) {
 			// use new address
 			needToUpdate = true;

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -2037,7 +2037,10 @@ export const setupCpfp = async ({
 		return err(response.error?.message);
 	}
 
-	const receiveAddress = getReceiveAddress({ selectedWallet, selectedNetwork });
+	const receiveAddress = await getReceiveAddress({
+		selectedWallet,
+		selectedNetwork,
+	});
 	if (receiveAddress.isErr()) {
 		return err(receiveAddress.error.message);
 	}


### PR DESCRIPTION
This PR:
- Adds "Rescan Addresses" feature to advanced settings.
- Updates `getReceiveAddress` in `utils/wallet/index.ts`.
  - Adds an additional fallback to generate a receiving address on the fly in the event the wallet hasn't generated or stored one yet.
- Adds `rescanAddresses` method to `utils/wallet/index.ts`.
- Adds `resetAddressIndexes` method to `store/actions/wallet.ts`.

Notes:
- The rescan addresses feature is currently available to everyone and can be utilized by navigating to "Settings->Advanced" and tapping "Rescan Addresses".
- Once tapped, it will clear the UTXO array for each address type and reset the address indexes back to the original/default values. The app will then rescan each address type of the wallet's addresses from index zero.