### PR TITLE
fix: add polyfill for Promise.allSettled

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -62,3 +62,23 @@ if (!Symbol.asyncIterator) {
 if (!Symbol.iterator) {
 	Symbol.iterator = '@@iterator';
 }
+
+if (!Promise.allSettled) {
+	// RN only supports Promise.allSettled after v0.70.6
+	// https://stackoverflow.com/a/70114114/1231070
+	// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+	Promise.allSettled = (promises) =>
+		Promise.all(
+			promises.map((pr) =>
+				pr
+					.then((value) => ({
+						status: 'fulfilled',
+						value,
+					}))
+					.catch((reason) => ({
+						status: 'rejected',
+						reason,
+					})),
+			),
+		);
+}


### PR DESCRIPTION
# Description

Currently if you try to save Slashtags profile app shows `undefined is not a function` error. This is because our React Native version doesn't support `Promise.allSettled` which is used inside hypercore library. So I'm adding it.

---

## Type of change

Bug fix

## Tests

No test

## QA Notes

Open app, edit the Profile name and try to save it, the should be no errors

## Bitkit Version
