### PR TITLE
fix(wallet): Add & Implement lodash.clonedeep

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "immer": "^9.0.16",
     "intl": "^1.2.5",
     "jdenticon": "^3.1.1",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",
     "lodash.throttle": "^4.1.1",

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -60,7 +60,7 @@ import {
 import { getBoostedTransactionParents } from '../../utils/boost';
 import { updateSlashPayConfig } from '../../utils/slashtags';
 import { sdk } from '../../components/SlashtagsProvider';
-import { defaultWalletShape, TAddressIndexInfo } from '../shapes/wallet';
+import { getDefaultWalletShape, TAddressIndexInfo } from '../shapes/wallet';
 
 const dispatch = getDispatch();
 
@@ -85,7 +85,7 @@ export const updateWallet = (
  * @return {Promise<Result<string>>}
  */
 export const createWallet = async ({
-	walletName = defaultWalletShape.id,
+	walletName = getDefaultWalletShape().id,
 	addressAmount = GENERATE_ADDRESS_AMOUNT,
 	changeAddressAmount = GENERATE_ADDRESS_AMOUNT,
 	mnemonic = '',
@@ -269,6 +269,7 @@ export const resetAddressIndexes = ({
 
 	const addressTypes = getAddressTypes();
 	const addressTypeKeys = Object.keys(addressTypes) as EAddressType[];
+	const defaultWalletShape = getDefaultWalletShape();
 	addressTypeKeys.map((addressType) => {
 		dispatch({
 			type: actions.UPDATE_ADDRESS_INDEX,

--- a/src/store/reducers/wallet.ts
+++ b/src/store/reducers/wallet.ts
@@ -6,7 +6,10 @@ import {
 	EOutput,
 	IWalletStore,
 } from '../types/wallet';
-import { defaultWalletShape, defaultWalletStoreShape } from '../shapes/wallet';
+import {
+	getDefaultWalletShape,
+	defaultWalletStoreShape,
+} from '../shapes/wallet';
 
 const wallet = (
 	state: IWalletStore = defaultWalletStoreShape,
@@ -197,7 +200,7 @@ const wallet = (
 				...state,
 				wallets: {
 					...state.wallets,
-					[selectedWallet]: defaultWalletShape,
+					[selectedWallet]: getDefaultWalletShape(),
 				},
 			};
 

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -14,12 +14,14 @@ import {
 import { IHeader } from '../../utils/types/electrum';
 import { EAvailableNetworks } from '../../utils/networks';
 import { objectKeys } from '../../utils/objectKeys';
+import cloneDeep from 'lodash.clonedeep';
 
-const cloneDeep = require('lodash.clonedeep');
+export const assetNetworks: Readonly<TAssetNetwork[]> = [
+	'bitcoin',
+	'lightning',
+];
 
-export const assetNetworks: TAssetNetwork[] = ['bitcoin', 'lightning'];
-
-export const addressTypes: IAddressTypes = {
+export const addressTypes: Readonly<IAddressTypes> = {
 	[EAddressType.p2pkh]: {
 		path: "m/44'/0'/0'/0/0",
 		type: EAddressType.p2pkh,
@@ -37,41 +39,43 @@ export const addressTypes: IAddressTypes = {
 	},
 };
 
-export const bitcoinTransaction: IWalletItem<IBitcoinTransactionData> = {
+export const bitcoinTransaction: Readonly<
+	IWalletItem<IBitcoinTransactionData>
+> = {
 	bitcoin: defaultBitcoinTransactionData,
 	bitcoinTestnet: defaultBitcoinTransactionData,
 	bitcoinRegtest: defaultBitcoinTransactionData,
 };
 
-export const numberTypeItems: IWalletItem<number> = {
+export const numberTypeItems: Readonly<IWalletItem<number>> = {
 	bitcoin: 0,
 	bitcoinTestnet: 0,
 	bitcoinRegtest: 0,
 	timestamp: null,
 };
 
-export const arrayTypeItems: IWalletItem<[]> = {
+export const arrayTypeItems: Readonly<IWalletItem<[]>> = {
 	bitcoin: [],
 	bitcoinTestnet: [],
 	bitcoinRegtest: [],
 	timestamp: null,
 };
 
-export const objectTypeItems = {
+export const objectTypeItems: Readonly<IWalletItem<{}>> = {
 	bitcoin: {},
 	bitcoinTestnet: {},
 	bitcoinRegtest: {},
 	timestamp: null,
 };
 
-export const stringTypeItems: IWalletItem<string> = {
+export const stringTypeItems: Readonly<IWalletItem<string>> = {
 	bitcoin: '',
 	bitcoinTestnet: '',
 	bitcoinRegtest: '',
 	timestamp: null,
 };
 
-export const addressContent: IAddress = {
+export const addressContent: Readonly<IAddress> = {
 	index: -1,
 	path: '',
 	address: '',
@@ -126,7 +130,7 @@ export const getAddressesShape = (): IWalletItem<
 	});
 };
 
-export const defaultKeyDerivationPath: IKeyDerivationPath = {
+export const defaultKeyDerivationPath: Readonly<IKeyDerivationPath> = {
 	purpose: '84',
 	coinType: '0',
 	account: '0',
@@ -134,13 +138,13 @@ export const defaultKeyDerivationPath: IKeyDerivationPath = {
 	addressIndex: '0',
 };
 
-export const header: IHeader = {
+export const header: Readonly<IHeader> = {
 	height: 0,
 	hash: '',
 	hex: '',
 };
 
-export const defaultWalletShape: IWallet = {
+export const defaultWalletShape: Readonly<IWallet> = {
 	id: 'wallet0',
 	name: '',
 	type: 'default',
@@ -180,7 +184,7 @@ export const defaultWalletShape: IWallet = {
 	transaction: bitcoinTransaction,
 };
 
-export const defaultWalletStoreShape: IWalletStore = {
+export const defaultWalletStoreShape: Readonly<IWalletStore> = {
 	walletExists: false,
 	selectedNetwork: EAvailableNetworks.bitcoin,
 	selectedWallet: 'wallet0',

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -15,6 +15,8 @@ import { IHeader } from '../../utils/types/electrum';
 import { EAvailableNetworks } from '../../utils/networks';
 import { objectKeys } from '../../utils/objectKeys';
 
+const cloneDeep = require('lodash.clonedeep');
+
 export const assetNetworks: TAssetNetwork[] = ['bitcoin', 'lightning'];
 
 export const addressTypes: IAddressTypes = {
@@ -85,7 +87,7 @@ export const getAddressTypeContent = <T>(data: T): IAddressTypeContent<T> => {
 		content[addressType] = data;
 	});
 
-	return content;
+	return cloneDeep(content);
 };
 
 export type IAddressTypeContent<T> = {
@@ -102,7 +104,7 @@ export type TAddressIndexInfo = {
 export const getAddressIndexShape = (): IWalletItem<
 	IAddressTypeContent<IAddress>
 > => {
-	return {
+	return cloneDeep({
 		[EAvailableNetworks.bitcoin]:
 			getAddressTypeContent<IAddress>(addressContent),
 		[EAvailableNetworks.bitcoinTestnet]:
@@ -110,18 +112,18 @@ export const getAddressIndexShape = (): IWalletItem<
 		[EAvailableNetworks.bitcoinRegtest]:
 			getAddressTypeContent<IAddress>(addressContent),
 		timestamp: null,
-	};
+	});
 };
 
 export const getAddressesShape = (): IWalletItem<
 	IAddressTypeContent<IAddresses>
 > => {
-	return {
+	return cloneDeep({
 		[EAvailableNetworks.bitcoin]: getAddressTypeContent<IAddresses>({}),
 		[EAvailableNetworks.bitcoinTestnet]: getAddressTypeContent<IAddresses>({}),
 		[EAvailableNetworks.bitcoinRegtest]: getAddressTypeContent<IAddresses>({}),
 		timestamp: null,
-	};
+	});
 };
 
 export const defaultKeyDerivationPath: IKeyDerivationPath = {
@@ -190,4 +192,8 @@ export const defaultWalletStoreShape: IWalletStore = {
 		bitcoinRegtest: header,
 	},
 	wallets: {},
+};
+
+export const getDefaultWalletShape = (): IWallet => {
+	return cloneDeep(defaultWalletShape);
 };

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -2574,7 +2574,7 @@ export const getAssetNames = ({
 	if (!selectedNetwork) {
 		selectedNetwork = getSelectedNetwork();
 	}
-	const assetNames: string[] = assetNetworks;
+	const assetNames: string[] = [...assetNetworks];
 	try {
 		// TODO: Grab available tokens/assets.
 	} catch {}

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -1126,8 +1126,9 @@ export const updateFee = ({
 		if (transactionDataResponse.isErr()) {
 			return err(transactionDataResponse.error.message);
 		}
-		transaction =
-			transactionDataResponse?.value ?? defaultBitcoinTransactionData;
+		transaction = transactionDataResponse?.value ?? {
+			...defaultBitcoinTransactionData,
+		};
 	}
 	const inputTotal = getTransactionInputValue({
 		selectedNetwork,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7540,6 +7540,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"


### PR DESCRIPTION
This PR:
- Adds `lodash.clonedeep` to dependencies in `package.json`.
- Implements `cloneDeep` on default wallet state references to protect against mutations when used. 
- Creates and implements `getDefaultWalletShape` where needed.
- Removes a lingering address type condition in `createDefaultWallet` method.
  - This condition was a remnant from when we tried to limit address generation to only a single address type when creating wallets for the first time. Removing this allows Bitkit to generate addresses for all address types when creating new wallets.