### PR TITLE
fix(lightning): add peers on ldk refresh

### DIFF
--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -482,6 +482,7 @@ export const refreshLdk = async ({
 		if (syncRes.isErr()) {
 			return err(syncRes.error.message);
 		}
+		await addPeers({ selectedNetwork, selectedWallet });
 		await updateLightningChannels({ selectedWallet, selectedNetwork });
 		await updateClaimableBalance({ selectedNetwork, selectedWallet });
 		return ok('');


### PR DESCRIPTION
### Description

We’re adding peers when buying a channel, creating invoice and paying an invoice but we need to add on startup/refresh in the case of a channel queued for opening.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
