### PR TITLE
fix(wallet): Wipe Previous Install During Onboarding

### DIFF
--- a/src/screens/Onboarding/TermsOfUse.tsx
+++ b/src/screens/Onboarding/TermsOfUse.tsx
@@ -17,17 +17,24 @@ const TermsOfUse = ({
 }: OnboardingStackScreenProps<'TermsOfUse'>): ReactElement => {
 	const [termsOfUse, setTermsOfUse] = useState(false);
 	const [privacyPolicy, setPrivacyPolicy] = useState(false);
-	const onPress = (): void => {
+	const [loading, setLoading] = useState(false);
+
+	const onPress = async (): Promise<void> => {
+		setLoading(true);
 		// Ensure the app is sufficiently wiped of data from any previous install.
-		wipeApp({
+		const wipeAppRes = await wipeApp({
 			selectedWallet: 'wallet0',
 			showNotification: false,
 			restartApp: false,
-		}).then();
+		});
+		setLoading(false);
+		if (wipeAppRes.isErr()) {
+			return;
+		}
 		navigation.navigate('Welcome');
 	};
 
-	const isValid = termsOfUse && privacyPolicy;
+	const isValid = termsOfUse && privacyPolicy && !loading;
 
 	return (
 		<GlowingBackground topLeft="brand">

--- a/src/screens/Onboarding/TermsOfUse.tsx
+++ b/src/screens/Onboarding/TermsOfUse.tsx
@@ -10,13 +10,22 @@ import { openURL } from '../../utils/helpers';
 import type { OnboardingStackScreenProps } from '../../navigation/types';
 
 import termsOfUseText from '../../assets/tos';
+import { wipeApp } from '../../store/actions/settings';
 
 const TermsOfUse = ({
 	navigation,
 }: OnboardingStackScreenProps<'TermsOfUse'>): ReactElement => {
 	const [termsOfUse, setTermsOfUse] = useState(false);
 	const [privacyPolicy, setPrivacyPolicy] = useState(false);
-	const onPress = (): void => navigation.navigate('Welcome');
+	const onPress = (): void => {
+		// Ensure the app is sufficiently wiped of data from any previous install.
+		wipeApp({
+			selectedWallet: 'wallet0',
+			showNotification: false,
+			restartApp: false,
+		}).then();
+		navigation.navigate('Welcome');
+	};
 
 	const isValid = termsOfUse && privacyPolicy;
 

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -837,7 +837,6 @@ export const resetSelectedWallet = async ({
 		type: actions.RESET_SELECTED_WALLET,
 		payload: { selectedWallet },
 	});
-	await createWallet({ walletName: selectedWallet });
 	await refreshWallet({});
 };
 
@@ -850,7 +849,11 @@ export const resetWalletStore = async (): Promise<Result<string>> => {
 		type: actions.RESET_WALLET_STORE,
 	});
 	await createWallet({});
-	await refreshWallet({});
+	await refreshWallet({
+		scanAllAddresses: true,
+		updateAllAddressTypes: true,
+		showNotification: false,
+	});
 	return ok('');
 };
 

--- a/src/store/reducers/wallet.ts
+++ b/src/store/reducers/wallet.ts
@@ -6,7 +6,7 @@ import {
 	EOutput,
 	IWalletStore,
 } from '../types/wallet';
-import { defaultWalletStoreShape } from '../shapes/wallet';
+import { defaultWalletShape, defaultWalletStoreShape } from '../shapes/wallet';
 
 const wallet = (
 	state: IWalletStore = defaultWalletStoreShape,
@@ -193,12 +193,11 @@ const wallet = (
 			};
 
 		case actions.RESET_SELECTED_WALLET:
-			const wallets = state.wallets;
-			delete wallets[selectedWallet];
 			return {
 				...state,
 				wallets: {
-					...wallets,
+					...state.wallets,
+					[selectedWallet]: defaultWalletShape,
 				},
 			};
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -74,6 +74,14 @@ export const getKeychainValue = async ({
 	});
 };
 
+/**
+ * Returns an array of all known Keychain keys.
+ * @returns {Promise<string[]>}
+ */
+export const getAllKeychainKeys = async (): Promise<string[]> => {
+	return await Keychain.getAllGenericPasswordServices();
+};
+
 //WARNING: This will wipe the specified key's value from storage
 export const resetKeychainValue = async ({
 	key = '',

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -170,7 +170,7 @@ export const startWalletServices = async ({
 					onchain: isConnectedToElectrum,
 					lightning: isConnectedToElectrum,
 					scanAllAddresses: restore,
-					updateAllAddressTypes: restore,
+					updateAllAddressTypes: true, // Ensure we scan all address types when spinning up the app.
 					showNotification: !restore,
 				}),
 			]);

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -374,7 +374,7 @@ export const slashtagsPrimaryKey = async (seed: Buffer): Promise<string> => {
 
 const setKeychainSlashtagsPrimaryKey = async (seed: Buffer): Promise<void> => {
 	const primaryKey = await slashtagsPrimaryKey(seed);
-	setKeychainValue({
+	await setKeychainValue({
 		key: slashtagsPrimaryKeyKeyChainName(seedHash(seed)),
 		value: primaryKey,
 	});


### PR DESCRIPTION
This PR:
- Adds `wipeApp` function to "Continue" button in `TermsOfUse` component.
- Updates `wipeApp` params in `actions/settings.ts`.
- Updates `wipeKeychain` method to iterate through and remove all known key/values.
- Sets `updateAllAddressTypes` param to `true` in `startWalletServices`.
- Updates `RESET_SELECTED_WALLET` reducer.
- Removes `createWallet ` from `resetSelectedWallet` in `actions/wallet.ts`.
- Updates `refreshWallet` params in `resetWalletStore` in `actions/wallet.ts`.