### PR TITLE
test: fix e2e beforeAll setup

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -12,23 +12,37 @@ jobs:
   e2e:
     runs-on: macos-12
 
+    strategy:
+      fail-fast: false
+      matrix:
+        attempt: [1, 2]
+
     steps:
+      - name: Echo attempt
+        run: echo ${{ matrix.attempt }}
+
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
-      - name: Setup Docker on macOS
-        uses: docker-practice/actions-setup-docker@master
+      - name: Setup Docker on macOS attempt 1
+        id: docker1
+        continue-on-error: true
+        uses: docker-practice/actions-setup-docker@1.0.11
+        timeout-minutes: 30
+
+      - name: Setup Docker on macOS attempt 2
+        if: steps.docker1.outcome != 'success'
+        uses: docker-practice/actions-setup-docker@1.0.11
+        timeout-minutes: 30
 
       - name: Run regtest setup
-        run: |
-          cd __tests__ && docker-compose up -d
+        run: cd __tests__ && docker-compose up -d
 
       - name: Wait for bitcoind
         timeout-minutes: 2
-        run: |
-          while ! nc -z '127.0.0.1' 43782; do sleep 1; done
+        run: while ! nc -z '127.0.0.1' 43782; do sleep 1; done
 
       - name: Wait for electrum server
         timeout-minutes: 2

--- a/e2e/onchain.e2e.js
+++ b/e2e/onchain.e2e.js
@@ -30,9 +30,10 @@ describe('Onchain', () => {
 
 		// repeat 60 times before fail
 		for (let i = 0; i < 60; i++) {
+			await sleep(1000);
 			try {
 				await element(by.id('ToGetStartedClose')).tap();
-				await sleep(1000);
+				await sleep(3000); // wait for redux-persist to save state
 				break;
 			} catch (e) {
 				continue;

--- a/e2e/settings.e2e.js
+++ b/e2e/settings.e2e.js
@@ -15,20 +15,21 @@ describe('Settings', () => {
 		await element(by.id('SkipIntro')).tap();
 		await element(by.id('NewWallet')).tap();
 
-		// wat for wallet to be created
+		// wait for wallet to be created
 		await waitFor(element(by.id('ToGetStartedClose'))).toBeVisible();
 		await sleep(1000); // take app some time to load
 
 		// repeat 60 times before fail
 		for (let i = 0; i < 60; i++) {
+			await sleep(1000);
 			try {
 				await element(by.id('ToGetStartedClose')).tap();
-				await sleep(1000);
-				break;
-			} catch (e) {
-				continue;
-			}
+				await sleep(3000); // wait for redux-persist to save state
+				return;
+			} catch (e) {}
 		}
+
+		throw new Error('Tapping "ToGetStartedClose" timeout');
 	});
 
 	beforeEach(async () => {


### PR DESCRIPTION
- fix bug in e2e beforeAll setup
- increase docker setup action timeout, run another attempt, if first one fails
- add github actions matrix, so we now have 2 e2e tests running simulataniously. 