### PR TITLE
fix(lightning): restore all networks during ldk backup recover

### DIFF
--- a/src/screens/Settings/AddressViewer/index.tsx
+++ b/src/screens/Settings/AddressViewer/index.tsx
@@ -14,6 +14,7 @@ import QRCode from 'react-native-qrcode-svg';
 import { err, ok, Result } from '@synonymdev/result';
 import Clipboard from '@react-native-clipboard/clipboard';
 import fuzzysort from 'fuzzysort';
+import { ldk } from '@synonymdev/react-native-ldk';
 
 import {
 	TouchableOpacity,
@@ -78,7 +79,7 @@ import {
 	resetActivityStore,
 	updateActivityList,
 } from '../../../store/actions/activity';
-import { restartLdk } from '../../../utils/lightning';
+import { setupLdk } from '../../../utils/lightning';
 import { startWalletServices } from '../../../utils/startup';
 import { updateOnchainFeeEstimates } from '../../../store/actions/fees';
 import { viewControllerIsOpenSelector } from '../../../store/reselect/ui';
@@ -812,6 +813,7 @@ const AddressViewer = ({
 		if (selectedNetwork !== config.selectedNetwork) {
 			// Wipe existing activity
 			resetActivityStore();
+			ldk.stop();
 			// Switch to new network.
 			updateWallet({ selectedNetwork: config.selectedNetwork });
 			// Generate addresses if none exist for the newly selected wallet and network.
@@ -821,7 +823,7 @@ const AddressViewer = ({
 				addressType: config.addressType,
 			});
 			// Switching networks requires us to reset LDK.
-			await restartLdk();
+			await setupLdk({ selectedWallet, selectedNetwork });
 			// Start wallet services with the newly selected network.
 			await startWalletServices({
 				selectedNetwork: config.selectedNetwork,

--- a/src/screens/Settings/Backup/ShowMnemonic.tsx
+++ b/src/screens/Settings/Backup/ShowMnemonic.tsx
@@ -1,6 +1,7 @@
 import React, { memo, ReactElement, useMemo, useState, useEffect } from 'react';
-import { StyleSheet, View, Platform } from 'react-native';
+import { StyleSheet, View, Platform, TouchableOpacity } from 'react-native';
 import { Trans, useTranslation } from 'react-i18next';
+import Clipboard from '@react-native-clipboard/clipboard';
 
 import { View as ThemedView } from '../../../styles/components';
 import { Text01S, Text01M, Text02S } from '../../../styles/text';
@@ -11,6 +12,7 @@ import BlurView from '../../../components/BlurView';
 import { getMnemonicPhrase, getBip39Passphrase } from '../../../utils/wallet';
 import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
 import { showErrorNotification } from '../../../utils/notifications';
+import { vibrate } from '../../../utils/helpers';
 import type { BackupScreenProps } from '../../../navigation/types';
 
 // Android doesn't have blur so we put a dummy mnemonic
@@ -78,16 +80,24 @@ const ShowMnemonic = ({
 				testID="SeedContaider"
 				accessibilityLabel={seed.join(' ')}>
 				<ThemedView color="gray324" style={styles.seed}>
-					<View style={styles.col}>
-						{seedToShow.slice(0, seedToShow.length / 2).map((w, i) => (
-							<Word key={i} word={w} number={i + 1} />
-						))}
-					</View>
-					<View style={styles.col}>
-						{seedToShow.slice(-seedToShow.length / 2).map((w, i) => (
-							<Word key={i} word={w} number={seedToShow.length / 2 + i + 1} />
-						))}
-					</View>
+					<TouchableOpacity
+						style={styles.seed2}
+						activeOpacity={1}
+						onLongPress={(): void => {
+							Clipboard.setString(seed.join(' '));
+							vibrate();
+						}}>
+						<View style={styles.col}>
+							{seedToShow.slice(0, seedToShow.length / 2).map((w, i) => (
+								<Word key={i} word={w} number={i + 1} />
+							))}
+						</View>
+						<View style={styles.col}>
+							{seedToShow.slice(-seedToShow.length / 2).map((w, i) => (
+								<Word key={i} word={w} number={seedToShow.length / 2 + i + 1} />
+							))}
+						</View>
+					</TouchableOpacity>
 				</ThemedView>
 
 				{!show && (
@@ -149,8 +159,10 @@ const styles = StyleSheet.create({
 		paddingTop: 32,
 		paddingBottom: 24,
 		paddingHorizontal: 16,
-		flexDirection: 'row',
 		borderRadius: 16,
+	},
+	seed2: {
+		flexDirection: 'row',
 	},
 	col: {
 		marginHorizontal: 16,

--- a/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
+++ b/src/screens/Settings/Bitcoin/BitcoinNetworkSelection.tsx
@@ -1,6 +1,7 @@
 import React, { memo, ReactElement, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
+import { ldk } from '@synonymdev/react-native-ldk';
 
 import { EItemType, IListData } from '../../../components/List';
 import SettingsView from '../SettingsView';
@@ -18,7 +19,7 @@ import { connectToElectrum } from '../../../utils/wallet/electrum';
 import { startWalletServices } from '../../../utils/startup';
 import { EAvailableNetworks } from '../../../utils/networks';
 import { getNetworkData } from '../../../utils/helpers';
-import { restartLdk } from '../../../utils/lightning';
+import { setupLdk } from '../../../utils/lightning';
 import {
 	getCurrentWallet,
 	getSelectedAddressType,
@@ -41,6 +42,7 @@ const BitcoinNetworkSelection = ({
 						type: EItemType.button,
 						onPress: async (): Promise<void> => {
 							navigation.goBack();
+							await ldk.stop();
 							// Wipe existing activity
 							resetActivityStore();
 							// Switch to new network.
@@ -62,7 +64,7 @@ const BitcoinNetworkSelection = ({
 								addressType,
 							});
 							// Switching networks requires us to reset LDK.
-							await restartLdk();
+							await setupLdk({ selectedWallet, selectedNetwork });
 							// Start wallet services with the newly selected network.
 							await startWalletServices({ selectedNetwork: network });
 							await updateOnchainFeeEstimates({

--- a/src/store/actions/backup.ts
+++ b/src/store/actions/backup.ts
@@ -16,7 +16,7 @@ import {
 	setAccount,
 	setLdkStoragePath,
 } from '../../utils/lightning';
-import { TAvailableNetworks } from '../../utils/networks';
+import { EAvailableNetworks, TAvailableNetworks } from '../../utils/networks';
 import { getSelectedNetwork } from '../../utils/wallet';
 import { ISettings } from '../types/settings';
 import { updateSettings } from './settings';
@@ -497,11 +497,18 @@ export const performFullRestoreFromLatestBackup = async (
 	slashtag: Slashtag,
 ): Promise<Result<{ backupExists: boolean }>> => {
 	try {
-		const selectedNetwork = getSelectedNetwork();
-		const ldkBackupRes = await performLdkRestore({ slashtag, selectedNetwork });
-		if (ldkBackupRes.isErr()) {
-			return err(ldkBackupRes.error.message);
+		// ldk restore should be perfomed for all networks
+		for (const network of Object.values(EAvailableNetworks)) {
+			const ldkBackupRes = await performLdkRestore({
+				slashtag,
+				selectedNetwork: network,
+			});
+			if (ldkBackupRes.isErr()) {
+				return err(ldkBackupRes.error.message);
+			}
 		}
+
+		const selectedNetwork = getSelectedNetwork();
 
 		const settingsBackupRes = await performSettingsRestore({
 			slashtag,

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -425,15 +425,6 @@ export const unsubscribeFromLightningSubscriptions = (): void => {
 	onSpendableOutputsSubscription?.remove();
 };
 
-export const restartLdk = async (): Promise<Result<string>> => {
-	// wait for interactions/animations to be completed
-	await new Promise((resolve) => {
-		InteractionManager.runAfterInteractions(() => resolve(null));
-	});
-
-	return await ldk.restart();
-};
-
 /**
  * This method syncs LDK, re-adds peers & updates lightning channels.
  * @param {TWalletName} [selectedWallet]


### PR DESCRIPTION
### Description

When restoring wallet we should fetch and restore LDK backups for all abailable networks.

### Linked Issues/Tasks

closes #563

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video

Insert relevant screenshot / recording

### QA Notes

- Create new wallet
- Open LN channel on Mainnet
- Open LN channel on Regtest
- Wipe and restore wallet from seed
- Make sure both Mainnet and Regtest channels are restored
