### PR TITLE
fix(wallet): Fix On-Chain Address Scanning

### DIFF
--- a/src/navigation/bottom-sheet/SendNavigation.tsx
+++ b/src/navigation/bottom-sheet/SendNavigation.tsx
@@ -97,7 +97,6 @@ const SendNavigation = (): ReactElement => {
 	const initialRouteName = screen ?? 'Recipient';
 
 	const onOpen = async (): Promise<void> => {
-		resetOnChainTransaction();
 		await setupOnChainTransaction();
 		setupFeeForOnChainTransaction();
 	};

--- a/src/screens/Wallets/Send/ReviewAndSend.tsx
+++ b/src/screens/Wallets/Send/ReviewAndSend.tsx
@@ -171,7 +171,7 @@ const ReviewAndSend = ({
 	const transactionTotal = amount + transaction.fee;
 	const selectedFeeId = transaction.selectedFeeId;
 	const satsPerByte = transaction.satsPerByte;
-	const address = transaction.outputs[outputIndex].address ?? '';
+	const address = transaction?.outputs[outputIndex]?.address ?? '';
 
 	useEffect(() => {
 		setupFeeForOnChainTransaction();

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -880,6 +880,17 @@ export const resetWalletStore = async (): Promise<Result<string>> => {
 	return ok('');
 };
 
+/**
+ * Sets up a transaction for a given wallet by gathering inputs, setting the next available change address as an output and sets up the baseline fee structure.
+ * This function will not override previously set transaction data. To do that you'll need to call resetOnChainTransaction.
+ * @param {TWalletName} [selectedWallet]
+ * @param {TAvailableNetworks} [selectedNetwork]
+ * @param {EAddressType} [addressType]
+ * @param {string[]} [inputTxHashes]
+ * @param {IUtxo[]} [utxos]
+ * @param {boolean} [rbf]
+ * @returns {Promise<Result<Partial<IBitcoinTransactionData>>>}
+ */
 export const setupOnChainTransaction = async ({
 	selectedWallet,
 	selectedNetwork,
@@ -1155,6 +1166,12 @@ export const updateSelectedFeeId = async ({
 	}
 };
 
+/**
+ * This completely resets the on-chain transaction data for the specified wallet and network.
+ * @param {TWalletName} [selectedWallet]
+ * @param {TAvailableNetworks} [selectedNetwork]
+ * @returns {Result<string>}
+ */
 export const resetOnChainTransaction = ({
 	selectedWallet,
 	selectedNetwork,


### PR DESCRIPTION
### Description

- Removes `resetOnChainTransaction` from `onOpen` in `SendNavigation.tsx`.
- Updates `address` variable in `ReviewAndSend.tsx`.
- Adds comments to `resetOnChainTransaction` & `setupOnChainTransaction` methods.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### QA Notes

1. Have some on-chain sats on a live device.
2. Scan a Bitcoin address on the device.
3. Select "Max" as the amount to send and select "Continue".
4. Ensure that the "TO" Bitcoin address previously scanned is listed and correct.
