### PR TITLE
chore: upgrade bip32 library

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -55,6 +55,15 @@ jobs:
       - name: Activate react-native-skia-stub
         run: patch -p1 < .github/workflows/react-native-skia-stub.patch
 
+      - name: Detox Framework Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/Library/Detox/ios
+          key: detox-framework-cache-${{ hashFiles('**/detox/package.json') }}
+
+      - name: Yarn Install
+        run: yarn --no-audit --prefer-offline || yarn --no-audit --prefer-offline
+
       - name: Cache Pods
         uses: actions/cache@v3
         id: podcache
@@ -62,8 +71,8 @@ jobs:
           path: ios/Pods
           key: pods-${{ hashFiles('**/Podfile.lock') }}
 
-      - name: Yarn Install
-        run: yarn --no-audit --prefer-offline
+      - name: Pod Install
+        run: pod install --project-directory=ios || pod install --project-directory=ios
 
       - name: Build
         run: yarn e2e:build:ios-release

--- a/__tests__/transactions.ts
+++ b/__tests__/transactions.ts
@@ -54,8 +54,7 @@ describe('On chain transactions', () => {
 		});
 
 		if (res.isErr()) {
-			expect(res.error.message).toEqual('');
-			return;
+			throw res.error;
 		}
 
 		expect(res.value.hex).toEqual(

--- a/__tests__/wallet.ts
+++ b/__tests__/wallet.ts
@@ -1,10 +1,15 @@
+import * as bip39 from 'bip39';
+
 // Fix 'getDispatch is not a function'
 import '../src/store/actions/ui';
-import { deriveMnemonicPhrases } from '../src/utils/wallet';
+import {
+	deriveMnemonicPhrases,
+	slashtagsPrimaryKey,
+} from '../src/utils/wallet';
 import { mnemonic } from './utils/dummy-wallet';
 
 describe('Wallet Methods', () => {
-	it('Derive multiple mnemonic phrases for lightning, tokens and slashtags via the on-chain phrase.', async () => {
+	it('Derive multiple mnemonic phrases for lightning and tokens via the on-chain phrase.', async () => {
 		const res = await deriveMnemonicPhrases(mnemonic);
 		if (res.isErr()) {
 			expect(res.error.message).toEqual('');
@@ -16,6 +21,14 @@ describe('Wallet Methods', () => {
 		);
 		expect(res.value.tokens).toEqual(
 			'inspire sick rule wild near rebuild pride tomato shell come drip reduce street steel warrior project radar sister day title spice execute evolve outside',
+		);
+	});
+
+	it('Derive slashtags primay key from the Seed', async () => {
+		const seed = await bip39.mnemonicToSeed(mnemonic);
+		const slashtags = await slashtagsPrimaryKey(seed);
+		expect(slashtags).toEqual(
+			'be6d74439798f3217043a38de8c4da5a7e2b73714ace0811163105731ff0a066',
 		);
 	});
 });

--- a/nodejs-assets/nodejs-project/bitcoin-actions.js
+++ b/nodejs-assets/nodejs-project/bitcoin-actions.js
@@ -1,12 +1,12 @@
-const networks = require("./networks");
-const bip39 = require("bip39");
+const bip39 = require('bip39');
 const ecc = require('./nobleSecp256k1Wrapper');
+const bitcoin = require('bitcoinjs-lib');
 const BIP32Factory = require('bip32').BIP32Factory;
+
+const { sha256 } = require('./utils');
+const networks = require('./networks');
+
 const bip32 = BIP32Factory(ecc);
-const bitcoin = require("bitcoinjs-lib");
-const {
-    sha256,
-} = require("./utils");
 
 class BitcoinActions {
     constructor() {

--- a/nodejs-assets/nodejs-project/package.json
+++ b/nodejs-assets/nodejs-project/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@noble/secp256k1": "^1.7.0",
-    "bip32": "git+ssh://git@github.com/synonymdev/bip32",
+    "bip32": "^3.1.0",
     "bip39": "^3.0.4",
     "bitcoinjs-lib": "^6.0.1",
     "create-hmac": "^1.1.7"

--- a/nodejs-assets/nodejs-project/yarn.lock
+++ b/nodejs-assets/nodejs-project/yarn.lock
@@ -29,9 +29,10 @@ bip174@^2.0.1:
   resolved "https://registry.yarnpkg.com/bip174/-/bip174-2.1.0.tgz#cd3402581feaa5116f0f00a0eaee87a5843a2d30"
   integrity sha512-lkc0XyiX9E9KiVAS1ZiOqK1xfiwvf4FXDDdkDq5crcDzOq+xGytY+14qCsqz7kCiy8rpN1CRNfacRhf9G3JNSA==
 
-"bip32@git+ssh://git@github.com/synonymdev/bip32":
+bip32@^3.1.0:
   version "3.1.0"
-  resolved "git+ssh://git@github.com/synonymdev/bip32#58f0dd7d253d70fa5ff442997464892c46874348"
+  resolved "https://registry.yarnpkg.com/bip32/-/bip32-3.1.0.tgz#ce90e020d0e6b41e891a0122ff053efabcce1ccc"
+  integrity sha512-eoeajYEzJ4d6yyVtby8C+XkCeKItiC4Mx56a0M9VaqTMC73SWOm4xVZG7SaR8e/yp4eSyky2XcBpH3DApPdu7Q==
   dependencies:
     bs58check "^2.1.1"
     create-hash "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "postinstall": "node postinstall.js"
   },
   "dependencies": {
+    "@bitcoinerlab/secp256k1": "^1.0.2",
     "@formatjs/intl-datetimeformat": "6.5.1",
     "@formatjs/intl-getcanonicallocales": "2.1.0",
     "@formatjs/intl-locale": "^3.1.1",
@@ -58,7 +59,7 @@
     "assert": "^2.0.0",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
     "bip21": "^2.0.3",
-    "bip32": "^2.0.6",
+    "bip32": "^3.1.0",
     "bip39": "^3.0.4",
     "bitcoin-address-validation": "^2.2.1",
     "bitcoin-units": "^0.3.0",

--- a/postinstall.js
+++ b/postinstall.js
@@ -7,27 +7,21 @@ const createDevEnvFile = 'cp .env.development.template .env.development';
 
 //Create development environment file if it doesn't exist
 fs.access(devEnvFile, fs.constants.F_OK, (err) => {
-	if (err) {
+	if (err || !process.env.CI) {
 		console.log(`File '${devEnvFile}' not found, running createDevEnv...`);
 		exec(createDevEnvFile);
 	}
 });
 
-const baseCommand = `
-cd nodejs-assets/nodejs-project &&
-yarn install &&
-cd ../../ &&
+let baseCommand = `
+yarn install --no-audit --prefer-offline --production=true --cwd nodejs-assets/nodejs-project &&
 rn-nodeify --install buffer,stream,assert,events,crypto,vm,process --hack`;
 
-function postInstallMac() {
-	exec(`${baseCommand} && react-native setup-ios-permissions && cd ios && pod install && cd ..`);
-}
-function postInstallLinWin() {
-	exec(baseCommand);
+if (os.type() === 'Darwin') {
+	baseCommand  += '&& react-native setup-ios-permissions';
+	if (!process.env.CI) {
+		baseCommand += '&& pod install --project-directory=ios';
+	}
 }
 
-if (os.type() === 'Darwin') {
-	postInstallMac();
-} else {
-	postInstallLinWin();
-}
+exec(baseCommand);

--- a/postinstall.js
+++ b/postinstall.js
@@ -7,7 +7,7 @@ const createDevEnvFile = 'cp .env.development.template .env.development';
 
 //Create development environment file if it doesn't exist
 fs.access(devEnvFile, fs.constants.F_OK, (err) => {
-	if (err || !process.env.CI) {
+	if (err && !process.env.CI) {
 		console.log(`File '${devEnvFile}' not found, running createDevEnv...`);
 		exec(createDevEnvFile);
 	}

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -3,7 +3,8 @@ import { getAddressInfo } from 'bitcoin-address-validation';
 import { constants } from '@synonymdev/slashtags-sdk';
 import * as bitcoin from 'bitcoinjs-lib';
 import * as bip39 from 'bip39';
-import * as bip32 from 'bip32';
+import { BIP32Factory } from 'bip32';
+import ecc from '@bitcoinerlab/secp256k1';
 import { err, ok, Result } from '@synonymdev/result';
 
 import { networks, TAvailableNetworks } from '../networks';
@@ -89,6 +90,8 @@ import { refreshOrdersList } from '../../store/actions/blocktank';
 import { IDefaultLightningShape } from '../../store/types/lightning';
 import { objectKeys } from '../objectKeys';
 import { IDisplayValues } from '../displayValues/types';
+
+const BIP32 = BIP32Factory(ecc);
 
 export const refreshWallet = async ({
 	onchain = true,
@@ -364,7 +367,7 @@ export const getSlashtagsPrimaryKey = async (
 
 export const slashtagsPrimaryKey = async (seed: Buffer): Promise<string> => {
 	const network = networks.bitcoin;
-	const root = bip32.fromSeed(seed, network);
+	const root = BIP32.fromSeed(seed, network);
 
 	const path = constants.PRIMARY_KEY_DERIVATION_PATH;
 	const keyPair = root.derivePath(path);

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -1,6 +1,6 @@
 import * as bip21 from 'bip21';
-import * as bip32 from 'bip32';
-import { BIP32Interface } from 'bip32';
+import ecc from '@bitcoinerlab/secp256k1';
+import { BIP32Factory, BIP32Interface } from 'bip32';
 import * as bip39 from 'bip39';
 import * as bitcoin from 'bitcoinjs-lib';
 import { Psbt } from 'bitcoinjs-lib';
@@ -66,6 +66,8 @@ import { EFeeId, IOnchainFees } from '../../store/types/fees';
 import { defaultFeesShape } from '../../store/shapes/fees';
 import { TRANSACTION_DEFAULTS } from './constants';
 import i18n from '../i18n';
+
+const BIP32 = BIP32Factory(ecc);
 
 /*
  * Attempts to parse any given string as an on-chain payment request.
@@ -416,7 +418,7 @@ const getBip32Interface = async (
 
 	const mnemonic = getMnemonicPhraseResult.value;
 	const seed = await bip39.mnemonicToSeed(mnemonic, bip39Passphrase);
-	const root = bip32.fromSeed(seed, network);
+	const root = BIP32.fromSeed(seed, network);
 
 	return ok(root);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,6 +1074,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@bitcoinerlab/secp256k1@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@bitcoinerlab/secp256k1/-/secp256k1-1.0.2.tgz#39dbbb9132c98026adaa08dbdc22e1b952facc89"
+  integrity sha512-zXhJNdnd9pkmBx3nJc1SjdNco49Fi1EPlj6d4JN5M4YjlFlVZyoD27hu6IWJQOaWwwagd6tsoKIQQEf+t+SvWw==
+  dependencies:
+    "@noble/hashes" "^1.1.5"
+    "@noble/secp256k1" "^1.7.1"
+
 "@commitlint/cli@^17.4.4":
   version "17.6.1"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-17.6.1.tgz#571a1272a656cd316f4b601cbb0fcb2ef50bfc7a"
@@ -1888,10 +1896,15 @@
   dependencies:
     eslint-scope "5.1.1"
 
-"@noble/hashes@^1.2.0":
+"@noble/hashes@^1.1.5", "@noble/hashes@^1.2.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
   integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
+
+"@noble/secp256k1@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
+  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -3640,6 +3653,18 @@ bip32@^2.0.6:
     create-hash "^1.2.0"
     create-hmac "^1.1.7"
     tiny-secp256k1 "^1.1.3"
+    typeforce "^1.11.5"
+    wif "^2.0.6"
+
+bip32@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/bip32/-/bip32-3.1.0.tgz#ce90e020d0e6b41e891a0122ff053efabcce1ccc"
+  integrity sha512-eoeajYEzJ4d6yyVtby8C+XkCeKItiC4Mx56a0M9VaqTMC73SWOm4xVZG7SaR8e/yp4eSyky2XcBpH3DApPdu7Q==
+  dependencies:
+    bs58check "^2.1.1"
+    create-hash "^1.2.0"
+    create-hmac "^1.1.7"
+    ripemd160 "^2.0.2"
     typeforce "^1.11.5"
     wif "^2.0.6"
 


### PR DESCRIPTION
### Description

- upgrade bip32 lib in root project
- use nice `@bitcoinerlab/secp256k1` replacement for tiny-secp
- do not run pod install on CI. This helps to write better caching for e2e tests
- unit test for slashtags key generation

Unfortinatly I wasn't able to use `@bitcoinerlab/secp256k1` for mobile-nodejs project, because it depends on `node:crypto`

### Linked Issues/Tasks


### Type of change

Bug fix

### Tests

Unit test

### Screenshot / Video


### QA Notes

Make sure slashtags still working fine 
