### PR TITLE
test: skip e2e tests using describe.skip

### DIFF
--- a/e2e/backup.e2e.js
+++ b/e2e/backup.e2e.js
@@ -10,7 +10,9 @@ import {
 } from './helpers';
 import initWaitForElectrumToSync from '../__tests__/utils/wait-for-electrum';
 
-describe('Backup', () => {
+d = checkComplete('backup-1') ? describe.skip : describe;
+
+d('Backup', () => {
 	let waitForElectrum;
 	const rpc = new BitcoinJsonRpc(bitcoinURL);
 

--- a/e2e/channels.e2e.js
+++ b/e2e/channels.e2e.js
@@ -12,7 +12,9 @@ import {
 	bitcoinURL,
 } from './helpers';
 
-describe('LN Channel Onboarding', () => {
+d = checkComplete('channels-1') ? describe.skip : describe;
+
+d('LN Channel Onboarding', () => {
 	let waitForElectrum;
 	const rpc = new BitcoinJsonRpc(bitcoinURL);
 
@@ -42,7 +44,7 @@ describe('LN Channel Onboarding', () => {
 		waitForElectrum?.close();
 	});
 
-	describe('Lightning onboarding / Channel purchase', () => {
+	d('Lightning onboarding / Channel purchase', () => {
 		// Test plan
 		// QuickSetup
 		// - can change amount via the slider

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -7,15 +7,21 @@ export const bitcoinURL = 'http://polaruser:polarpass@127.0.0.1:43782';
 
 export const checkComplete = (name) => {
 	if (!process.env.CI) {
-		return;
+		return false;
 	}
 
-	if (fs.existsSync(path.join(LOCK_PATH, 'lock-' + name))) {
-		console.warn('skipping', name, 'as it previously passed on CI');
-		return true;
+	if (typeof name === 'string') {
+		name = [name];
 	}
 
-	return false;
+	for (const n of name) {
+		if (!fs.existsSync(path.join(LOCK_PATH, 'lock-' + n))) {
+			return false;
+		}
+	}
+
+	console.warn('skipping', name, 'as it previously passed on CI');
+	return true;
 };
 
 export const markComplete = (name) => {

--- a/e2e/lightning.e2e.js
+++ b/e2e/lightning.e2e.js
@@ -13,7 +13,9 @@ import initWaitForElectrumToSync from '../__tests__/utils/wait-for-electrum';
 
 const __DEV__ = process.env.DEBUG === 'true';
 
-describe('Lightning', () => {
+d = checkComplete('lighting-1') ? describe.skip : describe;
+
+d('Lightning', () => {
 	let waitForElectrum;
 	const rpc = new BitcoinJsonRpc(bitcoinURL);
 
@@ -43,7 +45,7 @@ describe('Lightning', () => {
 		waitForElectrum?.close();
 	});
 
-	describe('Receive and Send', () => {
+	d('Receive and Send', () => {
 		// Test plan:
 		// - connect to LND node
 		// - receive funds

--- a/e2e/newWallet.e2e.js
+++ b/e2e/newWallet.e2e.js
@@ -1,13 +1,11 @@
 import { checkComplete, markComplete } from './helpers';
 
-describe('New Wallet', () => {
+d = checkComplete('newwallet-1') ? describe.skip : describe;
+
+d('New Wallet', () => {
 	beforeAll(async () => {
 		await device.launchApp();
 	});
-
-	// beforeEach(async () => {
-	// 	await device.reloadReactNative();
-	// });
 
 	it('should create new wallet', async () => {
 		if (checkComplete('newwallet-1')) {

--- a/e2e/numberpad.e2e.js
+++ b/e2e/numberpad.e2e.js
@@ -5,7 +5,9 @@ import {
 	launchAndWait,
 } from './helpers';
 
-describe('NumberPad', () => {
+d = checkComplete(['numberpad-1', 'numberpad-2']) ? describe.skip : describe;
+
+d('NumberPad', () => {
 	beforeAll(async () => {
 		await completeOnboarding();
 	});

--- a/e2e/onchain.e2e.js
+++ b/e2e/onchain.e2e.js
@@ -10,7 +10,9 @@ import {
 } from './helpers';
 import initWaitForElectrumToSync from '../__tests__/utils/wait-for-electrum';
 
-describe('Onchain', () => {
+d = checkComplete(['onchain-1', 'onchain-2']) ? describe.skip : describe;
+
+d('Onchain', () => {
 	let waitForElectrum;
 	const rpc = new BitcoinJsonRpc(bitcoinURL);
 
@@ -40,7 +42,7 @@ describe('Onchain', () => {
 		waitForElectrum?.close();
 	});
 
-	describe('Receive and Send', () => {
+	d('Receive and Send', () => {
 		// Test plan
 		// - can receive to 2 addresses and tag them
 		// - shows correct total balance

--- a/e2e/receive.e2e.js
+++ b/e2e/receive.e2e.js
@@ -6,7 +6,9 @@ import {
 	sleep,
 } from './helpers';
 
-describe('Receive', () => {
+d = checkComplete('receive-1') ? describe.skip : describe;
+
+d('Receive', () => {
 	beforeAll(async () => {
 		await completeOnboarding();
 	});
@@ -37,7 +39,7 @@ describe('Receive', () => {
 	// - can delete prev saved tag
 
 	it('Basic functionality', async () => {
-		if (checkComplete('receive-1-1')) {
+		if (checkComplete('receive-1')) {
 			return;
 		}
 
@@ -122,6 +124,6 @@ describe('Receive', () => {
 		await element(by.id(`Tag-${tag}-delete`)).tap();
 		await expect(element(by.text(tag))).not.toBeVisible();
 
-		markComplete('receive-1-1');
+		markComplete('receive-1');
 	});
 });

--- a/e2e/settings.e2e.js
+++ b/e2e/settings.e2e.js
@@ -8,7 +8,22 @@ import {
 
 const __DEV__ = process.env.DEBUG === 'true';
 
-describe('Settings', () => {
+d = checkComplete([
+	'settings-1',
+	'settings-2',
+	'settings-3',
+	'settings-4',
+	'settings-5',
+	'settings-6',
+	'settings-7',
+	'settings-8',
+	'settings-9',
+	'settings-10',
+])
+	? describe.skip
+	: describe;
+
+d('Settings', () => {
 	beforeAll(async () => {
 		await completeOnboarding();
 	});
@@ -17,7 +32,7 @@ describe('Settings', () => {
 		await launchAndWait();
 	});
 
-	describe('General', () => {
+	d('General', () => {
 		it('Can switch local currency', async () => {
 			if (checkComplete('settings-1')) {
 				return;
@@ -146,7 +161,7 @@ describe('Settings', () => {
 		});
 
 		it('Can remove last used tags', async () => {
-			if (checkComplete('s-1-5')) {
+			if (checkComplete('settings-5')) {
 				return;
 			}
 
@@ -185,11 +200,11 @@ describe('Settings', () => {
 			await element(by.id('TagsAdd')).tap();
 			await expect(element(by.text(tag))).not.toBeVisible();
 
-			markComplete('s-1-5');
+			markComplete('settings-5');
 		});
 	});
 
-	describe('Backup or restore', () => {
+	d('Backup or restore', () => {
 		it('Can show backup and validate it', async () => {
 			if (checkComplete('settings-6')) {
 				return;
@@ -226,7 +241,7 @@ describe('Settings', () => {
 		});
 	});
 
-	describe('Advanced', () => {
+	d('Advanced', () => {
 		it('Can switch address types', async () => {
 			if (checkComplete('settings-7')) {
 				return;
@@ -379,7 +394,7 @@ describe('Settings', () => {
 		});
 	});
 
-	describe('Dev Settings', () => {
+	d('Dev Settings', () => {
 		it('Shows the crash error screen when triggering render error', async () => {
 			if (checkComplete('settings-10')) {
 				return;
@@ -406,7 +421,7 @@ describe('Settings', () => {
 		});
 	});
 
-	describe('Security and Privacy', () => {
+	d('Security and Privacy', () => {
 		it('Can setup PIN and Biometrics', async () => {
 			// test plan:
 			// - set up PIN with Biometrics
@@ -416,7 +431,7 @@ describe('Settings', () => {
 			// - login with PIN
 			// - disable PIN
 			// - enter wrong PIN 10 times and reset the app
-			if (checkComplete('settings-5')) {
+			if (checkComplete('settings-11')) {
 				return;
 			}
 
@@ -540,7 +555,7 @@ describe('Settings', () => {
 			// await device.launchApp({ newInstance: true });
 			// await waitFor(element(by.id('Check1'))).toBeVisible();
 
-			markComplete('settings-5');
+			markComplete('settings-11');
 		});
 	});
 });

--- a/e2e/slashtags.e2e.js
+++ b/e2e/slashtags.e2e.js
@@ -12,7 +12,9 @@ import initWaitForElectrumToSync from '../__tests__/utils/wait-for-electrum';
 
 const __DEV__ = process.env.DEBUG === 'true';
 
-describe('Profile and Contacts', () => {
+d = checkComplete('slash-1') ? describe.skip : describe;
+
+d('Profile and Contacts', () => {
 	let waitForElectrum;
 	const rpc = new BitcoinJsonRpc(bitcoinURL);
 
@@ -42,7 +44,7 @@ describe('Profile and Contacts', () => {
 		waitForElectrum?.close();
 	});
 
-	describe('Slashtags', () => {
+	d('Slashtags', () => {
 		// Test plan
 		// - create new profile
 		// - edit profile


### PR DESCRIPTION
### Description

Now when CI re-runs partly complete e2e tests all `beforeAll` and `beforeEach` helpers are executed, which takes a lot of time. Now if all tests in file are completed it will be skipped with describe.skip. 

This should speedup tests for 20 minutes or so

### Type of change

Refactoring

### Tests

Detox test
