### PR TITLE
fix(wallet): Fix Transaction Details

### DIFF
--- a/src/screens/Settings/Advanced/index.tsx
+++ b/src/screens/Settings/Advanced/index.tsx
@@ -12,6 +12,7 @@ import {
 } from '../../../store/reselect/wallet';
 import type { SettingsScreenProps } from '../../../navigation/types';
 import { rescanAddresses } from '../../../utils/wallet';
+import { updateTransactions } from '../../../store/actions/wallet';
 
 const typesDescriptions = {
 	[EAddressType.p2wpkh]: 'Native Segwit',
@@ -68,6 +69,13 @@ const AdvancedSettings = ({
 				onPress: async (): Promise<void> => {
 					setRescanning(true);
 					await rescanAddresses({ selectedWallet, selectedNetwork });
+					await updateTransactions({
+						scanAllAddresses: true,
+						replaceStoredTransactions: true,
+						selectedWallet,
+						selectedNetwork,
+						showNotification: false,
+					});
 					setRescanning(false);
 				},
 			},


### PR DESCRIPTION
This PR:
- Updates `getInputData` method to include the `vout` index as part of the reference object key.
- Added `combinedAddressObj` for more efficient checks when handling a large number of inputs/outputs.
- Moved the `txid` check logic higher up in `formatTransactions`.
- Added `replaceStoredTransactions` to `updateTransactions` method.
- Added `updateTransactions` to the "Rescan Addresses" button.

Notes:
- Previously, `getInputData` was not taking into account the `vout` index when returning input data. So if a user had multiple inputs that were sourced from the same transaction, it would replace the information at that `tx_hash` index. Only returning one instead of all the desired inputs. This would result in the miscalculation when formatting and storing the transaction for later reference.
- User's that have encountered this issue can navigate to "Settings->Advanced->Rescan Addresses" to update their old transaction details.