### PR TITLE
feat(wallet): Add Minimum Transaction Relay Fee Dialog

### DIFF
--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -160,7 +160,7 @@ export const startWalletServices = async ({
 
 		if (onchain || lightning) {
 			await Promise.all([
-				updateOnchainFeeEstimates({ selectedNetwork }),
+				updateOnchainFeeEstimates({ selectedNetwork, forceUpdate: true }),
 				// if we restore wallet, we need to generate addresses for all types
 				refreshWallet({
 					onchain: isConnectedToElectrum,


### PR DESCRIPTION
This PR:
- Adds `Dialog` to `ReviewAndSend` component that alerts users when setting the min-relay fee.
- Sets `forceUpdate` param to true in `updateOnchainFeeEstimates` when starting app.

Notes:
- Bitkit will now grab fee estimates every time the app launches.
- Bitkit will now present a Dialog when users have set a fee that is at or below the current minimum tx relay fee.