### PR TITLE
fix: upgrade @synonymdev/react-native-lnurl to fix callback parsing bug

### DIFF
--- a/__tests__/lnurl.ts
+++ b/__tests__/lnurl.ts
@@ -3,8 +3,9 @@ import {
 	deriveLinkingKeys,
 	getLNURLParams,
 	signK1,
-	LNURLAuthParams,
 } from '@synonymdev/react-native-lnurl';
+import { LNURLAuthParams } from 'js-lnurl';
+
 import { EAvailableNetworks } from '@synonymdev/react-native-lnurl/dist/utils/types';
 
 const mnemonic =

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@shopify/react-native-skia": "0.1.182",
     "@synonymdev/blocktank-client": "0.0.50",
     "@synonymdev/react-native-ldk": "0.0.96",
-    "@synonymdev/react-native-lnurl": "0.0.3",
+    "@synonymdev/react-native-lnurl": "0.0.4",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",
     "@synonymdev/slashtags-sdk": "1.0.0-alpha.38",

--- a/src/utils/lnurl.ts
+++ b/src/utils/lnurl.ts
@@ -3,11 +3,13 @@ import {
 	createPayRequestUrl,
 	createWithdrawCallbackUrl,
 	lnurlAuth as lnAuth,
+} from '@synonymdev/react-native-lnurl';
+import {
 	LNURLAuthParams,
 	LNURLChannelParams,
 	LNURLPayParams,
 	LNURLWithdrawParams,
-} from '@synonymdev/react-native-lnurl';
+} from 'js-lnurl';
 import { err, ok, Result } from '@synonymdev/result';
 
 import {

--- a/src/utils/lnurl.ts
+++ b/src/utils/lnurl.ts
@@ -273,7 +273,7 @@ export const handleLnurlWithdraw = async ({
 		selectedNetwork = getSelectedNetwork();
 	}
 
-	const amountSats = params.maxWithdrawable / 1000; //Convert msats to sats.
+	const amountSats = Math.floor(params.maxWithdrawable / 1000); //Convert msats to sats.
 	const description = params.defaultDescription;
 
 	// Determine if we have enough receiving capacity before proceeding.
@@ -326,6 +326,15 @@ export const handleLnurlWithdraw = async ({
 			message: i18n.t('other:lnurl_withdr_error_connect'),
 		});
 		return err('Unable to connect to LNURL withdraw server.');
+	}
+
+	const jsonRes = await channelStatusRes.json();
+	if (jsonRes.status === 'ERROR') {
+		showErrorNotification({
+			title: i18n.t('other:lnurl_withdr_error'),
+			message: jsonRes.reason,
+		});
+		return err(jsonRes.reason);
 	}
 
 	showSuccessNotification({

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -7,14 +7,15 @@ import { address as bitcoinJSAddress } from 'bitcoinjs-lib';
 import { err, ok, Result } from '@synonymdev/result';
 import SDK from '@synonymdev/slashtags-sdk';
 import { TInvoice } from '@synonymdev/react-native-ldk';
+import { getLNURLParams } from '@synonymdev/react-native-lnurl';
+
 import {
-	getLNURLParams,
 	LNURLAuthParams,
 	LNURLChannelParams,
 	LNURLPayParams,
 	LNURLResponse,
 	LNURLWithdrawParams,
-} from '@synonymdev/react-native-lnurl';
+} from 'js-lnurl';
 
 import {
 	getOnchainTransactionData,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2610,16 +2610,17 @@
   dependencies:
     bitcoinjs-lib "^6.0.2"
 
-"@synonymdev/react-native-lnurl@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-lnurl/-/react-native-lnurl-0.0.3.tgz#ee8da8d1ad1b18e220fd49bf7cf303ddf4db56f8"
-  integrity sha512-xHdrqWzjRf6Pq95qqs4uWtFSu4vsaxu05uIC0aYwHzFvMWsJvONyakNoLvgLAHOp+9nEWG5PPqQMvQItGWu79A==
+"@synonymdev/react-native-lnurl@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-lnurl/-/react-native-lnurl-0.0.4.tgz#1bfa6b85e29ab03795b5cf5aabfc7637e784d4d1"
+  integrity sha512-fUmcSmqGIXCHjNnVguqm3HlGzIkTB1x9OYFcD2xaOn+ENeRbrMDm48KMSkwFn+NdkEG/YZSTjR9N14X2lSWfYw==
   dependencies:
     base64-js "^1.5.1"
     bip32 "^2.0.6"
     bip39 "^3.0.4"
     fast-sha256 "^1.3.0"
     js-lnurl "^0.2.5"
+    query-string "^7.1.3"
     readable-stream "^3.6.0"
     secp256k1 "^4.0.2"
     stream-browserify "^3.0.0"


### PR DESCRIPTION
### Description

While tesing LNURLWithdraw with lnbits.com I've discovered that Bitkit can't properly append GET query params to callback. I've fixed this bug in `@synonymdev/react-native-lnurl`
Also I've added additional check for callback return, that works for LN Markets

### Linked Issues/Tasks

closes #942

### Type of change

Bug fix

### Tests

No test

### QA Notes

Fix lnurl withdraw with lnbits.com
