### PR TITLE
feat(lightning): Set user agent for Blocktank requests

### DIFF
--- a/src/utils/blocktank/index.ts
+++ b/src/utils/blocktank/index.ts
@@ -34,6 +34,7 @@ export const unsettledStatuses = [0, 100, 200, 300, 350, 500];
  * @returns {void}
  */
 export const setupBlocktank = (selectedNetwork: TAvailableNetworks): void => {
+	bt.setHeaders({ 'User-Agent': 'Bitkit' });
 	if (selectedNetwork === EAvailableNetworks.bitcoinTestnet) {
 		return;
 	} else if (selectedNetwork === EAvailableNetworks.bitcoinRegtest) {


### PR DESCRIPTION
# Description

Sets `User-Agent: Bitkit` header for all Blocktank API requests

---

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
