### PR TITLE
fix(lightning): show error if unable to afford channel

### DIFF
--- a/__tests__/wallet-send.ts
+++ b/__tests__/wallet-send.ts
@@ -7,9 +7,9 @@ import { createNewWallet, startWalletServices } from '../src/utils/startup';
 import {
 	updateAddressIndexes,
 	updateWallet,
+	resetSendTransaction,
 	updateSendTransaction,
 	setupOnChainTransaction,
-	resetSendTransaction,
 } from '../src/store/actions/wallet';
 import { connectToElectrum } from '../src/utils/wallet/electrum';
 import {
@@ -168,16 +168,19 @@ describe('Wallet - new wallet, send and receive', () => {
 		expect(tx12?.satsPerByte).toBe(2);
 
 		// setting fee too high should return an error
-		res = updateFee({ satsPerByte: 100_000_000, transaction: tx12 });
+		let updateFeeRes = updateFee({
+			satsPerByte: 100_000_000,
+			transaction: tx12,
+		});
 		// @ts-ignore
-		expect(res.error.message).toBe(
+		expect(updateFeeRes.error.message).toBe(
 			'Unable to increase the fee any further. Otherwise, it will exceed half the current balance.',
 		);
 
 		// set fee to 3 vsat/byte
-		res = updateFee({ satsPerByte: 3, transaction: tx12 });
-		if (res.isErr()) {
-			throw res.error;
+		updateFeeRes = updateFee({ satsPerByte: 3, transaction: tx12 });
+		if (updateFeeRes.isErr()) {
+			throw updateFeeRes.error;
 		}
 
 		const tx13 =

--- a/src/utils/i18n/locales/en/other.json
+++ b/src/utils/i18n/locales/en/other.json
@@ -58,6 +58,8 @@
 	"lnurl_withdr_success_title": "Withdraw Requested",
 	"lnurl_withdr_success_msg": "LNURL Withdraw was successfully requested.",
 	"bt_error_retrieve": "Unable To Retrieve Order Information",
+	"bt_channel_purchase_fee_error": "Not enough funds to cover the transaction fee.",
+	"bt_channel_purchase_cost_error": "You need {{delta}} more to complete this transaction.",
 	"earlier": "EARLIER",
 	"update_title": "Update Available",
 	"update_text": "Please update Bitkit to the latest version for new features and bug fixes!",


### PR DESCRIPTION
### Description

Improve channel purchase UX by showing an error toast when the user is unable to afford the cost for the channel.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/1050

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/8538369/892c90b3-97b1-4462-9cfc-2eb869010634

### QA Notes

If unable to afford the cost for a channel an error toast should appear.
