### PR TITLE
feat(lightning): recover stuck outputs button

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -348,7 +348,7 @@ PODS:
     - React-Core
   - react-native-image-picker (5.3.1):
     - React-Core
-  - react-native-ldk (0.0.90):
+  - react-native-ldk (0.0.91):
     - React
   - react-native-libsodium (0.7.0):
     - React-Core
@@ -835,7 +835,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: 495c444c0c773c6e83a5d91165890ecb1c0a399a
   react-native-flipper: fe6db6651d338f516899ebe8dad573d0f2d7aa76
   react-native-image-picker: ec9b713e248760bfa0f879f0715391de4651a7cb
-  react-native-ldk: 241f399896586366742aa7e5e3cc779b72645bc8
+  react-native-ldk: 9b145611f4fa892c873626d55490bfb71ae5aeb9
   react-native-libsodium: 2834a805c906aef4b7609019bcc87e7d9eb86b23
   react-native-mmkv: 7da5e18e55c04a9af9a7e0ab9792a1e8d33765a1
   react-native-netinfo: 22c082970cbd99071a4e5aa7a612ac20d66b08f0

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -348,7 +348,7 @@ PODS:
     - React-Core
   - react-native-image-picker (5.3.1):
     - React-Core
-  - react-native-ldk (0.0.89):
+  - react-native-ldk (0.0.90):
     - React
   - react-native-libsodium (0.7.0):
     - React-Core
@@ -835,7 +835,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: 495c444c0c773c6e83a5d91165890ecb1c0a399a
   react-native-flipper: fe6db6651d338f516899ebe8dad573d0f2d7aa76
   react-native-image-picker: ec9b713e248760bfa0f879f0715391de4651a7cb
-  react-native-ldk: 58ed077970033a7017a290b4a5ec6189c70ebb08
+  react-native-ldk: 241f399896586366742aa7e5e3cc779b72645bc8
   react-native-libsodium: 2834a805c906aef4b7609019bcc87e7d9eb86b23
   react-native-mmkv: 7da5e18e55c04a9af9a7e0ab9792a1e8d33765a1
   react-native-netinfo: 22c082970cbd99071a4e5aa7a612ac20d66b08f0

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@reduxjs/toolkit": "^1.9.3",
     "@shopify/react-native-skia": "0.1.182",
     "@synonymdev/blocktank-client": "0.0.50",
-    "@synonymdev/react-native-ldk": "^0.0.89",
+    "@synonymdev/react-native-ldk": "^0.0.90",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@reduxjs/toolkit": "^1.9.3",
     "@shopify/react-native-skia": "0.1.182",
     "@synonymdev/blocktank-client": "0.0.50",
-    "@synonymdev/react-native-ldk": "^0.0.90",
+    "@synonymdev/react-native-ldk": "^0.0.91",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",

--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -39,6 +39,7 @@ import {
 	getNodeId,
 	payLightningInvoice,
 	rebroadcastAllKnownTransactions,
+	recoverOutputs,
 	refreshLdk,
 	setupLdk,
 } from '../../../utils/lightning';
@@ -51,6 +52,7 @@ import {
 } from '../../../hooks/lightning';
 import {
 	showErrorNotification,
+	showInfoNotification,
 	showSuccessNotification,
 } from '../../../utils/notifications';
 import {
@@ -209,6 +211,8 @@ const Channels = ({
 	const [refreshingLdk, setRefreshingLdk] = useState(false);
 	const [restartingLdk, setRestartingLdk] = useState(false);
 	const [rebroadcastingLdk, setRebroadcastingLdk] = useState(false);
+	const [spendingStuckOutputs, setSpendingStuckOutputs] = useState(false);
+
 	const [peer, setPeer] = useState('');
 
 	const colors = useColors();
@@ -505,6 +509,26 @@ const Channels = ({
 								setRebroadcastingLdk(false);
 							}}
 							testID="RebroadcastLDKTXS"
+						/>
+						<Button
+							style={styles.devButton}
+							text="Spend stuck outputs"
+							loading={spendingStuckOutputs}
+							onPress={async (): Promise<void> => {
+								setSpendingStuckOutputs(true);
+								const res = await recoverOutputs();
+								if (res.isOk()) {
+									showInfoNotification({
+										message: res.value,
+									});
+								} else {
+									showErrorNotification({
+										title: 'No stuck outputs recovered',
+										message: res.error.message,
+									});
+								}
+								setSpendingStuckOutputs(false);
+							}}
 						/>
 						<Button
 							style={styles.devButton}

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -1209,6 +1209,10 @@ export const rebroadcastAllKnownTransactions = async (): Promise<any> => {
 	return await lm.rebroadcastAllKnownTransactions();
 };
 
+export const recoverOutputs = async (): Promise<Result<string>> => {
+	return await lm.recoverOutputs();
+};
+
 /**
  * Returns total reserve balance for all open lightning channels.
  * @param {TWalletName} [selectedWallet]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,10 +2408,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@^0.0.90":
-  version "0.0.90"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.90.tgz#04b1ec67ba6bceda8b04487af3f29f0fc2376849"
-  integrity sha512-3DpWRIm/WSlR64cQqyaFpY0DzkAYIcCH34a6NIo/jit13fONVbD7paXQTKJfZnmxkWCJHdCl52bIWQDlv+C1jg==
+"@synonymdev/react-native-ldk@^0.0.91":
+  version "0.0.91"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.91.tgz#ecd7a264fc9e743bf52ca56b0b9a10b206491b44"
+  integrity sha512-b4vYj4seK25ESXULkBDAc4y7vBCIT5u//KNQnidyYmb9FqW1Yop1K4fsHrYjw/J1kbwbrnK9NtEDK3VJuwlAbw==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,10 +2408,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@^0.0.89":
-  version "0.0.89"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.89.tgz#82956436011cc575e893422e12469a298bf214b2"
-  integrity sha512-AAfnVM3AEGkoJaSNcbtjLd3Xnfx/87Jj1owETB2fY77f2bw4rFFsgoQyge6OfsHst5xlpohCqVmTVzzcH6J0Sg==
+"@synonymdev/react-native-ldk@^0.0.90":
+  version "0.0.90"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.90.tgz#04b1ec67ba6bceda8b04487af3f29f0fc2376849"
+  integrity sha512-3DpWRIm/WSlR64cQqyaFpY0DzkAYIcCH34a6NIo/jit13fONVbD7paXQTKJfZnmxkWCJHdCl52bIWQDlv+C1jg==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 


### PR DESCRIPTION
# Description

- Updates react-native-ldk
- Adds a button in settings that attempts to recover stuck outputs

---

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Tests
- [ ] Detox test
- [ ] Unit test
- [x] No test

## Screen shot / Video
![simulator_screenshot_EB83CBC6-A8C0-4CD8-ADE2-CED1357E8575](https://user-images.githubusercontent.com/5300488/235877549-718a19b4-bbbc-4c1e-9db1-4286f708eb2e.png)
