### PR TITLE
fix(send): fee calculation for tx w/ p2sh input addresses

### DIFF
--- a/__tests__/wallet-send.ts
+++ b/__tests__/wallet-send.ts
@@ -171,8 +171,8 @@ describe('Wallet - new wallet, send and receive', () => {
 
 		const tx13 =
 			store.getState().wallet.wallets.wallet0.transaction.bitcoinRegtest;
-		expect(tx13?.satsPerByte).toBe(3);
-		expect(tx13?.fee).toBe(900);
+		expect(tx13.satsPerByte).toBe(3);
+		expect(tx13.fee).toBe(423);
 
 		res = validateTransaction(tx13);
 		if (res.isErr()) {

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -51,16 +51,16 @@ export type TBitcoinLabel =
 export type TTicker = 'BTC' | 'tBTC';
 
 export type TGetByteCountInput =
-	| 'MULTISIG-P2SH'
-	| 'MULTISIG-P2WSH'
-	| 'MULTISIG-P2SH-P2WSH'
-	| 'P2PKH'
-	| 'P2WPKH'
+	| `MULTISIG-P2SH:${number}-${number}`
+	| `MULTISIG-P2WSH:${number}-${number}`
+	| `MULTISIG-P2SH-P2WSH:${number}-${number}`
 	| 'P2SH-P2WPKH'
-	| 'p2wpkh'
-	| 'p2sh'
+	| 'P2PKH'
 	| 'p2pkh'
-	| string; //Unsure how to account for multisig variations (ex. 'MULTISIG-P2SH:2-4')
+	| 'P2WPKH'
+	| 'p2wpkh'
+	| 'P2SH'
+	| 'p2sh';
 
 export type TGetByteCountOutput =
 	| 'P2SH'


### PR DESCRIPTION
This fixes the min relay fee error when sending from a p2sh input. Also removed the condition for the fee to be higher than `recommendedBaseFee`.

### Changes
- add missing field `P2SH` for fee calculation
- add types for address weight calculation objects