### PR TITLE
fix(wallet): #780 skipping addressIndex

### DIFF
--- a/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
+++ b/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 
 import { EItemType, IListData } from '../../../components/List';
 import SettingsView from '../SettingsView';
-import { EAvailableNetworks } from '../../../utils/networks';
 import {
 	updateAddressIndexes,
 	updateWallet,
@@ -14,15 +13,17 @@ import {
 	updateActivityList,
 } from '../../../store/actions/activity';
 import { updateOnchainFeeEstimates } from '../../../store/actions/fees';
-import { getNetworkData } from '../../../utils/helpers';
+import { selectedNetworkSelector } from '../../../store/reselect/wallet';
+import { connectToElectrum } from '../../../utils/wallet/electrum';
 import { startWalletServices } from '../../../utils/startup';
+import { EAvailableNetworks } from '../../../utils/networks';
+import { getNetworkData } from '../../../utils/helpers';
+import { resetLdk } from '../../../utils/lightning';
 import {
 	getCurrentWallet,
 	getSelectedAddressType,
 } from '../../../utils/wallet';
 import { SettingsScreenProps } from '../../../navigation/types';
-import { selectedNetworkSelector } from '../../../store/reselect/wallet';
-import { resetLdk } from '../../../utils/lightning';
 
 const BitcoinNetworkSelection = ({
 	navigation,
@@ -52,6 +53,8 @@ const BitcoinNetworkSelection = ({
 								selectedNetwork: network,
 								selectedWallet,
 							});
+							// Connect to a Electrum Server on the network
+							await connectToElectrum({ selectedNetwork: network });
 							// Generate addresses if none exist for the newly selected wallet and network.
 							await updateAddressIndexes({
 								selectedWallet,

--- a/src/store/types/settings.ts
+++ b/src/store/types/settings.ts
@@ -31,9 +31,7 @@ export type TReceiveOption = {
 
 export type TUnitPreference = 'asset' | 'fiat';
 
-export type TCustomElectrumPeers =
-	| IWalletItem<ICustomElectrumPeer[]>
-	| IWalletItem<[]>;
+export type TCustomElectrumPeers = IWalletItem<ICustomElectrumPeer[]>;
 
 export interface ISettings {
 	enableAutoReadClipboard: boolean;

--- a/src/utils/wallet/electrum.ts
+++ b/src/utils/wallet/electrum.ts
@@ -44,6 +44,20 @@ export type TUnspentAddressScriptHashData = {
 };
 
 /**
+ * Check if app is connected to Electrum Server.
+ * @returns {Promise<boolean>}
+ */
+export const isConnectedElectrum = async (): Promise<boolean> => {
+	const { error } = await electrum.pingServer();
+
+	if (error) {
+		return false;
+	} else {
+		return true;
+	}
+};
+
+/**
  * Returns UTXO's for a given wallet and network along with the available balance.
  * @param {TWalletName} [selectedWallet]
  * @param {TAvailableNetworks} [selectedNetwork]
@@ -610,10 +624,10 @@ export const getAddressHistory = async ({
 		}
 
 		const history: IGetAddressHistoryResponse[] = [];
-		combinedResponse.map(
+		combinedResponse.forEach(
 			({ data, result }: { data: IAddress; result: TTxResult[] }): void => {
 				if (result && result?.length > 0) {
-					result.map((item) => {
+					result.forEach((item) => {
 						history.push({ ...data, ...item });
 					});
 				}

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -514,7 +514,7 @@ const createPsbtFromTransactionData = async ({
 	}
 
 	//Embed any OP_RETURN messages.
-	if (message && message.trim() !== '') {
+	if (message.trim() !== '') {
 		const messageLength = message.length;
 		const lengthMin = 5;
 		//This is a patch for the following: https://github.com/coreyphillips/moonshine/issues/52
@@ -545,7 +545,7 @@ const createPsbtFromTransactionData = async ({
 
 	//Add Inputs from inputs array
 	try {
-		for await (const input of inputs) {
+		for (const input of inputs) {
 			const path = input.path;
 			const keyPair: BIP32Interface = root.derivePath(path);
 			await addInput({
@@ -841,7 +841,7 @@ export const addInput = async ({
 		const network = networks[selectedNetwork];
 		const { type } = getAddressInfo(input.address);
 
-		if (!input?.value) {
+		if (!input.value) {
 			return err('No input provided.');
 		}
 
@@ -909,7 +909,7 @@ export const addInput = async ({
 };
 
 export const broadcastTransaction = async ({
-	rawTx = '',
+	rawTx,
 	selectedNetwork,
 	selectedWallet,
 	subscribeToOutputAddress = true,
@@ -931,14 +931,14 @@ export const broadcastTransaction = async ({
 		if (!selectedWallet) {
 			selectedWallet = getSelectedWallet();
 		}
-		const transaction = await getOnchainTransactionData({
+		const transaction = getOnchainTransactionData({
 			selectedNetwork,
 			selectedWallet,
 		});
 		if (transaction.isErr()) {
 			return err(transaction.error.message);
 		}
-		const address = transaction.value.outputs?.[0]?.address;
+		const address = transaction.value.outputs[0]?.address;
 		if (address) {
 			const scriptHash = await getScriptHash(address, selectedNetwork);
 			if (scriptHash) {


### PR DESCRIPTION
Closes https://github.com/synonymdev/bitkit/issues/780

~This PR fixes some incorrect usages of `.map()` together with `async` that most likely caused a race condition when generating addresses causing the above issue. Also removes other unnecessary async code.~

~I'll probably enable the `@typescript-eslint/no-misused-promises` eslint rule and fix other occurrences of this type in another PR.~

This PR fixes a race condition caused by calling `updateAddressIndexes()` twice when switching networks causing the above issue. Also removes other unnecessary async code.

### Changes
- remove all function calls in `BitcoinNetworkSelection.tsx` that are already called in `startWalletServices()`
- remove unnecessary async code, cleanup