### PR TITLE
fix: QRCode share on iOS

### DIFF
--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -221,7 +221,9 @@ const QRView = ({
 					quietZone={20}
 					getRef={(c): void => {
 						if (c) {
-							c.toDataURL((data: string) => (qrRef.current = data));
+							c.toDataURL((data: string) => {
+								qrRef.current = data.replace(/(\r\n|\n|\r)/gm, '');
+							});
 						}
 					}}
 				/>

--- a/src/screens/Wallets/Receive/ReceiveQR.tsx
+++ b/src/screens/Wallets/Receive/ReceiveQR.tsx
@@ -254,10 +254,7 @@ const ReceiveQR = ({
 		console.log('TODO: copy QR code as image');
 		// not implemented in upstream yet
 		// https://github.com/react-native-clipboard/clipboard/issues/6
-		// qrRef.current.toDataURL((base64) => {
-		// 	const image = `data:image/png;base64,${base64}`;
-		// 	// Clipboard.setString(image);
-		// });
+		// Clipboard.setString(qrRef.current);
 	}, []);
 
 	const handleShare = useCallback(
@@ -309,7 +306,9 @@ const ReceiveQR = ({
 						quietZone={16}
 						getRef={(c): void => {
 							if (c) {
-								c.toDataURL((data: string) => (qrRef.current = data));
+								c.toDataURL((data: string) => {
+									qrRef.current = data.replace(/(\r\n|\n|\r)/gm, '');
+								});
 							}
 						}}
 					/>


### PR DESCRIPTION
### Description

Because `react-native-qrcode-svg`  .toDataURL method returns base64 image with linebreaks sharing is not working on the iOS. So before sharing, i'm now removing all linebreaks from the string.

### Linked Issues/Tasks

closes #1069

### Type of change

Bug fix

### Tests

No test

### QA Notes

try to share Profile or Receiving address on the iOS, make sure that QRcode is shared correctly
