### PR TITLE
test(ui): add e2e test for NumberPad

### DIFF
--- a/e2e/backup.e2e.js
+++ b/e2e/backup.e2e.js
@@ -1,6 +1,12 @@
 import BitcoinJsonRpc from 'bitcoin-json-rpc';
 
-import { sleep, checkComplete, markComplete } from './helpers';
+import {
+	sleep,
+	checkComplete,
+	markComplete,
+	launchAndWait,
+	completeOnboarding,
+} from './helpers';
 import initWaitForElectrumToSync from '../__tests__/utils/wait-for-electrum';
 
 const bitcoinURL =
@@ -11,33 +17,7 @@ describe('Backup', () => {
 	const rpc = new BitcoinJsonRpc(bitcoinURL);
 
 	beforeAll(async () => {
-		await device.launchApp();
-		// TOS and PP
-		await waitFor(element(by.id('Check1'))).toBeVisible();
-
-		await element(by.id('Check1')).tap();
-		await element(by.id('Check2')).tap();
-		await element(by.id('Continue')).tap();
-
-		await waitFor(element(by.id('SkipIntro'))).toBeVisible();
-		await element(by.id('SkipIntro')).tap();
-		await element(by.id('NewWallet')).tap();
-
-		// wat for wallet to be created
-		await waitFor(element(by.id('ToGetStartedClose'))).toBeVisible();
-		await sleep(1000); // take app some time to load
-
-		// repeat 60 times before fail
-		for (let i = 0; i < 60; i++) {
-			await sleep(1000);
-			try {
-				await element(by.id('ToGetStartedClose')).tap();
-				await sleep(3000); // wait for redux-persist to save state
-				break;
-			} catch (e) {
-				continue;
-			}
-		}
+		await completeOnboarding();
 
 		let balance = await rpc.getBalance();
 		const address = await rpc.getNewAddress();
@@ -54,21 +34,7 @@ describe('Backup', () => {
 	});
 
 	beforeEach(async () => {
-		await sleep(1000);
-		await device.launchApp({
-			newInstance: true,
-			// permissions: { faceid: 'YES' },
-		});
-		// wait for AssetsTitle to appear and be accessible
-		for (let i = 0; i < 60; i++) {
-			try {
-				await element(by.id('AssetsTitle')).tap();
-				await sleep(1000);
-				break;
-			} catch (e) {
-				continue;
-			}
-		}
+		await launchAndWait();
 		await waitForElectrum();
 	});
 

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -25,3 +25,53 @@ export const markComplete = (name) => {
 };
 
 export const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export const completeOnboarding = async () => {
+	await device.launchApp();
+
+	// TOS and PP
+	await waitFor(element(by.id('Check1'))).toBeVisible();
+
+	await element(by.id('Check1')).tap();
+	await element(by.id('Check2')).tap();
+	await element(by.id('Continue')).tap();
+
+	await waitFor(element(by.id('SkipIntro'))).toBeVisible();
+	await element(by.id('SkipIntro')).tap();
+	await element(by.id('NewWallet')).tap();
+
+	// wait for wallet to be created
+	await waitFor(element(by.id('ToGetStartedClose'))).toBeVisible();
+	await sleep(1000); // take app some time to load
+
+	// repeat 60 times before fail
+	for (let i = 0; i < 60; i++) {
+		await sleep(1000);
+		try {
+			await element(by.id('ToGetStartedClose')).tap();
+			await sleep(3000); // wait for redux-persist to save state
+			return;
+		} catch (e) {}
+	}
+
+	throw new Error('Tapping "ToGetStartedClose" timeout');
+};
+
+export const launchAndWait = async () => {
+	await sleep(1000);
+	await device.launchApp({
+		newInstance: true,
+		permissions: { faceid: 'YES' },
+	});
+
+	// wait for AssetsTitle to appear and be accessible
+	for (let i = 0; i < 60; i++) {
+		try {
+			await element(by.id('AssetsTitle')).tap();
+			await sleep(1000);
+			break;
+		} catch (e) {
+			continue;
+		}
+	}
+};

--- a/e2e/numberpad.e2e.js
+++ b/e2e/numberpad.e2e.js
@@ -1,0 +1,61 @@
+import {
+	sleep,
+	checkComplete,
+	markComplete,
+	completeOnboarding,
+	launchAndWait,
+} from './helpers';
+
+describe('NumberPad', () => {
+	beforeAll(async () => {
+		await completeOnboarding();
+	});
+
+	beforeEach(async () => {
+		await launchAndWait();
+	});
+
+	it('Can enter amounts and switch units', async () => {
+		if (checkComplete('numberpad-1')) {
+			return;
+		}
+
+		await element(by.id('Receive')).tap();
+		await element(by.id('UnderstoodButton')).tap();
+		await sleep(1000); // animation
+		await element(by.id('SpecifyInvoiceButton')).tap();
+		await element(by.id('ReceiveAmountToggle')).tap();
+
+		// Unit set to sats
+		await element(by.id('N1').withAncestor(by.id('ReceiveNumberPad'))).tap();
+		await element(by.id('N2').withAncestor(by.id('ReceiveNumberPad'))).tap();
+		await element(by.id('N3').withAncestor(by.id('ReceiveNumberPad'))).tap();
+		await expect(element(by.text('123'))).toBeVisible();
+
+		await element(by.id('N000').withAncestor(by.id('ReceiveNumberPad'))).tap();
+		await expect(element(by.text('123 000'))).toBeVisible();
+
+		await element(
+			by.id('NRemove').withAncestor(by.id('ReceiveNumberPad')),
+		).tap();
+		await expect(element(by.text('12 300'))).toBeVisible();
+
+		// Switch to BTC
+		await element(by.id('ReceiveNumberPadSwitch')).multiTap(2);
+		await expect(element(by.text('0.00012300'))).toBeVisible();
+		await element(
+			by.id('NRemove').withAncestor(by.id('ReceiveNumberPad')),
+		).multiTap(3);
+		await element(by.id('N4').withAncestor(by.id('ReceiveNumberPad'))).tap();
+		await element(
+			by.id('NDecimal').withAncestor(by.id('ReceiveNumberPad')),
+		).tap();
+		await element(by.id('N2').withAncestor(by.id('ReceiveNumberPad'))).tap();
+		await element(by.id('N0').withAncestor(by.id('ReceiveNumberPad'))).tap();
+		await element(by.id('N6').withAncestor(by.id('ReceiveNumberPad'))).tap();
+		await element(by.id('N9').withAncestor(by.id('ReceiveNumberPad'))).tap();
+		await expect(element(by.text('4.20690000'))).toBeVisible();
+
+		markComplete('numberpad-1');
+	});
+});

--- a/e2e/settings.e2e.js
+++ b/e2e/settings.e2e.js
@@ -1,55 +1,20 @@
-import { sleep, checkComplete, markComplete } from './helpers';
+import {
+	sleep,
+	checkComplete,
+	markComplete,
+	launchAndWait,
+	completeOnboarding,
+} from './helpers';
 
 const __DEV__ = process.env.DEBUG === 'true';
 
 describe('Settings', () => {
 	beforeAll(async () => {
-		await device.launchApp();
-
-		// TOS and PP
-		await waitFor(element(by.id('Check1'))).toBeVisible();
-
-		await element(by.id('Check1')).tap();
-		await element(by.id('Check2')).tap();
-		await element(by.id('Continue')).tap();
-
-		await waitFor(element(by.id('SkipIntro'))).toBeVisible();
-		await element(by.id('SkipIntro')).tap();
-		await element(by.id('NewWallet')).tap();
-
-		// wait for wallet to be created
-		await waitFor(element(by.id('ToGetStartedClose'))).toBeVisible();
-		await sleep(1000); // take app some time to load
-
-		// repeat 60 times before fail
-		for (let i = 0; i < 60; i++) {
-			await sleep(1000);
-			try {
-				await element(by.id('ToGetStartedClose')).tap();
-				await sleep(3000); // wait for redux-persist to save state
-				return;
-			} catch (e) {}
-		}
-
-		throw new Error('Tapping "ToGetStartedClose" timeout');
+		await completeOnboarding();
 	});
 
 	beforeEach(async () => {
-		await sleep(1000);
-		await device.launchApp({
-			newInstance: true,
-			permissions: { faceid: 'YES' },
-		});
-		// wait for AssetsTitle to appear and be accessible
-		for (let i = 0; i < 60; i++) {
-			try {
-				await element(by.id('AssetsTitle')).tap();
-				await sleep(1000);
-				break;
-			} catch (e) {
-				continue;
-			}
-		}
+		await launchAndWait();
 	});
 
 	describe('General', () => {

--- a/src/components/AmountToggle.tsx
+++ b/src/components/AmountToggle.tsx
@@ -27,8 +27,8 @@ const AmountToggle = ({
 	disable?: boolean;
 	children?: ReactElement;
 	style?: StyleProp<ViewStyle>;
-	onPress?: () => void;
 	testID?: string;
+	onPress?: () => void;
 }): ReactElement => {
 	const unitPreference = useSelector(unitPreferenceSelector);
 

--- a/src/components/NumberPad.tsx
+++ b/src/components/NumberPad.tsx
@@ -120,7 +120,8 @@ const NumberPad = ({
 						onPress={(): void => handlePress('000')}
 						activeOpacity={ACTIVE_OPACITY}
 						style={styles.buttonContainer}
-						color="transparent">
+						color="transparent"
+						testID="N000">
 						<Text style={styles.button}>000</Text>
 					</TouchableOpacity>
 				)}
@@ -129,7 +130,8 @@ const NumberPad = ({
 						onPress={(): void => handlePress('.')}
 						activeOpacity={ACTIVE_OPACITY}
 						style={styles.buttonContainer}
-						color="transparent">
+						color="transparent"
+						testID="NDecimal">
 						<Text style={styles.button}>.</Text>
 					</TouchableOpacity>
 				)}
@@ -142,7 +144,8 @@ const NumberPad = ({
 					onPress={handleRemove}
 					activeOpacity={ACTIVE_OPACITY}
 					style={styles.buttonContainer}
-					color="transparent">
+					color="transparent"
+					testID="NRemove">
 					<Ionicons name={'ios-backspace-outline'} size={31} />
 				</TouchableOpacity>
 			</View>

--- a/src/screens/Wallets/Receive/ReceiveDetails.tsx
+++ b/src/screens/Wallets/Receive/ReceiveDetails.tsx
@@ -101,6 +101,7 @@ const ReceiveDetails = ({
 					sats={invoice.amount}
 					reverse={true}
 					space={16}
+					testID="ReceiveAmountToggle"
 					onPress={(): void => setShowNumberPad(true)}
 				/>
 
@@ -185,13 +186,14 @@ const ReceiveDetails = ({
 				)}
 
 				{showNumberPad && (
-					<View style={styles.numberPad}>
+					<View style={styles.numberPad} testID="ReceiveNumberPad">
 						<View style={styles.actions}>
 							<View style={styles.actionButtons}>
 								<View style={styles.actionButtonContainer}>
 									<TouchableOpacity
 										style={styles.actionButton}
 										color="white08"
+										testID="ReceiveNumberPadSwitch"
 										onPress={onChangeUnit}>
 										<SwitchIcon color="brand" width={16.44} height={13.22} />
 										<Text02B


### PR DESCRIPTION
### Changes
- add rudimentary e2e tests for NumberPad (will be refactored/fixed soon)
- pull out `completeOnboarding` and `launchAndWait` helpers