### PR TITLE
fix(lightning): sync ldk fees when refreshing

### DIFF
--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -473,6 +473,7 @@ export const refreshLdk = async ({
 		}
 
 		const syncRes = await lm.syncLdk();
+		await lm.setFees();
 		if (syncRes.isErr()) {
 			return err(syncRes.error.message);
 		}


### PR DESCRIPTION
### Description

Syncs LDK fees when refreshing. Refresh function is called right before closing a channel so this could avoid any potential fee mismatching with counter party node resulting in a force close.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

We should see less force closing channels.