### PR TITLE
fix(wallet): Temporarily Comment Out sdk.join

### DIFF
--- a/src/components/SlashtagsProvider.tsx
+++ b/src/components/SlashtagsProvider.tsx
@@ -15,7 +15,7 @@ import {
 	isSlashtagsDisabled,
 } from '../utils/slashtags';
 import { updateSeederMaybe } from '../store/actions/slashtags';
-import { SLASHTAGS_SEEDER_TOPIC } from '@env';
+//import { SLASHTAGS_SEEDER_TOPIC } from '@env';
 import { seedHashSelector } from '../store/reselect/wallet';
 
 export const RAWS = RAWSFactory({
@@ -163,10 +163,15 @@ export const SlashtagsProvider = ({
 				return;
 			}
 
+			/*
+			TODO:
+			 This is temporarily commented out to improve start-up time and reduce lag on app-start.
+			 Uncomment this once additional seeders outside of Synonym begin to appear or prior to a full release.
 			// Hardcode a single topic to connect to the seeder
 			// seeder this way won't need to announce O(n) topics.
 			const topic = b4a.from(SLASHTAGS_SEEDER_TOPIC, 'hex');
 			sdk.join(topic, { server: false, client: true });
+			 */
 
 			// Increase swarm sockets max event listeners
 			sdk.swarm.on('connection', (socket: any) => socket.setMaxListeners(1000));


### PR DESCRIPTION
This PR:
- Temporarily comments out `sdk.join` in order to improve start-up time and reduce lag on app-start.