### PR TITLE
fix(recovery): export LDK logs

### DIFF
--- a/src/screens/Recovery/Recovery.tsx
+++ b/src/screens/Recovery/Recovery.tsx
@@ -35,7 +35,7 @@ const Recovery = ({
 	}, []);
 
 	const onExportLogs = async (): Promise<void> => {
-		const result = await zipLogs();
+		const result = await zipLogs({ limit: 20, allAccounts: true });
 		if (result.isErr()) {
 			showErrorNotification({
 				title: t('lightning:error_logs'),

--- a/src/utils/lightning/logs.ts
+++ b/src/utils/lightning/logs.ts
@@ -6,39 +6,108 @@ import { err, ok, Result } from '@synonymdev/result';
 /**
  * Zips up the newest LDK logs and returns base64 of zip file
  * @param {number} limit
+ * @param {allAccounts} boolean
  */
-export const zipLogs = async (limit: number = 10): Promise<Result<string>> => {
-	const logFilePrefix = 'bitkit_ldk_logs';
+export const zipLogs = async ({
+	limit = 10,
+	allAccounts = false,
+}: {
+	limit?: number;
+	allAccounts?: boolean;
+} = {}): Promise<Result<string>> => {
 	const time = new Date().getTime();
-	const fileName = `${logFilePrefix}_${time}`;
-
-	const logsPath = `${RNFS.DocumentDirectoryPath}/ldk/${lm.account.name}/logs`;
-	const tempPath = `${logsPath}/share`;
-	const zipPath = `${tempPath}/${fileName}.zip`;
+	const logFilePrefix = 'bitkit_ldk_logs';
+	const ldkPath = `${RNFS.DocumentDirectoryPath}/ldk`;
+	const tempPath = `${RNFS.DocumentDirectoryPath}/bitkit_temp`;
+	const zipFileName = `${logFilePrefix}_${time}`;
+	const zipPath = `${tempPath}/${zipFileName}.zip`;
 
 	try {
-		const logs = await listLogs(logsPath, limit);
-
-		//Copy to dir to be zipped
+		// Create temporary folder
 		await rm(tempPath);
-		await mkdir(tempPath);
-		for (let index = 0; index < logs.length; index++) {
-			const logPath = logs[index];
-			let filename = logPath.substring(logPath.lastIndexOf('/') + 1);
-			await copyFile(logPath, `${tempPath}/${filename}`);
-		}
+		await mkdir(`${tempPath}/${zipFileName}`);
 
-		await zip(logs, zipPath);
-
-		//Cleanup duplicate logs after zips
-		listLogs(tempPath, limit).then((newFiles) => {
-			newFiles.forEach((f) => rm(f));
+		const accounts = await listLogs({
+			path: ldkPath,
+			limit,
+			accountName: allAccounts ? undefined : lm.account.name,
 		});
 
-		return ok(zipPath);
+		// Copy files to temporary folder to be zipped
+		for (const account of accounts) {
+			// Make a subfolder for each account
+			const accountFolder = `${tempPath}/${zipFileName}/${account.id}`;
+			await mkdir(accountFolder);
+
+			// Copy each log file to the account folder
+			for (const logPath of account.files) {
+				const fileName = logPath.substring(logPath.lastIndexOf('/') + 1);
+				await copyFile(logPath, `${accountFolder}/${fileName}`);
+			}
+		}
+
+		// Zip up files
+		const result = await zip(tempPath, zipPath);
+
+		return ok(result);
 	} catch (error) {
 		return err(error);
 	}
+};
+
+/**
+ * Lists .log files for all LDK accounts sorted by newest first
+ * @param {string} path
+ * @param {number} limit
+ * @param {string} [accountName]
+ */
+const listLogs = async ({
+	path,
+	limit,
+	accountName,
+}: {
+	path: string;
+	limit: number;
+	accountName?: string;
+}): Promise<{ id: string; files: string[] }[]> => {
+	const ldkPathItems = await RNFS.readDir(path);
+	const filter = accountName ?? 'account';
+	const accounts = ldkPathItems.filter((item) => item.path.endsWith(filter));
+
+	const promises = accounts.map(async (account) => {
+		const files = await listLogsForAccount(`${account.path}/logs`, limit);
+		return { id: account.name, files };
+	});
+
+	return Promise.all(promises);
+};
+
+/**
+ * Lists .log files for an LDK account sorted by newest first
+ * @param path
+ * @param limit
+ * @returns {Promise<string[]>}
+ */
+const listLogsForAccount = async (
+	path: string,
+	limit: number,
+): Promise<string[]> => {
+	let list = await RNFS.readDir(path);
+
+	// Filter for log files only
+	list = list.filter((f) => {
+		return f.isFile() && f.name.indexOf('.log') > -1 && f.size > 0;
+	});
+
+	// Newest first
+	list.sort((a, b) => {
+		return (
+			(b.mtime ?? new Date()).getTime() - (a.mtime ?? new Date()).getTime()
+		);
+	});
+
+	// Limit number of files
+	return list.slice(0, limit).map((f) => f.path);
 };
 
 /**
@@ -52,28 +121,4 @@ const rm = async (path: string): Promise<void> => {
 			await unlink(path);
 		}
 	} catch (e) {}
-};
-
-/**
- * Lists .log files in a given directory and returns newest files first
- * @param path
- * @param limit
- * @returns {Promise<string[]>}
- */
-const listLogs = async (path: string, limit: number): Promise<string[]> => {
-	let list = await RNFS.readDir(path);
-
-	//Filter for log files only
-	list = list.filter((f) => {
-		return f.isFile() && f.name.indexOf('.log') > -1 && f.size > 0;
-	});
-
-	//Newest first
-	list.sort((a, b) => {
-		return (
-			(b.mtime ?? new Date()).getTime() - (a.mtime ?? new Date()).getTime()
-		);
-	});
-
-	return list.slice(0, limit).map((f) => f.path);
 };


### PR DESCRIPTION
### Description

When booting the app into recovery LDK will not be started therefore there will be no account name set for LDK. This makes the `zipLogs` function export logs for all accounts in this case.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

Test the "Export Logs" functionality in recovery and in the settings