### PR TITLE
fix: save receive tags on ReceiveDetails screen

### DIFF
--- a/src/navigation/bottom-sheet/ReceiveNavigation.tsx
+++ b/src/navigation/bottom-sheet/ReceiveNavigation.tsx
@@ -20,7 +20,7 @@ export type ReceiveNavigationProp =
 
 export type ReceiveStackParamList = {
 	ReceiveQR: undefined;
-	ReceiveDetails: undefined;
+	ReceiveDetails: { receiveAddress: string; lightningInvoice?: string };
 	Tags: undefined;
 };
 

--- a/src/screens/Wallets/Receive/ReceiveDetails.tsx
+++ b/src/screens/Wallets/Receive/ReceiveDetails.tsx
@@ -1,4 +1,10 @@
-import React, { ReactElement, memo, useCallback, useState } from 'react';
+import React, {
+	ReactElement,
+	memo,
+	useCallback,
+	useState,
+	useEffect,
+} from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
@@ -30,11 +36,13 @@ import GlowImage from '../../../components/GlowImage';
 import { useScreenSize } from '../../../hooks/screen';
 import { getNumberPadText } from '../../../utils/numberpad';
 import { useSwitchUnit } from '../../../hooks/wallet';
+import { updateMetaIncTxTags } from '../../../store/actions/metadata';
 
 const imageSrc = require('../../../assets/illustrations/coin-stack-4.png');
 
 const ReceiveDetails = ({
 	navigation,
+	route,
 }: ReceiveScreenProps<'ReceiveDetails'>): ReactElement => {
 	const { t } = useTranslation('wallet');
 	const { keyboardShown } = useKeyboard();
@@ -43,6 +51,7 @@ const ReceiveDetails = ({
 	const [showNumberPad, setShowNumberPad] = useState(false);
 	const invoice = useSelector(receiveSelector);
 	const { fiatTicker } = useCurrency();
+	const { receiveAddress, lightningInvoice } = route.params;
 
 	const onChangeUnit = (): void => {
 		const result = getNumberPadText(invoice.amount, nextUnit);
@@ -58,6 +67,12 @@ const ReceiveDetails = ({
 	const onContinue = useCallback(() => {
 		setShowNumberPad(false);
 	}, []);
+
+	useEffect(() => {
+		if (invoice.tags.length > 0 && receiveAddress) {
+			updateMetaIncTxTags(receiveAddress, lightningInvoice, invoice.tags);
+		}
+	}, [receiveAddress, lightningInvoice, invoice.tags]);
 
 	return (
 		<GradientView style={styles.container}>

--- a/src/screens/Wallets/Receive/ReceiveQR.tsx
+++ b/src/screens/Wallets/Receive/ReceiveQR.tsx
@@ -516,7 +516,12 @@ const ReceiveQR = ({
 				<Button
 					size="large"
 					text={t('receive_specify')}
-					onPress={(): void => navigation.navigate('ReceiveDetails')}
+					onPress={(): void =>
+						navigation.navigate('ReceiveDetails', {
+							receiveAddress,
+							lightningInvoice,
+						})
+					}
 					testID="SpecifyInvoiceButton"
 				/>
 			</View>

--- a/src/store/actions/metadata.ts
+++ b/src/store/actions/metadata.ts
@@ -49,7 +49,7 @@ export const deleteMetaTxTag = (txid: string, tag: string): Result<string> => {
  */
 export const updateMetaIncTxTags = (
 	address: string,
-	payReq: string,
+	payReq?: string,
 	tags: Array<string> = [],
 ): Result<string> => {
 	dispatch({


### PR DESCRIPTION
### Description

Save tags on ReceiveDetails screen

### Linked Issues/Tasks

closes #957

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video


### QA Notes

- open receive screen
- save address
- tap specify invoice
- add tag
- close this bottomsheet without tapping show QR code
- send money to the address
- check transaction, make sure tag is in place
