### PR TITLE
fix: use numberOfLines={2} to display name in slashtags profile

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -45,9 +45,6 @@ const ProfileCard = ({
 	const name = profile?.name ?? '';
 	const bio = profile?.bio;
 
-	// two lines max.
-	const nameParts = name.split(/\s+/).slice(0, 2);
-
 	return (
 		<>
 			<View style={styles.row} testID="ProfileCardName">
@@ -83,11 +80,9 @@ const ProfileCard = ({
 									{t('contact_retrieving')}
 								</Headline>
 							) : (
-								nameParts.map((part, index) => (
-									<Headline key={index} numberOfLines={1} style={styles.name}>
-										{truncate(part, 30)}
-									</Headline>
-								))
+								<Headline numberOfLines={2} style={styles.name}>
+									{truncate(name, 30)}
+								</Headline>
 							)}
 						</View>
 					)}


### PR DESCRIPTION
### Description

Fix cutting logic for long names in slashtags profile

### Linked Issues/Tasks

closes #1088

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video

<img width="390" alt="Screenshot 2023-06-06 at 13 09 53" src="https://github.com/synonymdev/bitkit/assets/155891/b98aa226-3c75-4dcf-a583-152a7eac8edf">
<img width="395" alt="Screenshot 2023-06-06 at 13 09 33" src="https://github.com/synonymdev/bitkit/assets/155891/54393889-78dc-436a-a314-08bb06a3e659">
<img width="389" alt="Screenshot 2023-06-06 at 13 08 54" src="https://github.com/synonymdev/bitkit/assets/155891/f97e89a6-2f4c-40d8-a500-c2febb8cefa2">
