### PR TITLE
fix(wallet): Fix Receive Share Button

### DIFF
--- a/src/screens/Wallets/Receive/index.tsx
+++ b/src/screens/Wallets/Receive/index.tsx
@@ -289,7 +289,7 @@ const Receive = ({
 			} catch (error) {
 				console.log(error);
 			} finally {
-				setIsSharing(true);
+				setIsSharing(false);
 			}
 		},
 		[],


### PR DESCRIPTION
This PR:
- Fixes the receive share button so that it is no longer disabled when navigating back to it.