### PR TITLE
fix: Main scanner redirect

### DIFF
--- a/src/components/NavigationHeader.tsx
+++ b/src/components/NavigationHeader.tsx
@@ -91,7 +91,7 @@ const NavigationHeader = ({
 	return (
 		<View style={[container, style]}>
 			<View style={[styles.leftColumn, buttonOffset]}>
-				{displayBackButton && (
+				{displayBackButton && navigation.canGoBack() && (
 					<ActionButton onPress={handleBackPress} testID="NavigationBack">
 						<BackIcon width={20} height={20} />
 					</ActionButton>


### PR DESCRIPTION
Follow up to https://github.com/synonymdev/bitkit/pull/888

Previously when redirecting from the main scanner after scanning invoices the BottomSheet would open first on the Recipient screen and then navigate further. This sets the initial screen to smoothen out the transition

### Changes
- enable smoother transition from the Main Scanner when scanning invoices