### PR TITLE
fix(lightning): set channel opening tx fallback fee

### DIFF
--- a/__tests__/transactions.ts
+++ b/__tests__/transactions.ts
@@ -31,7 +31,7 @@ describe('On chain transactions', () => {
 	it('Creates an on chain transaction from the transaction store', async () => {
 		const selectedWallet = getSelectedWallet();
 
-		await updateBitcoinTransaction({
+		updateBitcoinTransaction({
 			selectedNetwork,
 			selectedWallet,
 			transaction: {

--- a/__tests__/wallet-send.ts
+++ b/__tests__/wallet-send.ts
@@ -141,7 +141,7 @@ describe('Wallet - new wallet, send and receive', () => {
 		expect(tx11?.satsPerByte).toBe(2);
 
 		// set address and amount
-		res = await updateBitcoinTransaction({
+		res = updateBitcoinTransaction({
 			transaction: {
 				outputs: [{ address: receivingAddress1, value: 50_000_000, index: 0 }],
 			},
@@ -237,7 +237,7 @@ describe('Wallet - new wallet, send and receive', () => {
 		}
 
 		// set address and amount
-		res = await updateBitcoinTransaction({
+		res = updateBitcoinTransaction({
 			transaction: {
 				outputs: [{ address: receivingAddress2, value: 50_000_000, index: 0 }],
 				rbf: true,

--- a/src/screens/Settings/AddressViewer/index.tsx
+++ b/src/screens/Settings/AddressViewer/index.tsx
@@ -687,7 +687,7 @@ const AddressViewer = ({
 			if (receiveAddress.isErr()) {
 				return;
 			}
-			await updateBitcoinTransaction({
+			updateBitcoinTransaction({
 				transaction: {
 					...transactionRes.value,
 					outputs: [{ address: receiveAddress.value, value: 0, index: 0 }],

--- a/src/screens/Wallets/Send/Recipient.tsx
+++ b/src/screens/Wallets/Send/Recipient.tsx
@@ -222,7 +222,7 @@ const Recipient = ({
 					transaction: {
 						outputs: [{ address: clipboardData, value, index }],
 					},
-				}).then();
+				});
 			}
 		},
 		[index, value, selectedNetwork, selectedWallet, sdk],
@@ -269,7 +269,7 @@ const Recipient = ({
 			selectedWallet,
 			selectedNetwork,
 			transaction: tx,
-		}).then();
+		});
 	}, [
 		handledOsPaste,
 		address,
@@ -303,7 +303,7 @@ const Recipient = ({
 					outputs: [{ address: txt, value, index }],
 					lightningInvoice: '',
 				},
-			}).then();
+			});
 		},
 		[
 			handlePaste,

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -1075,7 +1075,7 @@ export const getChangeAddress = async ({
  * @param {TAvailableNetworks} [selectedNetwork]
  * @return {Promise<Result<string>>}
  */
-export const updateBitcoinTransaction = async ({
+export const updateBitcoinTransaction = ({
 	transaction,
 	selectedWallet,
 	selectedNetwork,
@@ -1083,7 +1083,7 @@ export const updateBitcoinTransaction = async ({
 	transaction: Partial<IBitcoinTransactionData>;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: TAvailableNetworks;
-}): Promise<Result<string>> => {
+}): Result<string> => {
 	try {
 		if (!selectedNetwork) {
 			selectedNetwork = getSelectedNetwork();
@@ -1143,7 +1143,7 @@ export const updateSelectedFeeId = async ({
 		}
 		const transaction = transactionResponse.value;
 		transaction.selectedFeeId = feeId;
-		await updateBitcoinTransaction({ transaction });
+		updateBitcoinTransaction({ transaction });
 		return ok('Fee updated');
 	} catch (e) {
 		console.log(e);

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -721,7 +721,7 @@ export const handleData = async ({
 				amount = outputAmount.value;
 			}
 
-			await updateBitcoinTransaction({
+			updateBitcoinTransaction({
 				selectedWallet,
 				selectedNetwork,
 				transaction: {
@@ -756,7 +756,7 @@ export const handleData = async ({
 				sendNavigation.navigate('Amount');
 			}
 
-			await updateBitcoinTransaction({
+			updateBitcoinTransaction({
 				selectedWallet,
 				selectedNetwork,
 				transaction: {

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -701,9 +701,7 @@ export const createTransaction = async ({
 	}
 
 	//Remove any outputs that are below the dust limit and apply them to the fee.
-	if (transactionData?.outputs) {
-		transactionData.outputs = removeDustOutputs(transactionData.outputs);
-	}
+	removeDustOutputs(transactionData.outputs);
 
 	const inputValue = getTransactionInputValue({
 		selectedNetwork,
@@ -1125,10 +1123,10 @@ export const updateFee = ({
 	});
 
 	const max = transaction.max;
-	const message = transaction.message ?? '';
-	const outputs = transaction.outputs ?? [];
+	const message = transaction.message;
+	const outputs = transaction.outputs;
 	let address = '';
-	if (outputs?.length > index) {
+	if (outputs.length > index) {
 		address = outputs[index]?.address ?? '';
 	}
 
@@ -1166,7 +1164,7 @@ export const updateFee = ({
 			selectedNetwork,
 			selectedWallet,
 			transaction: _transaction,
-		}).then();
+		});
 		return ok('Successfully updated the transaction fee.');
 	}
 	return err(
@@ -1558,13 +1556,13 @@ export const sendMax = ({
 					selectedWallet,
 					selectedNetwork,
 					transaction: _transaction,
-				}).then();
+				});
 			} else {
 				updateBitcoinTransaction({
 					selectedWallet,
 					selectedNetwork,
 					transaction: { max: !max },
-				}).then();
+				});
 			}
 		} else {
 			// onchain transaction
@@ -1594,13 +1592,13 @@ export const sendMax = ({
 					selectedWallet,
 					selectedNetwork,
 					transaction: _transaction,
-				}).then();
+				});
 			} else {
 				updateBitcoinTransaction({
 					selectedWallet,
 					selectedNetwork,
 					transaction: { max: !max },
-				}).then();
+				});
 			}
 		}
 
@@ -1710,9 +1708,9 @@ export const updateAmount = async ({
 
 	let newAmount = Number(amount);
 	let inputTotal = 0;
-	const outputs = transaction?.outputs ?? [];
+	const outputs = transaction.outputs;
 
-	if (transaction?.lightningInvoice) {
+	if (transaction.lightningInvoice) {
 		// lightning transaction
 		const { satoshis } = getBalance({
 			lightning: true,
@@ -1726,8 +1724,8 @@ export const updateAmount = async ({
 		}
 	} else {
 		// onchain transaction
-		const satsPerByte = transaction?.satsPerByte ?? 1;
-		const message = transaction?.message;
+		const satsPerByte = transaction.satsPerByte;
+		const message = transaction.message;
 
 		let totalNewAmount = 0;
 		const totalFee = getTotalFee({
@@ -1761,7 +1759,7 @@ export const updateAmount = async ({
 
 	let address = '';
 	let value = 0;
-	if (outputs?.length > index) {
+	if (outputs.length > index) {
 		value = outputs[index].value ?? 0;
 		address = outputs[index].address ?? '';
 	}
@@ -1775,7 +1773,7 @@ export const updateAmount = async ({
 	}
 
 	const output = { address, value: newAmount, index };
-	await updateBitcoinTransaction({
+	updateBitcoinTransaction({
 		selectedWallet,
 		selectedNetwork,
 		transaction: {
@@ -1856,7 +1854,7 @@ export const updateMessage = async ({
 			selectedNetwork,
 			selectedWallet,
 			transaction: _transaction,
-		}).then();
+		});
 		return ok('Successfully updated the message.');
 	}
 	if (totalNewAmount <= inputTotal) {
@@ -1864,7 +1862,7 @@ export const updateMessage = async ({
 			selectedNetwork,
 			selectedWallet,
 			transaction: _transaction,
-		}).then();
+		});
 	}
 	return ok('Successfully updated the message.');
 };
@@ -2121,7 +2119,7 @@ export const setupRbf = async ({
 				txid,
 			});
 		}
-		const newTransaction = {
+		const newTransaction: Partial<IBitcoinTransactionData> = {
 			...transaction,
 			minFee: _satsPerByte,
 			fee: newFee,
@@ -2130,7 +2128,7 @@ export const setupRbf = async ({
 			boostType: EBoostType.rbf,
 		};
 
-		await updateBitcoinTransaction({
+		updateBitcoinTransaction({
 			selectedWallet,
 			selectedNetwork,
 			transaction: newTransaction,
@@ -2312,7 +2310,7 @@ export const getFeeEstimates = async (
 			selectedNetwork = getSelectedNetwork();
 		}
 
-		if (__DEV__ && selectedNetwork === 'bitcoinTestnet') {
+		if (__DEV__ && selectedNetwork === 'bitcoinRegtest') {
 			return defaultFeesShape.onchain;
 		}
 


### PR DESCRIPTION
Sets the fee for the channel opening transaction to "fast" if BT's `zero_conf_satvbyte` is not available for some reason.

### Changes
- add channel opening tx fallback fee
- remove some unnecessary async code
- set default onchain fees for development on regtest