### PR TITLE
test: buildcache

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -15,6 +15,9 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Setup Buildcache
+        uses: mikehardy/buildcache-action@v2
+
       - name: Setup Docker
         uses: douglascamata/setup-docker-macos-action@v1-alpha
 
@@ -55,6 +58,17 @@ jobs:
       - name: Activate react-native-skia-stub
         run: patch -p1 < .github/workflows/react-native-skia-stub.patch
 
+      - name: Detox Framework Cache
+        uses: actions/cache@v3
+        with:
+          path: ~/Library/Detox/ios
+          key: detox-framework-cache-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Yarn Install
+        run: yarn --no-audit --prefer-offline || yarn --no-audit --prefer-offline
+        env:
+          HUSKY: 0
+
       - name: Cache Pods
         uses: actions/cache@v3
         id: podcache
@@ -62,8 +76,8 @@ jobs:
           path: ios/Pods
           key: pods-${{ hashFiles('**/Podfile.lock') }}
 
-      - name: Yarn Install
-        run: yarn --no-audit --prefer-offline
+      - name: Pod Install
+        run: pod install --project-directory=ios || pod install --project-directory=ios
 
       - name: Build
         run: yarn e2e:build:ios-release

--- a/__tests__/transactions.ts
+++ b/__tests__/transactions.ts
@@ -54,8 +54,7 @@ describe('On chain transactions', () => {
 		});
 
 		if (res.isErr()) {
-			expect(res.error.message).toEqual('');
-			return;
+			throw res.error;
 		}
 
 		expect(res.value.hex).toEqual(

--- a/__tests__/wallet.ts
+++ b/__tests__/wallet.ts
@@ -1,10 +1,15 @@
+import * as bip39 from 'bip39';
+
 // Fix 'getDispatch is not a function'
 import '../src/store/actions/ui';
-import { deriveMnemonicPhrases } from '../src/utils/wallet';
+import {
+	deriveMnemonicPhrases,
+	slashtagsPrimaryKey,
+} from '../src/utils/wallet';
 import { mnemonic } from './utils/dummy-wallet';
 
 describe('Wallet Methods', () => {
-	it('Derive multiple mnemonic phrases for lightning, tokens and slashtags via the on-chain phrase.', async () => {
+	it('Derive multiple mnemonic phrases for lightning and tokens via the on-chain phrase.', async () => {
 		const res = await deriveMnemonicPhrases(mnemonic);
 		if (res.isErr()) {
 			expect(res.error.message).toEqual('');
@@ -16,6 +21,14 @@ describe('Wallet Methods', () => {
 		);
 		expect(res.value.tokens).toEqual(
 			'inspire sick rule wild near rebuild pride tomato shell come drip reduce street steel warrior project radar sister day title spice execute evolve outside',
+		);
+	});
+
+	it('Derive slashtags primay key from the Seed', async () => {
+		const seed = await bip39.mnemonicToSeed(mnemonic);
+		const slashtags = await slashtagsPrimaryKey(seed);
+		expect(slashtags).toEqual(
+			'be6d74439798f3217043a38de8c4da5a7e2b73714ace0811163105731ff0a066',
 		);
 	});
 });

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -56,5 +56,16 @@ target 'bitkit' do
       :mac_catalyst_enabled => false
     )
     __apply_Xcode_12_5_M1_post_install_workaround(installer)
+
+    # buildcache begin
+    installer.pods_project.targets.each do |target|
+      target.build_configurations.each do |config|
+        config.build_settings["CC"] = "clang"
+        config.build_settings["LD"] = "clang"
+        config.build_settings["CXX"] = "clang++"
+        config.build_settings["LDPLUSPLUS"] = "clang++"
+      end
+    end
+    # buildcache end
   end
 end

--- a/postinstall.js
+++ b/postinstall.js
@@ -7,27 +7,21 @@ const createDevEnvFile = 'cp .env.development.template .env.development';
 
 //Create development environment file if it doesn't exist
 fs.access(devEnvFile, fs.constants.F_OK, (err) => {
-	if (err) {
+	if (err && !process.env.CI) {
 		console.log(`File '${devEnvFile}' not found, running createDevEnv...`);
 		exec(createDevEnvFile);
 	}
 });
 
-const baseCommand = `
-cd nodejs-assets/nodejs-project &&
-yarn install &&
-cd ../../ &&
+let baseCommand = `
+yarn install --no-audit --prefer-offline --production=true --cwd nodejs-assets/nodejs-project &&
 rn-nodeify --install buffer,stream,assert,events,crypto,vm,process --hack`;
 
-function postInstallMac() {
-	exec(`${baseCommand} && react-native setup-ios-permissions && cd ios && pod install && cd ..`);
-}
-function postInstallLinWin() {
-	exec(baseCommand);
+if (os.type() === 'Darwin') {
+	baseCommand  += '&& react-native setup-ios-permissions';
+	if (!process.env.CI) {
+		baseCommand += '&& pod install --project-directory=ios';
+	}
 }
 
-if (os.type() === 'Darwin') {
-	postInstallMac();
-} else {
-	postInstallLinWin();
-}
+exec(baseCommand);


### PR DESCRIPTION
### Description

- do not run pod install on CI. This helps to write better caching for e2e tests
- unit test for slashtags key generation
- add buildcache action. Build now takes ~15 minues, instead of ~30 🥳


### Linked Issues/Tasks

### Type of change

New feature

### Tests

Detox test

### Screenshot / Video

### QA Notes

Nothing to QA here
