### PR TITLE
fix(lightning): calculate blocktank limits

### DIFF
--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -80,7 +80,9 @@ const QuickSetup = ({
 
 	const diff = 0.01;
 	const btSpendingLimit = blocktankService.max_chan_spending;
-	const blocktankChannelLimit = btSpendingLimit / 2 - btSpendingLimit * diff;
+	const btSpendingLimitBalanced = Math.round(
+		btSpendingLimit / 2 - btSpendingLimit * diff,
+	);
 	const spendableBalance = Math.round(onchainBalance * SPENDING_LIMIT_RATIO);
 	const savingsAmount = onchainBalance - spendingAmount;
 	const savingsPercentage = Math.round((savingsAmount / onchainBalance) * 100);
@@ -89,17 +91,17 @@ const QuickSetup = ({
 	);
 
 	const spendingLimit = useMemo(() => {
-		return Math.min(spendableBalance, blocktankChannelLimit);
-	}, [spendableBalance, blocktankChannelLimit]);
+		return Math.min(spendableBalance, btSpendingLimitBalanced);
+	}, [spendableBalance, btSpendingLimitBalanced]);
 
-	const blocktankChannelLimitUsd = useMemo((): string => {
+	const btSpendingLimitBalancedUsd = useMemo((): string => {
 		const { fiatWhole } = getFiatDisplayValues({
-			satoshis: blocktankChannelLimit,
+			satoshis: btSpendingLimitBalanced,
 			currency: 'USD',
 		});
 
 		return fiatWhole;
-	}, [blocktankChannelLimit]);
+	}, [btSpendingLimitBalanced]);
 
 	// BTC -> satoshi -> fiat
 	const nextUnit = useMemo(() => {
@@ -222,7 +224,7 @@ const QuickSetup = ({
 							</View>
 						</AnimatedView>
 
-						{spendingAmount === Math.round(blocktankChannelLimit) && (
+						{spendingAmount === Math.round(btSpendingLimitBalanced) && (
 							<AnimatedView
 								style={styles.note}
 								entering={FadeIn}
@@ -230,7 +232,7 @@ const QuickSetup = ({
 								testID="QuickSetupBlocktankNote">
 								<Text02S color="gray1">
 									{t('note_blocktank_limit', {
-										usdValue: blocktankChannelLimitUsd,
+										usdValue: btSpendingLimitBalancedUsd,
 									})}
 								</Text02S>
 							</AnimatedView>

--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -30,7 +30,7 @@ import {
 	startChannelPurchase,
 } from '../../store/actions/blocktank';
 import { showErrorNotification } from '../../utils/notifications';
-import { convertToSats } from '../../utils/exchange-rate';
+import { convertToSats, getFiatDisplayValues } from '../../utils/exchange-rate';
 import { SPENDING_LIMIT_RATIO } from '../../utils/wallet/constants';
 import type { LightningScreenProps } from '../../navigation/types';
 import {
@@ -78,7 +78,9 @@ const QuickSetup = ({
 		return convertToSats(textFieldValue, unit);
 	}, [textFieldValue, unit]);
 
-	const blocktankSpendingLimit = blocktankService.max_chan_spending;
+	const diff = 0.01;
+	const btSpendingLimit = blocktankService.max_chan_spending;
+	const blocktankChannelLimit = btSpendingLimit / 2 - btSpendingLimit * diff;
 	const spendableBalance = Math.round(onchainBalance * SPENDING_LIMIT_RATIO);
 	const savingsAmount = onchainBalance - spendingAmount;
 	const savingsPercentage = Math.round((savingsAmount / onchainBalance) * 100);
@@ -87,8 +89,17 @@ const QuickSetup = ({
 	);
 
 	const spendingLimit = useMemo(() => {
-		return Math.min(spendableBalance, blocktankSpendingLimit);
-	}, [spendableBalance, blocktankSpendingLimit]);
+		return Math.min(spendableBalance, blocktankChannelLimit);
+	}, [spendableBalance, blocktankChannelLimit]);
+
+	const blocktankChannelLimitUsd = useMemo((): string => {
+		const { fiatWhole } = getFiatDisplayValues({
+			satoshis: blocktankChannelLimit,
+			currency: 'USD',
+		});
+
+		return fiatWhole;
+	}, [blocktankChannelLimit]);
 
 	// BTC -> satoshi -> fiat
 	const nextUnit = useMemo(() => {
@@ -135,7 +146,7 @@ const QuickSetup = ({
 
 		// Ensure local balance is bigger than remote balance
 		const localBalance = Math.max(
-			Math.round(spendingAmount * 1.1),
+			Math.round(spendingAmount + spendingAmount * diff),
 			blocktankService.min_channel_size,
 		);
 		const purchaseResponse = await startChannelPurchase({
@@ -211,13 +222,17 @@ const QuickSetup = ({
 							</View>
 						</AnimatedView>
 
-						{spendingAmount === Math.round(blocktankSpendingLimit) && (
+						{spendingAmount === Math.round(blocktankChannelLimit) && (
 							<AnimatedView
 								style={styles.note}
 								entering={FadeIn}
 								exiting={FadeOut}
 								testID="QuickSetupBlocktankNote">
-								<Text02S color="gray1">{t('note_blocktank_limit')}</Text02S>
+								<Text02S color="gray1">
+									{t('note_blocktank_limit', {
+										usdValue: blocktankChannelLimitUsd,
+									})}
+								</Text02S>
 							</AnimatedView>
 						)}
 

--- a/src/screens/Transfer/Setup.tsx
+++ b/src/screens/Transfer/Setup.tsx
@@ -74,7 +74,9 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 
 	const diff = 0.01;
 	const btSpendingLimit = blocktankService.max_chan_spending;
-	const blocktankChannelLimit = btSpendingLimit / 2 - btSpendingLimit * diff;
+	const btSpendingLimitBalanced = Math.round(
+		btSpendingLimit / 2 - btSpendingLimit * diff,
+	);
 	const totalBalance = onchainBalance + lightningBalance;
 	const spendableBalance = Math.round(totalBalance * SPENDING_LIMIT_RATIO);
 	const savingsAmount = totalBalance - spendingAmount;
@@ -84,18 +86,18 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 	const isButtonDisabled = spendingAmount === lightningBalance;
 
 	const spendingLimit = useMemo(() => {
-		const min = Math.min(spendableBalance, blocktankChannelLimit);
+		const min = Math.min(spendableBalance, btSpendingLimitBalanced);
 		return min < lightningBalance ? lightningBalance : min;
-	}, [spendableBalance, blocktankChannelLimit, lightningBalance]);
+	}, [spendableBalance, btSpendingLimitBalanced, lightningBalance]);
 
-	const blocktankChannelLimitUsd = useMemo((): string => {
+	const btSpendingLimitBalancedUsd = useMemo((): string => {
 		const { fiatWhole } = getFiatDisplayValues({
-			satoshis: blocktankChannelLimit,
+			satoshis: btSpendingLimitBalanced,
 			currency: 'USD',
 		});
 
 		return fiatWhole;
-	}, [blocktankChannelLimit]);
+	}, [btSpendingLimitBalanced]);
 
 	// set initial value
 	useEffect(() => {
@@ -243,14 +245,14 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 								</View>
 							</AnimatedView>
 
-							{spendingAmount === Math.round(blocktankChannelLimit) && (
+							{spendingAmount === Math.round(btSpendingLimitBalanced) && (
 								<AnimatedView
 									style={styles.note}
 									entering={FadeIn}
 									exiting={FadeOut}>
 									<Text02S color="gray1">
 										{t('note_blocktank_limit', {
-											usdValue: blocktankChannelLimitUsd,
+											usdValue: btSpendingLimitBalancedUsd,
 										})}
 									</Text02S>
 								</AnimatedView>

--- a/src/screens/Transfer/Setup.tsx
+++ b/src/screens/Transfer/Setup.tsx
@@ -28,7 +28,7 @@ import {
 } from '../../store/actions/blocktank';
 import { useSelector } from 'react-redux';
 import { SPENDING_LIMIT_RATIO } from '../../utils/wallet/constants';
-import { convertToSats } from '../../utils/exchange-rate';
+import { convertToSats, getFiatDisplayValues } from '../../utils/exchange-rate';
 import {
 	resetOnChainTransaction,
 	setupOnChainTransaction,
@@ -72,8 +72,10 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 		return convertToSats(textFieldValue, unit);
 	}, [textFieldValue, unit]);
 
+	const diff = 0.01;
+	const btSpendingLimit = blocktankService.max_chan_spending;
+	const blocktankChannelLimit = btSpendingLimit / 2 - btSpendingLimit * diff;
 	const totalBalance = onchainBalance + lightningBalance;
-	const blocktankSpendingLimit = blocktankService.max_chan_spending;
 	const spendableBalance = Math.round(totalBalance * SPENDING_LIMIT_RATIO);
 	const savingsAmount = totalBalance - spendingAmount;
 	const spendingPercentage = Math.round((spendingAmount / totalBalance) * 100);
@@ -82,9 +84,18 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 	const isButtonDisabled = spendingAmount === lightningBalance;
 
 	const spendingLimit = useMemo(() => {
-		const min = Math.min(spendableBalance, blocktankSpendingLimit);
+		const min = Math.min(spendableBalance, blocktankChannelLimit);
 		return min < lightningBalance ? lightningBalance : min;
-	}, [spendableBalance, blocktankSpendingLimit, lightningBalance]);
+	}, [spendableBalance, blocktankChannelLimit, lightningBalance]);
+
+	const blocktankChannelLimitUsd = useMemo((): string => {
+		const { fiatWhole } = getFiatDisplayValues({
+			satoshis: blocktankChannelLimit,
+			currency: 'USD',
+		});
+
+		return fiatWhole;
+	}, [blocktankChannelLimit]);
 
 	// set initial value
 	useEffect(() => {
@@ -144,10 +155,11 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 		// buy an additional channel from Blocktank with the difference
 		setLoading(true);
 		const remoteBalance = spendingAmount - lightningBalance;
-		const localBalance =
-			Math.round(remoteBalance * 1.1) > blocktankService.min_channel_size
-				? Math.round(remoteBalance * 1.1)
-				: blocktankService.min_channel_size;
+		// Ensure local balance is bigger than remote balance
+		const localBalance = Math.max(
+			Math.round(remoteBalance + remoteBalance * diff),
+			blocktankService.min_channel_size,
+		);
 
 		const purchaseResponse = await startChannelPurchase({
 			selectedNetwork,
@@ -231,12 +243,16 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 								</View>
 							</AnimatedView>
 
-							{spendingAmount === Math.round(blocktankSpendingLimit) && (
+							{spendingAmount === Math.round(blocktankChannelLimit) && (
 								<AnimatedView
 									style={styles.note}
 									entering={FadeIn}
 									exiting={FadeOut}>
-									<Text02S color="gray1">{t('note_blocktank_limit')}</Text02S>
+									<Text02S color="gray1">
+										{t('note_blocktank_limit', {
+											usdValue: blocktankChannelLimitUsd,
+										})}
+									</Text02S>
 								</AnimatedView>
 							)}
 

--- a/src/utils/i18n/locales/en/lightning.json
+++ b/src/utils/i18n/locales/en/lightning.json
@@ -16,7 +16,7 @@
 	"savings": "Savings",
 	"spending_label": "Spending balance",
 	"receiving_label": "Receiving capacity",
-	"note_blocktank_limit": "The amount you can transfer to your spending balance is currently limited to $999.",
+	"note_blocktank_limit": "The amount you can transfer to your spending balance is currently limited to ${{usdValue}}.",
 	"note_reserve_limit": "The amount you can transfer to your spending balance is limited to 80%. You need to keep funds in reserve to move this bitcoin back to savings.",
 	"quick_confirm_header": "Please\nConfirm.",
 	"quick_confirm_cost": "It costs <white>{{amount}}</white> to connect you to Lightning and set up your spending balance.",


### PR DESCRIPTION
### Description

This change helps the user avoid running into BT channel cap limits in the QuickSetup, CustomSetup & Transfer flows.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

![image](https://user-images.githubusercontent.com/8538369/236841916-d67ba94b-28e1-491c-8a87-44598502ed88.png)

### QA Notes

Try to buy a channel with max channel size in the various flows.