### PR TITLE
chore(lightning): Update react-native-ldk to 0.0.82

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -320,7 +320,7 @@ PODS:
     - React-Core
   - react-native-image-picker (4.10.0):
     - React-Core
-  - react-native-ldk (0.0.80):
+  - react-native-ldk (0.0.82):
     - React
   - react-native-libsodium (0.0.1):
     - React-Core
@@ -808,7 +808,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: f68191637788994baed5f57d12994aa32cf8bf88
   react-native-flipper: 7eeb9b59b667dd0619372c7349cf7c78032d1de2
   react-native-image-picker: 4bc9ed38c8be255b515d8c88babbaf74973f91a8
-  react-native-ldk: eab39afb545fcb7e943119ab142c9e40e7d9f59a
+  react-native-ldk: 32e1bcb49b7fdb2dc381ee8cb53fd3cb3c1a5f49
   react-native-libsodium: f4eba037c4ddf73f86b08075452cacb957256147
   react-native-mmkv: 1265a348a4711097ba29c8bcefd5971f48220f2b
   react-native-netinfo: 1a6035d3b9780221d407c277ebfb5722ace00658

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@reduxjs/toolkit": "^1.9.1",
     "@shopify/react-native-skia": "0.1.141",
     "@synonymdev/blocktank-client": "0.0.49",
-    "@synonymdev/react-native-ldk": "^0.0.82",
+    "@synonymdev/react-native-ldk": "0.0.82",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@reduxjs/toolkit": "^1.9.1",
     "@shopify/react-native-skia": "0.1.141",
     "@synonymdev/blocktank-client": "0.0.49",
-    "@synonymdev/react-native-ldk": "0.0.80",
+    "@synonymdev/react-native-ldk": "^0.0.82",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",

--- a/src/store/actions/fees.ts
+++ b/src/store/actions/fees.ts
@@ -24,15 +24,6 @@ export const updateOnchainFeeEstimates = async ({
 
 	if (forceUpdate || (timestamp && difference > REFRESH_INTERVAL)) {
 		const feeEstimates = await getFeeEstimates(selectedNetwork);
-
-		// TODO: set fees for LDK
-		// LDK expects fees to be satoshis per 1000 Weight Units
-		// await ldk.updateFees({
-		// 	highPriority: feeEstimates.fast * 250,
-		// 	normal: feeEstimates.normal * 250,
-		// 	background: feeEstimates.minimum * 250,
-		// });
-
 		dispatch({
 			type: actions.UPDATE_ONCHAIN_FEE_ESTIMATES,
 			payload: feeEstimates,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2110,7 +2110,7 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@^0.0.82":
+"@synonymdev/react-native-ldk@0.0.82":
   version "0.0.82"
   resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.82.tgz#656379f257ba321831b59a3455cd99d7752f9e51"
   integrity sha512-vB80VE+bbzppsKunOAFl0z1GR3Sgaezh+ne5ukYsFN2p73nvdA4eMbSIYptR2GJEW+p/ShwfIrOYBcRBSK2cUg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2110,10 +2110,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@0.0.80":
-  version "0.0.80"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.80.tgz#6f8729ff6fcea4d3963b40d60cfb7dd7e27321f8"
-  integrity sha512-/ikfCEPPmNaL3cdWI4/dWlT+54Br6LoA15WpKBpMzbgo/lVvRKwf55UPXFH8QGuIY+dckrin3y57VcLqfZrgag==
+"@synonymdev/react-native-ldk@^0.0.82":
+  version "0.0.82"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.82.tgz#656379f257ba321831b59a3455cd99d7752f9e51"
+  integrity sha512-vB80VE+bbzppsKunOAFl0z1GR3Sgaezh+ne5ukYsFN2p73nvdA4eMbSIYptR2GJEW+p/ShwfIrOYBcRBSK2cUg==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 


### PR DESCRIPTION
This PR:
- Updates `react-native-ldk` to `0.0.82`.
- Adds `getFees` param to `lm.start` method.