### PR TITLE
fix(wallet): Address Viewer Sweep Fix

### DIFF
--- a/src/screens/Settings/AddressViewer/index.tsx
+++ b/src/screens/Settings/AddressViewer/index.tsx
@@ -712,6 +712,7 @@ const AddressViewer = ({
 				transaction: {
 					...transactionRes.value,
 					outputs: [{ address: receiveAddress.value, value: 0, index: 0 }],
+					fromAddressViewer: true,
 				},
 				selectedWallet,
 				selectedNetwork,

--- a/src/screens/Wallets/Send/Amount.tsx
+++ b/src/screens/Wallets/Send/Amount.tsx
@@ -139,6 +139,7 @@ const Amount = ({ navigation }: SendScreenProps<'Amount'>): ReactElement => {
 			amount,
 			selectedWallet,
 			selectedNetwork,
+			transaction,
 		});
 		if (result.isErr()) {
 			return;
@@ -155,7 +156,7 @@ const Amount = ({ navigation }: SendScreenProps<'Amount'>): ReactElement => {
 		selectedWallet,
 		selectedNetwork,
 		coinSelectAuto,
-		transaction.lightningInvoice,
+		transaction,
 		navigation,
 	]);
 

--- a/src/screens/Wallets/Send/Recipient.tsx
+++ b/src/screens/Wallets/Send/Recipient.tsx
@@ -33,6 +33,7 @@ import {
 import {
 	resetSendTransaction,
 	setupOnChainTransaction,
+	updateSendTransaction,
 } from '../../../store/actions/wallet';
 
 const imageSrc = require('../../../assets/illustrations/coin-stack-logo.png');
@@ -116,15 +117,26 @@ const Recipient = ({
 	const onContinue = async (): Promise<void> => {
 		await Keyboard.dismiss();
 
-		// make sure transaction is up-to-date when navigating back and forth
-		await processInputData({
-			data: textFieldValue,
-			source: 'send',
-			showErrors: false,
-			sdk,
-			selectedNetwork,
-			selectedWallet,
-		});
+		if (transaction?.fromAddressViewer) {
+			//Skip processInputData if from address viewer so-as to not lose inputs.
+			updateSendTransaction({
+				selectedWallet,
+				selectedNetwork,
+				transaction: {
+					fromAddressViewer: false,
+				},
+			});
+		} else {
+			// make sure transaction is up-to-date when navigating back and forth
+			await processInputData({
+				data: textFieldValue,
+				source: 'send',
+				showErrors: false,
+				sdk,
+				selectedNetwork,
+				selectedWallet,
+			});
+		}
 
 		if (transaction.lightningInvoice && transaction.outputs[0].value > 0) {
 			navigation.navigate('ReviewAndSend');

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -121,6 +121,7 @@ export const defaultSendTransaction: ISendTransaction = {
 	max: false,
 	tags: [],
 	lightningInvoice: '',
+	fromAddressViewer: false, //When true, ensures tx inputs are not cleared when sweeping from address viewer.
 };
 
 export const defaultAddressContent: Readonly<IAddress> = {

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -209,6 +209,7 @@ export interface ISendTransaction {
 	tags: string[];
 	slashTagsUrl?: string;
 	lightningInvoice?: string;
+	fromAddressViewer?: boolean;
 }
 
 export interface IBoostedTransaction {


### PR DESCRIPTION
### Description
- Ensures inputs are not wiped when attempting to sweep from address viewer.
- Adds `fromAddressViewer` to `transaction` object.
- Ensures inputs with an index outside of the scanning range are able to be swept.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Screenshot / Video
https://github.com/synonymdev/bitkit/assets/8532651/0a6ab6fc-d646-4a85-b013-7f26ed669dee

### Tests
- [x] No test

### QA Notes
- Create a new wallet.
- Navigate to Settings->Advanced->Address Viewer.
- Tap "Generate 20 More", copy the address from index 39 and send sats to it.
    - Bitkit should not be able to detect this send since it's beyond its scanning threshold.
- Ensure index 39 is still present in the Address Viewer and tap "Check Balances".
- Tap "Spend All Funds From 1 address".
- The send window should appear. Add an address (any address) and tap "Continue".

Expected: You should be able to successfully spend the funds from the address at index 39.
