### PR TITLE
feat(wallet): Add Min-Fee Relay Dialog

### DIFF
--- a/src/screens/Wallets/Send/FeeCustom.tsx
+++ b/src/screens/Wallets/Send/FeeCustom.tsx
@@ -70,7 +70,7 @@ const FeeCustom = ({
 		if (
 			transaction?.satsPerByte &&
 			// This check is to prevent situations where all values are set to 1sat/vbyte. Where setting 1sat/vbyte is perfectly fine.
-			feeEstimates.minimum !== feeEstimates.slow &&
+			feeEstimates.minimum < feeEstimates.slow &&
 			transaction.satsPerByte <= feeEstimates.minimum
 		) {
 			setDisplayFeeDialog(true);

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -160,7 +160,7 @@ export const startWalletServices = async ({
 
 		if (onchain || lightning) {
 			await Promise.all([
-				updateOnchainFeeEstimates({ selectedNetwork }),
+				updateOnchainFeeEstimates({ selectedNetwork, forceUpdate: true }),
 				// if we restore wallet, we need to generate addresses for all types
 				refreshWallet({
 					onchain: isConnectedToElectrum,


### PR DESCRIPTION
This PR:
- Creates `onContinue` method in `FeeCustom` component.
- Implements `Dialog` in `FeeCustom` component that alerts users when setting the min-relay fee.
- Sets `forceUpdate` param to true in `updateOnchainFeeEstimates` when starting app.

Notes:
- Bitkit will now grab fee estimates every time the app launches.
- Bitkit will now present a Dialog when users attempt to set a custom fee that is at or below the current minimum tx relay fee.