### PR TITLE
test: custom babel config for e2e tests

### DIFF
--- a/e2e/babel.config.js
+++ b/e2e/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	presets: [
+		['@babel/preset-env', { targets: { node: 'current' } }],
+		'@babel/preset-typescript',
+	],
+};

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -8,4 +8,7 @@ module.exports = {
 	globalSetup: 'detox/runners/jest/globalSetup',
 	globalTeardown: 'detox/runners/jest/globalTeardown',
 	testEnvironment: 'detox/runners/jest/testEnvironment',
+	transform: {
+		'\\.[jt]sx?$': ['babel-jest', { configFile: './e2e/babel.config.js' }],
+	},
 };


### PR DESCRIPTION
### Description

When using helpers in e2e tests, there is one problem - you can't clearly say where is the problem by looking at the stacktrace. I'm fixing it by adding custom babel config for e2e tests

### Type of change

Bug fix

### Tests

Detox test

### Screenshot / Video

## Before

<img width="666" alt="Screenshot 2023-07-04 at 16 54 37" src="https://github.com/synonymdev/bitkit/assets/155891/fb707137-91e6-4d6f-8e4c-b257a4fc3a7d">

## After

<img width="669" alt="Screenshot 2023-07-04 at 16 55 00" src="https://github.com/synonymdev/bitkit/assets/155891/0e331583-b9dc-42b8-8729-68259eea34ab">

