### PR TITLE
fix: remove Install SSH Key step from github actions

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -35,17 +35,6 @@ jobs:
         timeout-minutes: 2
         run: while ! nc -z '127.0.0.1' 60001; do sleep 1; done
 
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.TEST_USER_SSH_KEY }}
-          known_hosts: ${{ secrets.TEST_USER_KNOWN_HOSTS }}
-
-      - name: Use NPM Token with organization read access
-        uses: dkershner6/use-npm-token-action@v1
-        with:
-          token: '${{ secrets.NPMJS_READ }}'
-
       - name: Setup Node
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/jest.yml
+++ b/.github/workflows/jest.yml
@@ -30,17 +30,6 @@ jobs:
           node-version: 18
           cache: 'yarn'
 
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.TEST_USER_SSH_KEY }}
-          known_hosts: ${{ secrets.TEST_USER_KNOWN_HOSTS }}
-
-      - name: Use NPM Token with organization read access
-        uses: dkershner6/use-npm-token-action@v1
-        with:
-          token: '${{ secrets.NPMJS_READ }}'
-
       - name: Install Node.js dependencies
         run: yarn install
 

--- a/.github/workflows/lint-check.yml
+++ b/.github/workflows/lint-check.yml
@@ -19,17 +19,6 @@ jobs:
           node-version: 18
           cache: 'yarn'
 
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.TEST_USER_SSH_KEY }}
-          known_hosts: ${{ secrets.TEST_USER_KNOWN_HOSTS }}
-
-      - name: Use NPM Token with organization read access
-        uses: dkershner6/use-npm-token-action@v1
-        with:
-          token: '${{ secrets.NPMJS_READ }}'
-
       - name: Install Node.js dependencies
         run: yarn install
 

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -19,17 +19,6 @@ jobs:
           node-version: 18
           cache: 'yarn'
 
-      - name: Install SSH key
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.TEST_USER_SSH_KEY }}
-          known_hosts: ${{ secrets.TEST_USER_KNOWN_HOSTS }}
-
-      - name: Use NPM Token with organization read access
-        uses: dkershner6/use-npm-token-action@v1
-        with:
-          token: '${{ secrets.NPMJS_READ }}'
-
       - name: Install Node.js dependencies
         run: yarn install
 

--- a/nodejs-assets/nodejs-project/package.json
+++ b/nodejs-assets/nodejs-project/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@noble/secp256k1": "^1.7.0",
-    "bip32": "git+ssh://git@github.com/synonymdev/bip32",
+    "bip32": "github:synonymdev/bip32#58f0dd7d253d70fa5ff442997464892c46874348",
     "bip39": "^3.0.4",
     "bitcoinjs-lib": "^6.0.1",
     "create-hmac": "^1.1.7"

--- a/nodejs-assets/nodejs-project/yarn.lock
+++ b/nodejs-assets/nodejs-project/yarn.lock
@@ -29,9 +29,9 @@ bip174@^2.0.1:
   resolved "https://registry.yarnpkg.com/bip174/-/bip174-2.1.0.tgz#cd3402581feaa5116f0f00a0eaee87a5843a2d30"
   integrity sha512-lkc0XyiX9E9KiVAS1ZiOqK1xfiwvf4FXDDdkDq5crcDzOq+xGytY+14qCsqz7kCiy8rpN1CRNfacRhf9G3JNSA==
 
-"bip32@git+ssh://git@github.com/synonymdev/bip32":
+"bip32@github:synonymdev/bip32#58f0dd7d253d70fa5ff442997464892c46874348":
   version "3.1.0"
-  resolved "git+ssh://git@github.com/synonymdev/bip32#58f0dd7d253d70fa5ff442997464892c46874348"
+  resolved "https://codeload.github.com/synonymdev/bip32/tar.gz/58f0dd7d253d70fa5ff442997464892c46874348"
   dependencies:
     bs58check "^2.1.1"
     create-hash "^1.2.0"


### PR DESCRIPTION
### Description

Fix: remove Install SSH Key step from github actions

So that PRs from outside can run tests, like #1115

### Linked Issues/Tasks

#1115

### Type of change

Bug fix

### Tests

No test

