### PR TITLE
fix(widgets): app crashing when reopening price feed settings

### DIFF
--- a/src/hooks/widgets.ts
+++ b/src/hooks/widgets.ts
@@ -61,7 +61,7 @@ export const useFeedWidget = ({
 
 		return function cleanup() {
 			unmounted = true;
-			drive.close();
+			drive.core.removeAllListeners();
 		};
 	}, [url, sdk, feed]);
 


### PR DESCRIPTION
temporarily remove the drive.close() at the cleanup function need to bound the number of cores sessions opened for widgets best change the SDK to read and subscribe to updates without instantiating cores at all

closes #919