### PR TITLE
chore(lightning): Upgrade react-native-ldk to 0.0.88

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -320,7 +320,7 @@ PODS:
     - React-Core
   - react-native-image-picker (4.10.0):
     - React-Core
-  - react-native-ldk (0.0.87):
+  - react-native-ldk (0.0.88):
     - React
   - react-native-libsodium (0.0.1):
     - React-Core
@@ -813,7 +813,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: f68191637788994baed5f57d12994aa32cf8bf88
   react-native-flipper: 7eeb9b59b667dd0619372c7349cf7c78032d1de2
   react-native-image-picker: 4bc9ed38c8be255b515d8c88babbaf74973f91a8
-  react-native-ldk: b9b34c15067689e5aa7aef92ce278454b000ac39
+  react-native-ldk: e9021dac38a9b02194df3b409f4baed69f114b3c
   react-native-libsodium: f4eba037c4ddf73f86b08075452cacb957256147
   react-native-mmkv: 1265a348a4711097ba29c8bcefd5971f48220f2b
   react-native-netinfo: 1a6035d3b9780221d407c277ebfb5722ace00658
@@ -860,4 +860,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: a0cdae2b34e1f0caa9c485e11d315a325acc1c91
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@reduxjs/toolkit": "^1.9.1",
     "@shopify/react-native-skia": "0.1.141",
     "@synonymdev/blocktank-client": "0.0.50",
-    "@synonymdev/react-native-ldk": "0.0.87",
+    "@synonymdev/react-native-ldk": "0.0.88",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -1098,7 +1098,7 @@ export const payLightningInvoice = async (
 		const payResponse = await lm.payWithTimeout({
 			paymentRequest: invoice,
 			amountSats: sats ?? 0,
-			timeout: 30000,
+			timeout: 60000,
 		});
 		if (payResponse.isErr()) {
 			return err(payResponse.error.message);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2120,10 +2120,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@0.0.87":
-  version "0.0.87"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.87.tgz#3b16441b5e00d0fe0665a24c22a4c39baceac1fe"
-  integrity sha512-F7TK6qLpA6I5lF49QGchA5jNGKiyGhIto/tgVgWjeum5TcYAD8QCpmjNiTP/ETNWPYIIkQs+b4IkzZ75PzGIpQ==
+"@synonymdev/react-native-ldk@0.0.88":
+  version "0.0.88"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.88.tgz#c041e5b9cddcdd2ae330d14097a55f5c0faa807d"
+  integrity sha512-j0Un/5Cl9xnAmCVYO//BxGwNK0+tpUHgqstrLq3wM8hm/mZmCIWMYTtvY9J1OhIYBLP1ASfFGydyM8Rq9BO5bA==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 


### PR DESCRIPTION
# Description

- Upgrades `react-native-ldk` to `0.0.88`
- Updates `payWithTimeout` `timeout` to `60000`.
