### PR TITLE
chore(lightning): Updated react-native-ldk

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -348,7 +348,7 @@ PODS:
     - React-Core
   - react-native-image-picker (5.3.1):
     - React-Core
-  - react-native-ldk (0.0.93):
+  - react-native-ldk (0.0.94):
     - React
   - react-native-libsodium (0.7.0):
     - React-Core
@@ -835,7 +835,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: 495c444c0c773c6e83a5d91165890ecb1c0a399a
   react-native-flipper: fe6db6651d338f516899ebe8dad573d0f2d7aa76
   react-native-image-picker: ec9b713e248760bfa0f879f0715391de4651a7cb
-  react-native-ldk: 092ee2346aedc13bac062e1755ede58933967cac
+  react-native-ldk: 99ab8137d3fd15980a006aa229a90917b2324f91
   react-native-libsodium: 2834a805c906aef4b7609019bcc87e7d9eb86b23
   react-native-mmkv: 7da5e18e55c04a9af9a7e0ab9792a1e8d33765a1
   react-native-netinfo: 22c082970cbd99071a4e5aa7a612ac20d66b08f0
@@ -881,6 +881,6 @@ SPEC CHECKSUMS:
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
   ZXingObjC: fdbb269f25dd2032da343e06f10224d62f537bdb
 
-PODFILE CHECKSUM: bb277cebcaada22fda90f4a37439c3294c3d2ab8
+PODFILE CHECKSUM: 5e3106d0eae9adbae1813568923965b0b6812560
 
-COCOAPODS: 1.12.0
+COCOAPODS: 1.12.1

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@reduxjs/toolkit": "^1.9.3",
     "@shopify/react-native-skia": "0.1.182",
     "@synonymdev/blocktank-client": "0.0.50",
-    "@synonymdev/react-native-ldk": "^0.0.93",
+    "@synonymdev/react-native-ldk": "^0.0.94",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2408,10 +2408,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@^0.0.93":
-  version "0.0.93"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.93.tgz#99d10ab41ac4d7aa0df4a514303c6416931557dd"
-  integrity sha512-BCQ1PqE7g9rd+4B7XCOQpOrrhGsFQMDhq+yDsz//fLPdC7boSGu4N21YLGHeFQ7UfF0optHbat4YQedpC7gNhQ==
+"@synonymdev/react-native-ldk@^0.0.94":
+  version "0.0.94"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.94.tgz#3b24b12eac13c6c51f35dcf708a1f513f300c3ef"
+  integrity sha512-kB6gKZ5nDcX/CYf7Y7eBtdd+/mT9e88Dj660lzwPOLT6jef10zgnaufzFGxsbGWQvg27odKVnplMZO91Xc5Dqw==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 


### PR DESCRIPTION
### Description

Updates react-native-ldk that includes a fix for payments failing on first attempt. (https://github.com/synonymdev/react-native-ldk/pull/125)

### Linked Issues/Tasks

Fixes [Add any links to GitHub issues or Asana tasks that are relevant to this pull request.](https://github.com/synonymdev/bitkit/issues/974)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

Payments won't instantly fail and then succeed on a 2nd attempt. The node will continue to attempt making the payment until it succeeds, a timeout of 60 seconds, or a hard payment fail.