### PR TITLE
fix(lightning): removes LDK scorer caching on iOS

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -350,7 +350,7 @@ PODS:
     - React-Core
   - react-native-keep-awake (1.2.0):
     - React-Core
-  - react-native-ldk (0.0.98):
+  - react-native-ldk (0.0.99):
     - React
   - react-native-libsodium (0.7.0):
     - React-Core
@@ -841,7 +841,7 @@ SPEC CHECKSUMS:
   react-native-flipper: 5d8dcbcb905a7e8076c9a61a3709944c23cf48ee
   react-native-image-picker: ec9b713e248760bfa0f879f0715391de4651a7cb
   react-native-keep-awake: caee3ff89eaa21dfe29010f0d143566874a04441
-  react-native-ldk: 0b2b9c3e57c80b19d94ec306f49765b29530758e
+  react-native-ldk: 175104646d32a4f52d82299c6981ad4bf91ad603
   react-native-libsodium: 2834a805c906aef4b7609019bcc87e7d9eb86b23
   react-native-mmkv: 7da5e18e55c04a9af9a7e0ab9792a1e8d33765a1
   react-native-netinfo: 22c082970cbd99071a4e5aa7a612ac20d66b08f0

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@sayem314/react-native-keep-awake": "^1.2.0",
     "@shopify/react-native-skia": "0.1.182",
     "@synonymdev/blocktank-client": "0.0.50",
-    "@synonymdev/react-native-ldk": "0.0.98",
+    "@synonymdev/react-native-ldk": "^0.0.99",
     "@synonymdev/react-native-lnurl": "0.0.4",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2647,10 +2647,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@0.0.98":
-  version "0.0.98"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.98.tgz#560dc92ebb848a9bfb1b9cdb9391e3f2b8a8069c"
-  integrity sha512-uayVXhQ9s6toClr6nF3w5dKZFRer3xEdIkYglBmLXfgN8Lh2BTs3mPPUV01BJnY+Wb7mSWpuZ01M3qBfotBzqQ==
+"@synonymdev/react-native-ldk@^0.0.99":
+  version "0.0.99"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.99.tgz#f7a1a3fc82bc841950da31fe870c4f80caa4f8df"
+  integrity sha512-WXwJCJxBuEMc3vSLGwFzE6PxYPNsgbL9+6bF09Inuq1WeLbXQf3Sxg4uravXeDchQM8435YejKAQg+Q7YY7LRQ==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 


### PR DESCRIPTION
### Description

Updates react-native-ldk that has a a crash fix by removing scorer caching on iOS

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

App should stop crashing on startup