### PR TITLE
fix: handle SlashtagsAuthClient.authz "channel closed" error correctly

### DIFF
--- a/src/screens/Widgets/SlashAuthModal.tsx
+++ b/src/screens/Widgets/SlashAuthModal.tsx
@@ -124,15 +124,22 @@ const _SlashAuthModal = (): ReactElement => {
 		setIsLoading(true);
 
 		const client = new Client(slashtag);
-		const response = await client.authz(_url).catch((e: Error) => {
-			if (e.message === 'channel closed') {
-				closeBottomSheet('slashauthModal');
-				showErrorNotification({
-					title: t('signin_to_error_header'),
-					message: t('signin_to_error_text'),
-				});
-			}
-		});
+		let response;
+
+		try {
+			response = await client.authz(_url);
+		} catch (e) {
+			showErrorNotification({
+				title: t('signin_to_error_header'),
+				message:
+					e.message === 'channel closed'
+						? t('signin_to_error_text')
+						: e.message,
+			});
+			setIsLoading(false);
+			closeBottomSheet('slashauthModal');
+			return;
+		}
 
 		if (response?.status === 'ok') {
 			showSuccessNotification({


### PR DESCRIPTION
### Description

Do not overlap correct
```js
showErrorNotification({
	title: t('signin_to_error_header'),
	message: t('signin_to_error_text'),
});
```
with empty
```js
showErrorNotification({
	title: t('signin_to_error_header'),
	message: response?.message || '',
});
```

when it is `e.message === 'channel closed'` error.

### Linked Issues/Tasks

closes #1089

### Type of change

Bug fix

### Tests

No test

### QA Notes

Try signin https://testnet.lnmarkets.com/en with Slashtags and you now will see correct `Could not connect to peer` error
