### PR TITLE
fix(ui): #1109 RefreshControl crashing on Android

### DIFF
--- a/src/screens/Activity/ActivityList.tsx
+++ b/src/screens/Activity/ActivityList.tsx
@@ -15,10 +15,13 @@ import {
 } from 'react-native';
 import { useSelector } from 'react-redux';
 import { useNavigation } from '@react-navigation/native';
-import { FlatList, GestureType } from 'react-native-gesture-handler';
+import {
+	FlatList,
+	RefreshControl,
+	GestureType,
+} from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
 
-import { RefreshControl } from '../../styles/components';
 import { Caption13Up, Subtitle, Text01S } from '../../styles/text';
 import { refreshWallet } from '../../utils/wallet';
 import { groupActivityItems, filterActivityItems } from '../../utils/activity';

--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react';
 import { StyleSheet, View, ScrollView, TouchableOpacity } from 'react-native';
 import Share from 'react-native-share';
-import { FadeIn, FadeOut } from 'react-native-reanimated';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 import { IGetOrderResponse } from '@synonymdev/blocktank-client';
 import { TChannel } from '@synonymdev/react-native-ldk';
 import { useTranslation } from 'react-i18next';
@@ -79,6 +79,10 @@ import {
 } from '../../../store/reselect/blocktank';
 import { TPaidBlocktankOrders } from '../../../store/types/blocktank';
 import { EBalanceUnit } from '../../../store/types/wallet';
+
+// Workaround for crash on Android
+// https://github.com/software-mansion/react-native-reanimated/issues/4306#issuecomment-1538184321
+const AnimatedRefreshControl = Animated.createAnimatedComponent(RefreshControl);
 
 /**
  * Convert pending (non-channel) blocktank orders to (fake) channels.
@@ -357,7 +361,11 @@ const Channels = ({
 			<ScrollView
 				contentContainerStyle={styles.content}
 				refreshControl={
-					<RefreshControl refreshing={refreshingLdk} onRefresh={onRefreshLdk} />
+					<AnimatedRefreshControl
+						refreshing={refreshingLdk}
+						exiting={FadeOut}
+						onRefresh={onRefreshLdk}
+					/>
 				}>
 				<View style={styles.balances}>
 					<View style={styles.balance}>

--- a/src/screens/Wallets/index.tsx
+++ b/src/screens/Wallets/index.tsx
@@ -9,6 +9,7 @@ import { useSelector } from 'react-redux';
 import { StyleSheet, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import { RefreshControl, ScrollView } from 'react-native-gesture-handler';
+import Animated, { FadeOut } from 'react-native-reanimated';
 
 import { useNoTransactions } from '../../hooks/wallet';
 import useColors from '../../hooks/colors';
@@ -31,6 +32,10 @@ import {
 	hideOnboardingMessageSelector,
 } from '../../store/reselect/settings';
 import { widgetsSelector } from '../../store/reselect/widgets';
+
+// Workaround for crash on Android
+// https://github.com/software-mansion/react-native-reanimated/issues/4306#issuecomment-1538184321
+const AnimatedRefreshControl = Animated.createAnimatedComponent(RefreshControl);
 
 const Wallets = ({
 	navigation,
@@ -89,10 +94,11 @@ const Wallets = ({
 					disableScrollViewPanResponder={true}
 					showsVerticalScrollIndicator={false}
 					refreshControl={
-						<RefreshControl
+						<AnimatedRefreshControl
 							refreshing={refreshing}
-							onRefresh={onRefresh}
 							tintColor={colors.refreshControl}
+							exiting={FadeOut}
+							onRefresh={onRefresh}
 						/>
 					}>
 					<DetectSwipe


### PR DESCRIPTION
### Description

Implements workaround described in https://github.com/software-mansion/react-native-reanimated/issues/4306

### Linked Issues/Tasks

Closes #1109 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

See that crash described in #1109 doesn't occur.
