### PR TITLE
fix(send): update available/max amount calculation

### DIFF
--- a/__tests__/wallet-send.ts
+++ b/__tests__/wallet-send.ts
@@ -227,7 +227,7 @@ describe('Wallet - new wallet, send and receive', () => {
 		const receivingAddress2 = await rpc.getNewAddress();
 
 		// setup new transaction
-		res = await resetOnChainTransaction();
+		res = resetOnChainTransaction();
 		if (res.isErr()) {
 			throw res.error;
 		}
@@ -244,17 +244,17 @@ describe('Wallet - new wallet, send and receive', () => {
 			},
 		});
 
-		res = await sendMax();
+		res = sendMax();
 		if (res.isErr()) {
 			throw res.error;
 		}
 
 		const tx21 =
 			store.getState().wallet.wallets.wallet0.transaction.bitcoinRegtest;
-		expect(tx21?.rbf).toEqual(true);
+		expect(tx21.rbf).toEqual(true);
 
-		// sending amount + fee should be equeal to the balance
-		expect((tx21?.outputs?.[0].value ?? 0) + (tx21?.fee ?? 0)).toBe(
+		// sending amount + fee should be equal to the balance
+		expect((tx21.outputs[0]?.value ?? 0) + tx21.fee).toBe(
 			store.getState().wallet.wallets.wallet0.balance.bitcoinRegtest,
 		);
 

--- a/src/navigation/bottom-sheet/SendNavigation.tsx
+++ b/src/navigation/bottom-sheet/SendNavigation.tsx
@@ -27,6 +27,7 @@ import { viewControllerSelector } from '../../store/reselect/ui';
 import {
 	resetOnChainTransaction,
 	setupOnChainTransaction,
+	setupFeeForOnChainTransaction,
 } from '../../store/actions/wallet';
 
 export type SendNavigationProp = NativeStackNavigationProp<SendStackParamList>;
@@ -95,12 +96,17 @@ const SendNavigation = (): ReactElement => {
 
 	const initialRouteName = screen ?? 'Recipient';
 
+	const onOpen = (): void => {
+		setupOnChainTransaction();
+		setupFeeForOnChainTransaction();
+	};
+
 	return (
 		<BottomSheetWrapper
 			view="sendNavigation"
 			snapPoints={snapPoints}
 			onClose={resetOnChainTransaction}
-			onOpen={setupOnChainTransaction}>
+			onOpen={onOpen}>
 			<NavigationContainer key={isOpen.toString()} ref={navigationRef}>
 				<Stack.Navigator
 					initialRouteName={initialRouteName}

--- a/src/screens/Settings/AddressViewer/index.tsx
+++ b/src/screens/Settings/AddressViewer/index.tsx
@@ -696,7 +696,7 @@ const AddressViewer = ({
 				selectedWallet,
 				selectedNetwork,
 			});
-			await sendMax({ selectedWallet, selectedNetwork });
+			sendMax({ selectedWallet, selectedNetwork });
 			showBottomSheet('sendNavigation');
 		},
 		[selectedNetwork, selectedUtxos, selectedWallet, utxos],

--- a/src/screens/Wallets/Send/CoinSelection.tsx
+++ b/src/screens/Wallets/Send/CoinSelection.tsx
@@ -88,6 +88,9 @@ const CoinSelection = ({
 	const transaction = useSelector(transactionSelector);
 	const utxos = useSelector(utxosSelector);
 	const coinSelectPreference = useSelector(coinSelectPreferenceSelector);
+	const [autoSelectionEnabled, setAutoSelectionEnabled] = useState(
+		transaction.inputs.length === utxos.length,
+	);
 
 	const buttonContainerStyles = useMemo(
 		() => ({
@@ -100,10 +103,6 @@ const CoinSelection = ({
 	const preference = useMemo(
 		() => t(`preference_${coinSelectPreference}`),
 		[coinSelectPreference, t],
-	);
-
-	const [autoSelectionEnabled, setAutoSelectionEnabled] = useState(
-		transaction.inputs.length === utxos.length,
 	);
 
 	const txInputValue = useMemo(
@@ -147,6 +146,8 @@ const CoinSelection = ({
 		});
 		setAutoSelectionEnabled(true);
 	};
+
+	const isValid = txInputValue >= txOutputValue;
 
 	return (
 		<GradientView style={styles.container}>
@@ -213,7 +214,7 @@ const CoinSelection = ({
 					<Button
 						size="large"
 						text={t('continue')}
-						disabled={txInputValue < txOutputValue}
+						disabled={!isValid}
 						onPress={(): void => navigation.navigate('ReviewAndSend')}
 					/>
 				</View>

--- a/src/screens/Wallets/Send/FeeRate.tsx
+++ b/src/screens/Wallets/Send/FeeRate.tsx
@@ -92,20 +92,49 @@ const FeeRate = ({ navigation }: SendScreenProps<'FeeRate'>): ReactElement => {
 	);
 
 	const displayFast = useMemo(() => {
-		return balance.satoshis >= transactionTotal() + getFee(feeEstimates.fast);
-	}, [balance.satoshis, feeEstimates.fast, getFee, transactionTotal]);
-	const displayNormal = useMemo(
-		() => balance.satoshis >= transactionTotal() + getFee(feeEstimates.normal),
-		[balance.satoshis, feeEstimates.normal, getFee, transactionTotal],
-	);
-	const displaySlow = useMemo(
-		() => balance.satoshis >= transactionTotal() + getFee(feeEstimates.slow),
-		[balance.satoshis, feeEstimates.slow, getFee, transactionTotal],
-	);
-	const displayCustom = useMemo(
-		() => balance.satoshis >= transactionTotal() + getFee(1),
-		[balance.satoshis, getFee, transactionTotal],
-	);
+		return (
+			balance.satoshis >= transactionTotal() + getFee(feeEstimates.fast) ||
+			transaction.max
+		);
+	}, [
+		balance.satoshis,
+		feeEstimates.fast,
+		getFee,
+		transactionTotal,
+		transaction.max,
+	]);
+
+	const displayNormal = useMemo(() => {
+		return (
+			balance.satoshis >= transactionTotal() + getFee(feeEstimates.normal) ||
+			transaction.max
+		);
+	}, [
+		balance.satoshis,
+		feeEstimates.normal,
+		getFee,
+		transactionTotal,
+		transaction.max,
+	]);
+
+	const displaySlow = useMemo(() => {
+		return (
+			balance.satoshis >= transactionTotal() + getFee(feeEstimates.slow) ||
+			transaction.max
+		);
+	}, [
+		balance.satoshis,
+		feeEstimates.slow,
+		getFee,
+		transactionTotal,
+		transaction.max,
+	]);
+
+	const displayCustom = useMemo(() => {
+		return (
+			balance.satoshis >= transactionTotal() + getFee(1) || transaction.max
+		);
+	}, [balance.satoshis, getFee, transactionTotal, transaction.max]);
 
 	const isSelected = useCallback(
 		(id: EFeeId) => id === selectedFeeId,

--- a/src/screens/Wallets/Send/Result.tsx
+++ b/src/screens/Wallets/Send/Result.tsx
@@ -178,7 +178,7 @@ const Result = ({
 			If unable to properly create a valid transaction for any reason, reset the tx state as done below.
 		*/
 		//If unable to broadcast for any reason, reset the transaction object and try again.
-		await resetOnChainTransaction({ selectedWallet, selectedNetwork });
+		resetOnChainTransaction({ selectedWallet, selectedNetwork });
 		await setupOnChainTransaction({
 			selectedWallet,
 			selectedNetwork,

--- a/src/screens/Wallets/Send/ReviewAndSend.tsx
+++ b/src/screens/Wallets/Send/ReviewAndSend.tsx
@@ -225,10 +225,7 @@ const ReviewAndSend = ({
 	);
 
 	useEffect(() => {
-		const res = setupFeeForOnChainTransaction();
-		if (res.isErr()) {
-			console.log(res.error.message);
-		}
+		setupFeeForOnChainTransaction();
 	}, []);
 
 	const _onError = useCallback(
@@ -804,8 +801,11 @@ const ReviewAndSend = ({
 				/>
 				<Dialog
 					visible={showDialog5}
-					title="Fee is potentially too low"
-					description={`The fee you are trying to set is below ${feeEstimates.minimum} sats and may be too low due to current network conditions. This transaction may fail, take a while to confirm, or get trimmed from the mempool. Do you wish to proceed?`}
+					title={t('send_dialog5_title')}
+					description={t('send_dialog5_description', {
+						minimumFee: feeEstimates.minimum,
+					})}
+					confirmText={t('continue')}
 					onCancel={(): void => {
 						setShowDialog5(false);
 						setTimeout(() => navigation.goBack(), 100);

--- a/src/screens/Wallets/Send/SendNumberPad.tsx
+++ b/src/screens/Wallets/Send/SendNumberPad.tsx
@@ -3,7 +3,6 @@ import { StyleProp, ViewStyle } from 'react-native';
 import { useSelector } from 'react-redux';
 
 import NumberPad from '../../../components/NumberPad';
-import Store from '../../../store/types';
 import { btcToSats } from '../../../utils/helpers';
 import { useExchangeRate } from '../../../hooks/displayValues';
 import { EBitcoinUnit } from '../../../store/types/wallet';
@@ -21,6 +20,7 @@ import {
 	transactionSelector,
 } from '../../../store/reselect/wallet';
 import {
+	bitcoinUnitSelector,
 	selectedCurrencySelector,
 	unitPreferenceSelector,
 } from '../../../store/reselect/settings';
@@ -38,15 +38,11 @@ const SendNumberPad = ({
 
 	const selectedWallet = useSelector(selectedWalletSelector);
 	const selectedNetwork = useSelector(selectedNetworkSelector);
-
-	const bitcoinUnit = useSelector((store: Store) => store.settings.bitcoinUnit);
-
+	const bitcoinUnit = useSelector(bitcoinUnitSelector);
 	const unitPreference = useSelector(unitPreferenceSelector);
-
 	const currency = useSelector(selectedCurrencySelector);
-	const exchangeRate = useExchangeRate(currency);
-
 	const transaction = useSelector(transactionSelector);
+	const exchangeRate = useExchangeRate(currency);
 
 	/*
 	 * Retrieves total value of all outputs. Excludes change address.
@@ -159,7 +155,7 @@ const SendNumberPad = ({
 			selectedWallet,
 			selectedNetwork,
 			index: 0,
-		}).then();
+		});
 	};
 
 	// Shift, remove and update the current transaction amount based on the provided fiat value or bitcoin unit.
@@ -202,7 +198,7 @@ const SendNumberPad = ({
 			selectedNetwork,
 			index: 0,
 			max: false,
-		}).then();
+		});
 	};
 
 	const numberPadType =

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -24,6 +24,8 @@
 	"send_dialog2": "It appears you are sending over 50% of your total balance. Do you want to continue?",
 	"send_dialog3": "The transaction fee appears to be over 50% of the amount you are sending. Do you want to continue?",
 	"send_dialog4": "The transaction fee appears to be over $10. Do you want to continue?",
+	"send_dialog5_title": "Fee is potentially too low",
+	"send_dialog5_description": "Current network conditions require that your fee should be greater than {{minimumFee}} sats/vbyte. This transaction may fail, take a while to confirm, or get trimmed from the mempool. Do you wish to proceed?",
 	"send_sent": "Bitcoin Sent",
 	"send_instant_failed": "Instant Payment Failed",
 	"send_regular": "Regular Payment",

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -569,7 +569,7 @@ export const processBitcoinTransactionData = async ({
 				(d) => d.qrDataType === EQRDataType.bitcoinAddress,
 			);
 			if (filteredBitcoinInvoice) {
-				const requestedOnChainAmount = filteredBitcoinInvoice?.sats ?? 0;
+				const requestedOnChainAmount = filteredBitcoinInvoice.sats ?? 0;
 				// Only set a new requested amount if a value was specified in the invoice.
 				if (requestedOnChainAmount) {
 					requestedAmount = requestedOnChainAmount;
@@ -602,8 +602,8 @@ export const processBitcoinTransactionData = async ({
 					// If the user already specified an amount in the app, don't override it.
 					// Otherwise, set sats to 0.
 					let sats = 0;
-					if (transaction.isOk() && transaction.value?.outputs) {
-						sats = transaction.value?.outputs[0]?.value ?? 0;
+					if (transaction.isOk() && transaction.value.outputs) {
+						sats = transaction.value.outputs[0]?.value ?? 0;
 					}
 					response = {
 						...filteredBitcoinInvoice,


### PR DESCRIPTION
Calculate the correct available amount when sending onchain based on the user's preferred fee rate or  fee setting for the current transaction. 

### Changes
- calculate the correct available amount when sending onchain
- always show all FeeRate options if transaction is set to send max amount
- update low fee warning dialog text
- cleanup

### Preview

https://user-images.githubusercontent.com/8538369/222418385-b30b91bc-f929-4e7c-b8d2-abfeaca5e773.mp4

