### PR TITLE
feat(wallet): Send To P2TR

### DIFF
--- a/__tests__/wallet.ts
+++ b/__tests__/wallet.ts
@@ -2,27 +2,10 @@ import * as bip39 from 'bip39';
 
 // Fix 'getDispatch is not a function'
 import '../src/store/actions/ui';
-import {
-	deriveMnemonicPhrases,
-	slashtagsPrimaryKey,
-} from '../src/utils/wallet';
+import { slashtagsPrimaryKey } from '../src/utils/wallet';
 import { mnemonic } from './utils/dummy-wallet';
 
 describe('Wallet Methods', () => {
-	it('Derive multiple mnemonic phrases for lightning and tokens via the on-chain phrase.', async () => {
-		const res = await deriveMnemonicPhrases(mnemonic);
-		if (res.isErr()) {
-			throw res.error;
-		}
-		expect(res.value.onchain).toEqual(mnemonic);
-		expect(res.value.lightning).toEqual(
-			'old found shock tenant merit tower foster chase sauce stool book enhance public key whip group retreat member cabin blanket sorry pole gym wink',
-		);
-		expect(res.value.tokens).toEqual(
-			'inspire sick rule wild near rebuild pride tomato shell come drip reduce street steel warrior project radar sister day title spice execute evolve outside',
-		);
-	});
-
 	it('Derive slashtags primay key from the Seed', async () => {
 		const seed = await bip39.mnemonicToSeed(mnemonic);
 		const slashtags = await slashtagsPrimaryKey(seed);

--- a/nodejs-assets/nodejs-project/bitcoin-actions.js
+++ b/nodejs-assets/nodejs-project/bitcoin-actions.js
@@ -1,12 +1,10 @@
-const networks = require("./networks");
-const bip39 = require("bip39");
+const networks = require('./networks');
+const bip39 = require('bip39');
 const ecc = require('./nobleSecp256k1Wrapper');
 const BIP32Factory = require('bip32').BIP32Factory;
 const bip32 = BIP32Factory(ecc);
-const bitcoin = require("bitcoinjs-lib");
-const {
-    sha256,
-} = require("./utils");
+const bitcoin = require('bitcoinjs-lib');
+const { sha256 } = require('./utils');
 
 class BitcoinActions {
     constructor() {

--- a/nodejs-assets/nodejs-project/package.json
+++ b/nodejs-assets/nodejs-project/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@noble/secp256k1": "^1.7.0",
-    "bip32": "github:synonymdev/bip32#58f0dd7d253d70fa5ff442997464892c46874348",
+    "bip32": "^3.1.0",
     "bip39": "^3.0.4",
     "bitcoinjs-lib": "^6.0.1",
     "create-hmac": "^1.1.7"

--- a/nodejs-assets/nodejs-project/yarn.lock
+++ b/nodejs-assets/nodejs-project/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@noble/secp256k1@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.0.tgz#d15357f7c227e751d90aa06b05a0e5cf993ba8c1"
-  integrity sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
+  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
 "@types/node@11.11.6":
   version "11.11.6"
@@ -29,9 +29,10 @@ bip174@^2.0.1:
   resolved "https://registry.yarnpkg.com/bip174/-/bip174-2.1.0.tgz#cd3402581feaa5116f0f00a0eaee87a5843a2d30"
   integrity sha512-lkc0XyiX9E9KiVAS1ZiOqK1xfiwvf4FXDDdkDq5crcDzOq+xGytY+14qCsqz7kCiy8rpN1CRNfacRhf9G3JNSA==
 
-"bip32@github:synonymdev/bip32#58f0dd7d253d70fa5ff442997464892c46874348":
+bip32@^3.1.0:
   version "3.1.0"
-  resolved "https://codeload.github.com/synonymdev/bip32/tar.gz/58f0dd7d253d70fa5ff442997464892c46874348"
+  resolved "https://registry.yarnpkg.com/bip32/-/bip32-3.1.0.tgz#ce90e020d0e6b41e891a0122ff053efabcce1ccc"
+  integrity sha512-eoeajYEzJ4d6yyVtby8C+XkCeKItiC4Mx56a0M9VaqTMC73SWOm4xVZG7SaR8e/yp4eSyky2XcBpH3DApPdu7Q==
   dependencies:
     bs58check "^2.1.1"
     create-hash "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "postinstall": "node postinstall.js"
   },
   "dependencies": {
+    "@bitcoinerlab/secp256k1": "^1.0.5",
     "@formatjs/intl-datetimeformat": "6.5.1",
     "@formatjs/intl-getcanonicallocales": "2.1.0",
     "@formatjs/intl-locale": "^3.1.1",
@@ -58,12 +59,13 @@
     "@synonymdev/slashtags-sdk": "1.0.0-alpha.38",
     "assert": "^2.0.0",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
+    "bech32": "^2.0.0",
     "bip21": "^2.0.3",
-    "bip32": "^2.0.6",
+    "bip32": "^4.0.0",
     "bip39": "^3.0.4",
     "bitcoin-address-validation": "^2.2.1",
     "bitcoin-units": "^0.3.0",
-    "bitcoinjs-lib": "^6.0.1",
+    "bitcoinjs-lib": "^6.1.3",
     "bitcoinjs-message": "^2.2.0",
     "buffer": "^6.0.3",
     "compact-encoding": "^2.11.0",

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -56,7 +56,9 @@ export type TGetByteCountInput =
 	| 'P2WPKH'
 	| 'p2wpkh'
 	| 'P2SH'
-	| 'p2sh';
+	| 'p2sh'
+	| 'P2TR'
+	| 'p2tr';
 
 export type TGetByteCountOutput =
 	| 'P2SH'
@@ -65,7 +67,9 @@ export type TGetByteCountOutput =
 	| 'P2WSH'
 	| 'p2wpkh'
 	| 'p2sh'
-	| 'p2pkh';
+	| 'p2pkh'
+	| 'P2TR'
+	| 'p2tr';
 
 export type TGetByteCountInputs = {
 	[key in TGetByteCountInput]?: number;

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -3,7 +3,8 @@ import { getAddressInfo } from 'bitcoin-address-validation';
 import { constants } from '@synonymdev/slashtags-sdk';
 import * as bitcoin from 'bitcoinjs-lib';
 import * as bip39 from 'bip39';
-import * as bip32 from 'bip32';
+import { BIP32Factory } from 'bip32';
+import ecc from '@bitcoinerlab/secp256k1';
 import { err, ok, Result } from '@synonymdev/result';
 
 import { networks, TAvailableNetworks } from '../networks';
@@ -90,6 +91,9 @@ import { refreshOrdersList } from '../../store/actions/blocktank';
 import { IDefaultLightningShape } from '../../store/types/lightning';
 import { showNewTxPrompt } from '../../store/actions/ui';
 import { objectKeys } from '../objectKeys';
+
+bitcoin.initEccLib(ecc);
+const bip32 = BIP32Factory(ecc);
 
 export const refreshWallet = async ({
 	onchain = true,

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -532,53 +532,6 @@ export const getMnemonicPhrase = async (
 };
 
 /**
- * Generate a mnemonic phrase using a string as entropy.
- * @param {string} str
- * @return {string}
- */
-export const generateMnemonicPhraseFromEntropy = (str: string): string => {
-	// @ts-ignore
-	const hash = getSha256(str);
-	return bip39.entropyToMnemonic(hash);
-};
-
-/**
- * Derive multiple mnemonic phrases by appending a
- * descriptive string to the original mnemonic.
- * @param {string} mnemonic
- */
-export const deriveMnemonicPhrases = async (
-	mnemonic: string,
-): Promise<
-	Result<{
-		onchain: string;
-		lightning: string;
-		tokens: string;
-	}>
-> => {
-	if (!mnemonic) {
-		return err('Please provide a mnemonic phrase.');
-	}
-	const isValid = validateMnemonic(mnemonic);
-	if (!isValid) {
-		return err('Mnemonic provided is not valid.');
-	}
-	const onchain = mnemonic;
-	const lightning = generateMnemonicPhraseFromEntropy(`${mnemonic}lightning`);
-	const tokens = generateMnemonicPhraseFromEntropy(`${mnemonic}tokens`);
-	return ok({ onchain, lightning, tokens });
-};
-
-/**
- * Returns sha256 hash of string.
- * @param {Buffer} buff
- * @return {Buffer}
- */
-export const getSha256 = (buff: Buffer): Buffer => {
-	return bitcoin.crypto.sha256(buff);
-};
-
-/**
  * Generate a mnemonic phrase.
  * @async
  * @param {number} strength

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -1,6 +1,6 @@
 import * as bip21 from 'bip21';
-import * as bip32 from 'bip32';
-import { BIP32Interface } from 'bip32';
+import ecc from '@bitcoinerlab/secp256k1';
+import { BIP32Factory, BIP32Interface } from 'bip32';
 import * as bip39 from 'bip39';
 import * as bitcoin from 'bitcoinjs-lib';
 import { Psbt } from 'bitcoinjs-lib';
@@ -66,6 +66,9 @@ import { EFeeId, IOnchainFees } from '../../store/types/fees';
 import { defaultFeesShape } from '../../store/shapes/fees';
 import { TRANSACTION_DEFAULTS } from './constants';
 import i18n from '../i18n';
+
+bitcoin.initEccLib(ecc);
+const bip32 = BIP32Factory(ecc);
 
 /*
  * Attempts to parse any given string as an on-chain payment request.
@@ -219,6 +222,8 @@ export const getByteCount = (
 				P2SH: 108 + 64 * 4,
 				p2sh: 108 + 64 * 4 + 1,
 				'P2SH-P2WPKH': 108 + 64 * 4,
+				P2TR: 57.5 * 4,
+				p2tr: 57.5 * 4 + 1,
 			},
 			multiSigInputs: {
 				'MULTISIG-P2SH': 49 * 4,
@@ -233,6 +238,8 @@ export const getByteCount = (
 				p2wpkh: 31 * 4 + 1,
 				p2sh: 32 * 4 + 1,
 				p2pkh: 34 * 4 + 1,
+				P2TR: 43 * 4,
+				p2tr: 43 * 4 + 1,
 			},
 		};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,6 +1244,14 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@bitcoinerlab/secp256k1@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@bitcoinerlab/secp256k1/-/secp256k1-1.0.5.tgz#4643ba73619c24c7c455cc63c6338c69c2cf187c"
+  integrity sha512-8gT+ukTCFN2rTxn4hD9Jq3k+UJwcprgYjfK/SQUSLgznXoIgsBnlPuARMkyyuEjycQK9VvnPiejKdszVTflh+w==
+  dependencies:
+    "@noble/hashes" "^1.1.5"
+    "@noble/secp256k1" "^1.7.1"
+
 "@commitlint/cli@^17.6.3":
   version "17.6.3"
   resolved "https://registry.yarnpkg.com/@commitlint/cli/-/cli-17.6.3.tgz#a02194a2bb6efe4e681eda2addd072a8d02c9497"
@@ -2136,10 +2144,20 @@
   dependencies:
     eslint-scope "5.1.1"
 
+"@noble/hashes@^1.1.5":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.1.tgz#8831ef002114670c603c458ab8b11328406953a9"
+  integrity sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==
+
 "@noble/hashes@^1.2.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.0.tgz#085fd70f6d7d9d109671090ccae1d3bec62554a1"
   integrity sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==
+
+"@noble/secp256k1@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.7.1.tgz#b251c70f824ce3ca7f8dc3df08d58f005cc0507c"
+  integrity sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2534,6 +2552,11 @@
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@sayem314/react-native-keep-awake/-/react-native-keep-awake-1.2.0.tgz#72b0bbd6ed23dbef804a4c4ed431a3411e7976a2"
   integrity sha512-ZqGkxkPWT1p0qnZRS3ZvIpg3Bfv5j6QIcKAzniPZw30dMUbAgsJvPrsJU8ai34071sQm8mlyc7LgHLZh4Rhn6A==
+
+"@scure/base@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
+  integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
 
 "@shopify/react-native-skia@0.1.182":
   version "0.1.182"
@@ -3814,6 +3837,11 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
+base-x@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.0.tgz#d0e3b7753450c73f8ad2389b5c018a4af7b2224a"
+  integrity sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw==
+
 base58-js@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/base58-js/-/base58-js-1.0.5.tgz#00697bff954aa85007fa45ce76b699b7960768cd"
@@ -3908,6 +3936,16 @@ bip32@^2.0.6:
     typeforce "^1.11.5"
     wif "^2.0.6"
 
+bip32@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/bip32/-/bip32-4.0.0.tgz#7fac3c05072188d2d355a4d6596b37188f06aa2f"
+  integrity sha512-aOGy88DDlVUhspIXJN+dVEtclhIsfAUppD43V0j40cPTld3pv/0X/MlrZSZ6jowIaQQzFwP8M6rFU2z2mVYjDQ==
+  dependencies:
+    "@noble/hashes" "^1.2.0"
+    "@scure/base" "^1.1.1"
+    typeforce "^1.11.5"
+    wif "^2.0.6"
+
 bip39@^3.0.4:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.1.0.tgz#c55a418deaf48826a6ceb34ac55b3ee1577e18a3"
@@ -3950,7 +3988,7 @@ bitcoin-units@^0.3.0:
   dependencies:
     big.js "^5.2.2"
 
-bitcoinjs-lib@^6.0.1, bitcoinjs-lib@^6.0.2:
+bitcoinjs-lib@^6.0.2:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/bitcoinjs-lib/-/bitcoinjs-lib-6.1.0.tgz#2e3123d63eab5e8e752fd7e2f237314f35ed738f"
   integrity sha512-eupi1FBTJmPuAZdChnzTXLv2HBqFW2AICpzXZQLniP0V9FWWeeUQSMKES6sP8isy/xO0ijDexbgkdEyFVrsuJw==
@@ -3963,6 +4001,18 @@ bitcoinjs-lib@^6.0.1, bitcoinjs-lib@^6.0.2:
     typeforce "^1.11.3"
     varuint-bitcoin "^1.1.2"
     wif "^2.0.1"
+
+bitcoinjs-lib@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/bitcoinjs-lib/-/bitcoinjs-lib-6.1.3.tgz#88aed5a8d052e9faa04c6402d3f0865441f928d7"
+  integrity sha512-TYXs/Qf+GNk2nnsB9HrXWqzFuEgCg0Gx+v3UW3B8VuceFHXVvhT+7hRnTSvwkX0i8rz2rtujeU6gFaDcFqYFDw==
+  dependencies:
+    "@noble/hashes" "^1.2.0"
+    bech32 "^2.0.0"
+    bip174 "^2.1.0"
+    bs58check "^3.0.1"
+    typeforce "^1.11.3"
+    varuint-bitcoin "^1.1.2"
 
 bitcoinjs-message@^2.2.0:
   version "2.2.0"
@@ -4189,6 +4239,13 @@ bs58@^4.0.0:
   dependencies:
     base-x "^3.0.2"
 
+bs58@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
+  integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==
+  dependencies:
+    base-x "^4.0.0"
+
 bs58check@<3.0.0, bs58check@^2.1.1, bs58check@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
@@ -4197,6 +4254,14 @@ bs58check@<3.0.0, bs58check@^2.1.1, bs58check@^2.1.2:
     bs58 "^4.0.0"
     create-hash "^1.1.0"
     safe-buffer "^5.1.2"
+
+bs58check@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-3.0.1.tgz#2094d13720a28593de1cba1d8c4e48602fdd841c"
+  integrity sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==
+  dependencies:
+    "@noble/hashes" "^1.2.0"
+    bs58 "^5.0.0"
 
 bser@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
### Description
This PR allows users to scan and send to taproot addresses.

- Added check for taproot addresses.
- Added `@bitcoinerlab/secp256k1` & `bech32` dependencies to `package.json`.
- Upgraded `bip32` & `bitcoinjs-lib` dependencies in `package.json`.
- Upgraded `bip32` dependency in `nodejs-project`.
- Added and implemented `isValidBech32mEncodedString` in `utils/scanner.ts`.
- Updated `ecc` implementations as needed throughout the app.
- Added `p2tr` types as needed.
- Removed `generateMnemonicPhraseFromEntropy`, `deriveMnemonicPhrases` & `getSha256` methods.
- Removed test from "Wallet Methods" in `__tests__/wallet.ts`.
- Added a create transaction test that spends to a taproot address.

### Linked Issues/Tasks
- #1044

### Type of change
- [x] New feature (non-breaking change which adds functionality)

### Tests
- [x] No test

### QA Notes
- To test, ensure you are able to successfully scan and send sats to a taproot address.
