### PR TITLE
fix(ui): fix electrum connectivity toast falsely triggering

### DIFF
--- a/src/components/ConnectivityIndicator.tsx
+++ b/src/components/ConnectivityIndicator.tsx
@@ -38,10 +38,9 @@ const ConnectivityIndicator = (): ReactElement => {
 				message: 'Successfully reconnected to Electrum Server.',
 			});
 		} else {
-			updateUi({ isConnectedToElectrum: false });
 			showErrorNotification({
 				title: 'Bitkit Connection Lost',
-				message: 'Please check your settings.',
+				message: 'Please check your Electrum Server settings.',
 			});
 		}
 		setIsLoading(false);

--- a/src/screens/Settings/ElectrumConfig/index.tsx
+++ b/src/screens/Settings/ElectrumConfig/index.tsx
@@ -111,6 +111,8 @@ const ElectrumConfig = ({
 		const peerInfo = await getConnectedPeer(selectedNetwork);
 		if (peerInfo.isOk()) {
 			setConnectedPeer(peerInfo.value);
+		} else {
+			setConnectedPeer(undefined);
 		}
 	};
 
@@ -151,7 +153,6 @@ const ElectrumConfig = ({
 					title: 'Electrum Server Updated',
 					message: `Successfully connected to ${host}:${port}`,
 				});
-				await getAndUpdateConnectedPeer();
 			} else {
 				updateUi({ isConnectedToElectrum: false });
 				showErrorNotification({
@@ -159,6 +160,7 @@ const ElectrumConfig = ({
 					message: connectResponse.error.message,
 				});
 			}
+			await getAndUpdateConnectedPeer();
 		} catch (e) {
 			console.log(e);
 		} finally {


### PR DESCRIPTION
Stop the Electrum connectivity toast falsely showing when the app comes back to the foreground by unsubscribing when the app goes to background.