### PR TITLE
fix: remove lnurlpay from Payment Preference

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -37,7 +37,7 @@ const persistConfig = {
 	key: 'root',
 	storage: mmkvStorage,
 	// increase version after store shape changes
-	version: 9,
+	version: 10,
 	stateReconciler: autoMergeLevel2,
 	blacklist: ['ui'],
 	migrate: createMigrate(migrations, { debug: __ENABLE_MIGRATION_DEBUG__ }),

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -85,6 +85,20 @@ const migrations = {
 			checks: defaultChecksShape,
 		};
 	},
+	10: (state): PersistedState => {
+		// remove lnurlpay from receivePreference
+		const receivePreference = state.settings.receivePreference.filter(
+			(i) => i.key !== 'lnurlpay',
+		);
+
+		return {
+			...state,
+			settings: {
+				...state.settings,
+				receivePreference,
+			},
+		};
+	},
 };
 
 export default migrations;

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -77,10 +77,6 @@ const defaultReceivePreference = [
 		key: 'onchain',
 		title: 'On-chain (Bitkit)',
 	},
-	{
-		key: 'lnurlpay',
-		title: 'LNURL-pay',
-	},
 ];
 
 export const defaultSettingsShape: Readonly<ISettings> = {


### PR DESCRIPTION
# Description

Remove lnurlpay from Payment Preference, because it is not used and only brings confusion.

## Type of change

Bug fix

## Tests
No test

## Screen shot / Video

<img src="https://user-images.githubusercontent.com/155891/235094000-ac7d9b8c-cd48-41f6-b48d-de0df780b73b.png" width="300">

## QA Notes

Make sure that LNURL-Pay is disapeared from Payment Preference menu

## Bitkit Version
