### PR TITLE
fix(wallet): Address Viewer Fix

### DIFF
--- a/src/screens/Settings/AddressViewer/index.tsx
+++ b/src/screens/Settings/AddressViewer/index.tsx
@@ -467,6 +467,9 @@ const AddressViewer = ({
 			_config: TAddressViewerConfig,
 			_allAddresses: TAddressViewerData,
 		): void => {
+			if (privateKey) {
+				setPrivateKey(undefined);
+			}
 			if (!_allAddresses) {
 				_allAddresses = allAddresses;
 			}
@@ -513,6 +516,9 @@ const AddressViewer = ({
 				return;
 			}
 			setLoadingNetwork(n);
+			if (privateKey) {
+				setPrivateKey(undefined);
+			}
 			resetUtxos();
 			const newConfig = {
 				...config,
@@ -543,7 +549,14 @@ const AddressViewer = ({
 			setLoadingNetwork(undefined);
 			handleScroll(maxIndex);
 		},
-		[config, handleScroll, resetUtxos, selectedWallet, updateSelectedAddress],
+		[
+			config,
+			handleScroll,
+			privateKey,
+			resetUtxos,
+			selectedWallet,
+			updateSelectedAddress,
+		],
 	);
 
 	/**
@@ -654,8 +667,11 @@ const AddressViewer = ({
 			const filtered = fuzzyRes.map((r) => r.obj);
 			const sorted = Object.values(filtered).sort((a, b) => a.index - b.index);
 			setFilterAddresses(sorted);
+			if (privateKey) {
+				setPrivateKey(undefined);
+			}
 		},
-		[searchableAddresses],
+		[privateKey, searchableAddresses],
 	);
 
 	/**
@@ -785,6 +801,7 @@ const AddressViewer = ({
 	 */
 	const onCheckBalance = useCallback(async (): Promise<void> => {
 		setIsCheckingBalances(true);
+		setPrivateKey(undefined);
 
 		// Ensure we switch networks if the user opted to do-so.
 		if (selectedNetwork !== config.selectedNetwork) {
@@ -1072,6 +1089,7 @@ const AddressViewer = ({
 								isSelected={isSelected}
 								backgroundColor={backgroundColor}
 								onItemRowPress={(): void => {
+									setPrivateKey(undefined);
 									setSelectedAddress(item);
 								}}
 								onCheckMarkPress={(): void => {


### PR DESCRIPTION
### Description
- The private key is now cleared/reset in the address viewer when toggling between addresses & networks.


### Linked Issues/Tasks
- This closes #1031 

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test

### QA Notes
1. Navigate to Settings->Advanced->Address Viewer
2. Select an address and tap "View Private Key"
    - Observe that the addresses private key appears.
4. Tap a new/different address from the list.
    - Observe that the private key disappears.
