### PR TITLE
chore(lightning): Upgrade react-native-ldk to 0.0.96

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -348,7 +348,7 @@ PODS:
     - React-Core
   - react-native-image-picker (5.3.1):
     - React-Core
-  - react-native-ldk (0.0.95):
+  - react-native-ldk (0.0.96):
     - React
   - react-native-libsodium (0.7.0):
     - React-Core
@@ -835,7 +835,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: 495c444c0c773c6e83a5d91165890ecb1c0a399a
   react-native-flipper: 5d8dcbcb905a7e8076c9a61a3709944c23cf48ee
   react-native-image-picker: ec9b713e248760bfa0f879f0715391de4651a7cb
-  react-native-ldk: 3608ec98dc228dc8ea4ca15e68a8b4562be7cfb5
+  react-native-ldk: d74fff362f75541785d504c78407a1d89efc83e4
   react-native-libsodium: 2834a805c906aef4b7609019bcc87e7d9eb86b23
   react-native-mmkv: 7da5e18e55c04a9af9a7e0ab9792a1e8d33765a1
   react-native-netinfo: 22c082970cbd99071a4e5aa7a612ac20d66b08f0

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@reduxjs/toolkit": "^1.9.3",
     "@shopify/react-native-skia": "0.1.182",
     "@synonymdev/blocktank-client": "0.0.50",
-    "@synonymdev/react-native-ldk": "0.0.95",
+    "@synonymdev/react-native-ldk": "0.0.96",
     "@synonymdev/react-native-lnurl": "0.0.3",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",

--- a/src/screens/Settings/AddressViewer/index.tsx
+++ b/src/screens/Settings/AddressViewer/index.tsx
@@ -78,7 +78,7 @@ import {
 	resetActivityStore,
 	updateActivityList,
 } from '../../../store/actions/activity';
-import { resetLdk } from '../../../utils/lightning';
+import { restartLdk } from '../../../utils/lightning';
 import { startWalletServices } from '../../../utils/startup';
 import { updateOnchainFeeEstimates } from '../../../store/actions/fees';
 import { viewControllerIsOpenSelector } from '../../../store/reselect/ui';
@@ -820,7 +820,7 @@ const AddressViewer = ({
 				addressType: config.addressType,
 			});
 			// Switching networks requires us to reset LDK.
-			await resetLdk();
+			await restartLdk();
 			// Start wallet services with the newly selected network.
 			await startWalletServices({
 				selectedNetwork: config.selectedNetwork,

--- a/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
+++ b/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
@@ -18,7 +18,7 @@ import { connectToElectrum } from '../../../utils/wallet/electrum';
 import { startWalletServices } from '../../../utils/startup';
 import { EAvailableNetworks } from '../../../utils/networks';
 import { getNetworkData } from '../../../utils/helpers';
-import { resetLdk } from '../../../utils/lightning';
+import { restartLdk } from '../../../utils/lightning';
 import {
 	getCurrentWallet,
 	getSelectedAddressType,
@@ -62,7 +62,7 @@ const BitcoinNetworkSelection = ({
 								addressType,
 							});
 							// Switching networks requires us to reset LDK.
-							await resetLdk();
+							await restartLdk();
 							// Start wallet services with the newly selected network.
 							await startWalletServices({ selectedNetwork: network });
 							await updateOnchainFeeEstimates({

--- a/src/store/actions/blocktank.ts
+++ b/src/store/actions/blocktank.ts
@@ -35,7 +35,7 @@ import {
 } from '../../utils/notifications';
 import { getDisplayValues } from '../../utils/displayValues';
 import i18n from '../../utils/i18n';
-import { setupLdk } from '../../utils/lightning';
+import { refreshLdk } from '../../utils/lightning';
 import { TWalletName } from '../types/wallet';
 import { IBlocktank } from '../types/blocktank';
 
@@ -425,8 +425,8 @@ const handleOrderStateChange = (order: IGetOrderResponse): void => {
 			removeTodo('transferToSpending');
 		}
 
-		// restart LDK after channel open
-		setupLdk();
+		// refresh LDK after channel open
+		refreshLdk({});
 	}
 };
 

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -103,7 +103,7 @@ export const wipeLdkStorage = async ({
 		selectedNetwork = getSelectedNetwork();
 	}
 
-	await ldk.reset();
+	await ldk.stop();
 	const path = `${RNFS.DocumentDirectoryPath}/ldk/${lm.account.name}`;
 
 	const deleteAllFiles = async (dirpath: string): Promise<void> => {
@@ -159,7 +159,7 @@ export const setupLdk = async ({
 		}
 
 		// start from a clean slate
-		await resetLdk();
+		await ldk.stop();
 
 		const account = await getAccount({ selectedWallet });
 		if (account.isErr()) {
@@ -414,13 +414,13 @@ export const unsubscribeFromLightningSubscriptions = (): void => {
 	onSpendableOutputsSubscription?.remove();
 };
 
-export const resetLdk = async (): Promise<Result<string>> => {
+export const restartLdk = async (): Promise<Result<string>> => {
 	// wait for interactions/animations to be completed
 	await new Promise((resolve) => {
 		InteractionManager.runAfterInteractions(() => resolve(null));
 	});
 
-	return await ldk.reset();
+	return await ldk.restart();
 };
 
 /**
@@ -450,8 +450,7 @@ export const refreshLdk = async ({
 
 		const isRunning = await isLdkRunning();
 		if (!isRunning) {
-			await resetLdk();
-			// Attempt to reset LDK.
+			// Attempt to setup and start LDK.
 			const setupResponse = await setupLdk({
 				selectedNetwork,
 				selectedWallet,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2603,10 +2603,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@0.0.95":
-  version "0.0.95"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.95.tgz#b352dd05e4fd0ecc1d720f23ae932660483a900c"
-  integrity sha512-vT5cVCY9LtxeI+LtwnhbwG6PjH8/BDu6B8bgtOmJvmoHbHPl5QmKh8cRbddaZq2M39SSvWdF8IHKU3y3GF2PeA==
+"@synonymdev/react-native-ldk@0.0.96":
+  version "0.0.96"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.96.tgz#7fd8d9fc60784ead20f62ca684e30099af146ea9"
+  integrity sha512-zyvUCmVSM7uidPXgx+X1Ygi0aO9sbjtKmX75GTm2urw2PVESV840DhHcO0ojWYq3efrRYDf3AofDylRjCmHLqw==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 


### PR DESCRIPTION
### Description
- Upgrades `react-native-ldk` to `0.0.96`.
- Changes `resetLdk` method name to `restartLdk`.
- Replaces `ldk.reset()` with `ldk.restart()` in `restartLdk` method.
- Replaces `setupLdk` with `refreshLdk` in `handleOrderStateChange` method.
- Replaces` resetLdk()` with `ldk.stop()` in `setupLdk` method.
- Removes `resetLdk()` from `refreshLdk` method.

### Type of change
- [x] Refactoring (improving code without creating new functionality)

### Tests
- [x] No test

### QA Notes
- Ensure lightning channels continue to open as expected.
- Ensure the changes do not result in new or additional crashes when opening channels or making/receiving lightning payments.
- Lightning connectivity should be more reliable and require fewer, if any, app restarts/refreshes to interact with lightning.
