### PR TITLE
fix: Updated ldk to prevent scorer read crash

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -320,7 +320,7 @@ PODS:
     - React-Core
   - react-native-image-picker (4.10.0):
     - React-Core
-  - react-native-ldk (0.0.83):
+  - react-native-ldk (0.0.86):
     - React
   - react-native-libsodium (0.0.1):
     - React-Core
@@ -813,7 +813,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: f68191637788994baed5f57d12994aa32cf8bf88
   react-native-flipper: 7eeb9b59b667dd0619372c7349cf7c78032d1de2
   react-native-image-picker: 4bc9ed38c8be255b515d8c88babbaf74973f91a8
-  react-native-ldk: f9cbe8be61991389bca0ceb582f322745606ea75
+  react-native-ldk: 3818f8bca008a642c4fe59156f804ddc52eaa483
   react-native-libsodium: f4eba037c4ddf73f86b08075452cacb957256147
   react-native-mmkv: 1265a348a4711097ba29c8bcefd5971f48220f2b
   react-native-netinfo: 1a6035d3b9780221d407c277ebfb5722ace00658

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@reduxjs/toolkit": "^1.9.1",
     "@shopify/react-native-skia": "0.1.141",
     "@synonymdev/blocktank-client": "0.0.50",
-    "@synonymdev/react-native-ldk": "^0.0.83",
+    "@synonymdev/react-native-ldk": "0.0.86",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,10 +2120,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@^0.0.83":
-  version "0.0.83"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.83.tgz#4f64d6a968121b6396c78cfc0ca9bf52a3b6bec3"
-  integrity sha512-eJXWKxw0fO0Ih1CKfJQZte2EUc5LY4azyw8A2+fa2mONIqXtL/ULZKJwvsfeMHZ20f44mHVkzwONU/iJzeBAkA==
+"@synonymdev/react-native-ldk@0.0.86":
+  version "0.0.86"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.86.tgz#91b6aa9623469b149f3b7a7200e7756cada91bfe"
+  integrity sha512-wbWP+2le1l5Gwdvypxx36yjm58ok02inrErQr1/a/hnCeqGe2TTobdtmudEeAMUCF/23TypCloeP/3IkE/tvJw==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 


### PR DESCRIPTION
# Description

Updated react-native-ldk. New version removes caching and reading of probabilistic scorer causing crash loops for some users.

---

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tests
- [ ] Detox test
- [ ] Unit test
- [x] No test

## Screen shot / Video
Insert Relevant screenshot / Video share

## QA Notes

Users unable to open Bitkit due to crash should be able to update and continue using Bitkit again.

## Bitkit Version
