### PR TITLE
fix(settings): Fix Support Link

### DIFF
--- a/src/screens/Settings/About/index.tsx
+++ b/src/screens/Settings/About/index.tsx
@@ -106,7 +106,11 @@ const About = ({
 						type: EItemType.button,
 						onPress: async (): Promise<void> => {
 							const link = await createSupportLink();
-							await openURL(link);
+							const openUrlSuccess = await openURL(link);
+							if (!openUrlSuccess) {
+								//If unable to open mail app for any reason, open contact page in browser.
+								await openURL('https://synonym.to/contact');
+							}
 						},
 					},
 					{

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -425,18 +425,20 @@ export const timeAgo = (timestamp: number): string => {
 	});
 };
 
-export const openURL = async (url: string): Promise<void> => {
+export const openURL = async (url: string): Promise<boolean> => {
 	const supported = await Linking.canOpenURL(url);
-
 	try {
 		if (supported) {
 			await Linking.openURL(url);
+			return true;
 		} else {
 			console.log('Cannot open url: ', url);
+			return false;
 		}
 	} catch (e) {
 		console.log('Cannot open url: ', url);
 		console.error('Error open url: ', e);
+		return false;
 	}
 };
 

--- a/src/utils/support.ts
+++ b/src/utils/support.ts
@@ -12,7 +12,8 @@ const SUPPORT_EMAIL = 'support@synonym.to';
 /**
  * Support link for opening device mail app.
  * Includes an optional message, device details, app version and LDK node info.
- * @param message
+ * @param {string} [subject]
+ * @param {string} [message]
  * @returns {Promise<`mailto:support@synonym.to?subject=Bitkit support&body=${string}`>}
  */
 export const createSupportLink = async (
@@ -38,6 +39,9 @@ export const createSupportLink = async (
 	if (nodeId.isOk()) {
 		body += `\nLDK node ID: ${nodeId.value}`;
 	}
+
+	subject = encodeURIComponent(subject);
+	body = encodeURIComponent(body);
 
 	return `mailto:${SUPPORT_EMAIL}?subject=${subject}&body=${body}`;
 };


### PR DESCRIPTION
### Description
- Adds fallback url to the support link.
- Adds `encodeURIComponent` to subject and body in `createSupportLink` method.

### Linked Issues/Tasks
- This fixes #1095

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test

### QA Notes
- Navigate to Settings->About Bitkit and tap Support on a live iOS/Android device.
    - Expected: Bitkit should either open the device's default mail client, open a drawer to select and open a mail client or fallback to use the synonym.to support page in the event a default mail client is not available on the device.
