### PR TITLE
chore(lightning): react-native-ldk version bump

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -350,7 +350,7 @@ PODS:
     - React-Core
   - react-native-keep-awake (1.2.0):
     - React-Core
-  - react-native-ldk (0.0.100):
+  - react-native-ldk (0.0.101):
     - React
   - react-native-libsodium (0.7.0):
     - React-Core
@@ -841,7 +841,7 @@ SPEC CHECKSUMS:
   react-native-flipper: 5d8dcbcb905a7e8076c9a61a3709944c23cf48ee
   react-native-image-picker: ec9b713e248760bfa0f879f0715391de4651a7cb
   react-native-keep-awake: caee3ff89eaa21dfe29010f0d143566874a04441
-  react-native-ldk: 1f4ff6d711766800360d02bcc2dfac9eb46f5620
+  react-native-ldk: dcf18b998cb115ed2228fd09268b9b45d8fb5036
   react-native-libsodium: 2834a805c906aef4b7609019bcc87e7d9eb86b23
   react-native-mmkv: 7da5e18e55c04a9af9a7e0ab9792a1e8d33765a1
   react-native-netinfo: 22c082970cbd99071a4e5aa7a612ac20d66b08f0

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@sayem314/react-native-keep-awake": "^1.2.0",
     "@shopify/react-native-skia": "0.1.182",
     "@synonymdev/blocktank-client": "0.0.50",
-    "@synonymdev/react-native-ldk": "^0.0.100",
+    "@synonymdev/react-native-ldk": "^0.0.101",
     "@synonymdev/react-native-lnurl": "0.0.4",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "^1.0.0-alpha.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2647,10 +2647,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/react-native-ldk@^0.0.100":
-  version "0.0.100"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.100.tgz#1a829dd5e0c17f5cdc2db1b2f1c5a83e3d08667a"
-  integrity sha512-9GbZQIDfBAvKOM0MGBek3oJcgkTA75NvMnBp+TgoFRPovakXRUH5rUNp3njxwbK3t0uff0iUSIagYpmNj9LOrA==
+"@synonymdev/react-native-ldk@^0.0.101":
+  version "0.0.101"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.101.tgz#a9d527aefc638c499432f780f4de2df09c35f9ed"
+  integrity sha512-Dhuta1z0LRVL7/B/S9jsCB6xvt+3CsWFQgeX8TTMhcGLCfYEzfaDp/tTtU9Edzq/kxcYsNQrnXY+4tSLGLzlXA==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 


### PR DESCRIPTION
### Description

react-native-ldk version bump to 0.0.101 that includes a fix for iOS using wrong current timestamp when syncing via rapid gossip.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

Should fix lightning payments instantly failing