### PR TITLE
fix(wallet): Update Transaction Timestamps

### DIFF
--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -1176,7 +1176,10 @@ export const updateTransactions = async ({
 			formattedTransactions[txid] = {
 				...transactions[txid],
 				// Keep the previous timestamp if the tx is not new.
-				timestamp: storedTransactions[txid]?.timestamp ?? Date.now(),
+				timestamp:
+					storedTransactions[txid]?.timestamp ??
+					transactions[txid]?.timestamp ??
+					Date.now(),
 			};
 		}
 

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -1593,11 +1593,15 @@ export const formatTransactions = async ({
 		const fee = Number(Math.abs(totalValue).toFixed(8));
 		const satsPerByte = btcToSats(fee) / result.vsize;
 		const { address, height, scriptHash } = data;
-		const timestamp = Date.now();
+		let timestamp = Date.now();
 		let confirmTimestamp: number | undefined;
 
 		if (height > 0 && result.blocktime) {
 			confirmTimestamp = result.blocktime * 1000;
+			//In the event we're recovering, set the older timestamp.
+			if (confirmTimestamp < timestamp) {
+				timestamp = confirmTimestamp;
+			}
 		}
 
 		formattedTransactions[txid] = {


### PR DESCRIPTION
### Description
- Transaction timestamps are now set to the older, confirmed transaction timestamps when recovering without previous tx timestamps.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test

### QA Notes
- Transaction timestamps should be set to their confirmed timestamp when recovering.
