### PR TITLE
fix(profile): avoid 'undefined is not a function' by never closing hyperdrives

### DIFF
--- a/src/screens/Settings/SlashtagsSettings/index.tsx
+++ b/src/screens/Settings/SlashtagsSettings/index.tsx
@@ -58,8 +58,6 @@ const SlashtagsSettings = (): ReactElement => {
 				if (!unmounted) {
 					setProfileError(error.message);
 				}
-			} finally {
-				drive.close();
 			}
 		})();
 

--- a/src/screens/Widgets/WidgetFeedEdit.tsx
+++ b/src/screens/Widgets/WidgetFeedEdit.tsx
@@ -142,7 +142,6 @@ export const WidgetFeedEdit = ({
 
 		return function cleanup() {
 			unmounted = true;
-			drive.close();
 		};
 	}, [sdk, url, savedWidget, t]);
 

--- a/src/utils/slashtags/index.ts
+++ b/src/utils/slashtags/index.ts
@@ -75,7 +75,6 @@ export const saveContact = async (
 			message: error.message,
 		}),
 	);
-	drive.close();
 };
 
 export const saveProfile = async (
@@ -95,8 +94,6 @@ export const saveProfile = async (
 	);
 
 	cacheProfile(slashtag.url, drive.files.feed.fork, drive.version, profile);
-
-	drive.close();
 };
 
 /**
@@ -119,8 +116,6 @@ export const deleteContact = async (
 			message: error.message,
 		});
 	});
-
-	drive.close();
 };
 
 /**
@@ -148,7 +143,6 @@ export const saveBulkContacts = async (slashtag: Slashtag): Promise<void> => {
 	);
 	await batch.flush();
 	console.debug('Done saving bulk contacts');
-	drive.close();
 };
 
 export const onSDKError = (error: Error): void => {
@@ -290,7 +284,6 @@ export const updateSlashPayConfig = debounce(
 		}
 
 		if (!needToUpdate) {
-			drive.close();
 			return;
 		}
 
@@ -302,8 +295,6 @@ export const updateSlashPayConfig = debounce(
 				console.debug('Updated slashpay.json:', newPayConfig);
 			})
 			.catch(noop);
-
-		drive.close();
 	},
 	5000,
 );
@@ -343,7 +334,6 @@ export const seedDrives = async (slashtag: Slashtag): Promise<boolean> => {
 				},
 			);
 
-			drive.close();
 			return [firstResponse.status, secondResponse.status].every(
 				(s) => s === 200,
 			);
@@ -373,7 +363,6 @@ export const getSlashPayConfig = async (
 	const payConfig =
 		(await drive.get('/slashpay.json').then(decodeJSON).catch(noop)) || [];
 
-	drive.close();
 	return payConfig;
 };
 


### PR DESCRIPTION
# Description

`undefined is not a function` is an old error while saving profiles, while I can't figure out what is it, I know it happens in `Hyperdrive` module, and caused when a drive is closed (as a part of cleaning up `useProfile` hook).

Not closing any drives in any hook, avoids all of these issues hidden in Hyper* modules.

The tradeoff is that number of opened cores will keep increasing in memory.
An update for the SDK will deduplicate the core sessions (will publish it as soon as it is reviewed and merged), but at least, all the drives opened while checking a profile or a feed, will stay in memory for the lifetime of the session. But that is ok I think.

---

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## QA Notes

- [x] Open the app, try to edit profile and save it a couple of times, you should not get `undefined is not a function` error ever.

## Bitkit Version
1.0.0-beta.24
