### PR TITLE
fix(widgets): handle malformed slashfeed.json where fields are not ar…

### DIFF
--- a/src/components/FeedWidget.tsx
+++ b/src/components/FeedWidget.tsx
@@ -37,7 +37,7 @@ export const FeedWidget = ({
 		<BaseFeedWidget
 			url={url}
 			name={name || widget.feed.name}
-			label={widget.feed.field.name}
+			label={widget.feed.field?.name}
 			isEditing={isEditing}
 			onLongPress={onLongPress}
 			right={<DefaultRightComponent value={value?.toString()} />}

--- a/src/components/PriceWidget.tsx
+++ b/src/components/PriceWidget.tsx
@@ -111,7 +111,7 @@ const PriceWidget = ({
 	useEffect(() => {
 		let unmounted = false;
 
-		if (!drive) {
+		if (!drive || !widget.feed.field?.files[period]) {
 			return;
 		}
 		drive
@@ -126,7 +126,7 @@ const PriceWidget = ({
 		return function cleanup() {
 			unmounted = true;
 		};
-	}, [drive, widget.feed.field.files, period]);
+	}, [drive, widget.feed.field?.files, period]);
 
 	const change = useMemo((): {
 		color: keyof IThemeColors;
@@ -150,7 +150,7 @@ const PriceWidget = ({
 		<BaseFeedWidget
 			url={url}
 			name={t('widget_price')}
-			label={widget.feed.field.name}
+			label={widget.feed.field?.name}
 			icon={<ChartLineIcon width={32} height={32} />}
 			isEditing={isEditing}
 			middle={<Chart color={change.color} values={pastValues} />}

--- a/src/screens/Widgets/WidgetFeedEdit.tsx
+++ b/src/screens/Widgets/WidgetFeedEdit.tsx
@@ -153,7 +153,7 @@ export const WidgetFeedEdit = ({
 				type: config.type,
 				description: config.description,
 				icon: config.icon,
-				field: config.fields?.find((f) => f.name === selectedField),
+				field: config.fields?.find?.((f) => f.name === selectedField),
 			} as IWidget['feed']);
 		}
 
@@ -175,7 +175,7 @@ export const WidgetFeedEdit = ({
 			description: config.description ?? '',
 			icon: config.icon ?? '',
 			type: config.type ?? '',
-			field: config.fields?.find((f) => f.name === selectedField)!,
+			field: config.fields?.find?.((f) => f.name === selectedField),
 		},
 	};
 

--- a/src/store/types/widgets.ts
+++ b/src/store/types/widgets.ts
@@ -20,7 +20,7 @@ export interface SlashFeedJSON {
 export interface IWidget {
 	feed: Pick<SlashFeedJSON, 'name' | 'type'> & {
 		icon: string;
-		field: SlashFeedJSON['fields'][0];
+		field?: SlashFeedJSON['fields'][0];
 	};
 	magiclink?: boolean;
 }


### PR DESCRIPTION
Just in case slashfeed.json comes with an invalid `fields` or is empty so no fields are available.