### PR TITLE
fix(lightning): Fix Lingering Claimable/Pending Balance

### DIFF
--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -438,10 +438,8 @@ export const refreshLdk = async ({
 		if (syncRes.isErr()) {
 			return err(syncRes.error.message);
 		}
-		await Promise.all([
-			updateLightningChannels({ selectedWallet, selectedNetwork }),
-			updateClaimableBalance({ selectedNetwork, selectedWallet }),
-		]);
+		await updateLightningChannels({ selectedWallet, selectedNetwork });
+		await updateClaimableBalance({ selectedNetwork, selectedWallet });
 		return ok('');
 	} catch (e) {
 		console.log(e);


### PR DESCRIPTION
This PR:
- Ensures `updateClaimableBalance` awaits `updateLightningChannels` in `refreshLdk`.
    - This prevents the pending balance value from lingering on the main/home screen when receiving lightning payments.