### PR TITLE
fix: convert sats to BTC without scientific notation

### DIFF
--- a/__tests__/fiat.ts
+++ b/__tests__/fiat.ts
@@ -105,4 +105,14 @@ describe('Pulls latest fiat exchange rates and checks the wallet store for valid
 		expect(dv.bitcoinTicker).toBe('satoshi');
 		expect(dv.satoshis).toBe(1010101);
 	});
+
+	it('Can convert small amount of sats without scientific notation', () => {
+		const dv = getDisplayValues({
+			satoshis: 10,
+			bitcoinUnit: EBitcoinUnit.BTC,
+		});
+
+		expect(dv.bitcoinFormatted).toBe('0.0000001');
+		expect(dv.bitcoinWhole).toBe('0');
+	});
 });

--- a/src/utils/displayValues/index.ts
+++ b/src/utils/displayValues/index.ts
@@ -29,7 +29,9 @@ export const getBitcoinDisplayValues = ({
 		let bitcoinFormatted: string = bitcoinUnits(satoshis, 'satoshi')
 			.to(bitcoinUnit)
 			.value()
-			.toString();
+			// convert to string without scientific notation and trailing zeros
+			.toFixed(10)
+			.replace(/\.?0+$/, '');
 
 		const [bitcoinWhole, bitcoinDecimal] = bitcoinFormatted.split('.');
 


### PR DESCRIPTION
### Description

convert sats to BTC without scientific notation

### Type of change

Bug fix

### Tests

Unit test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/155891/aabab2b2-9269-495a-813b-79671b61ac38

