### PR TITLE
fix: #1180 PIN when idle on Android

### DIFF
--- a/src/components/AuthCheck.tsx
+++ b/src/components/AuthCheck.tsx
@@ -31,22 +31,26 @@ const AuthCheck = ({
 	const requirePin = route?.params?.requirePin ?? false;
 	onSuccess = route?.params?.onSuccess ?? onSuccess;
 
-	return (
-		<Animated.View style={StyleSheet.absoluteFillObject} exiting={FadeOut}>
-			{requireBiometrics && !requirePin ? (
+	if (requireBiometrics && !requirePin) {
+		return (
+			<Animated.View style={StyleSheet.absoluteFillObject} exiting={FadeOut}>
 				<GlowingBackground topLeft="brand">
 					<Biometrics
 						onSuccess={(): void => onSuccess?.()}
 						onFailure={(): void => setRequireBiometrics(false)}
 					/>
 				</GlowingBackground>
-			) : (
-				<PinPad
-					showBackNavigation={showBackNavigation}
-					showLogoOnPIN={showLogoOnPIN}
-					onSuccess={(): void => onSuccess?.()}
-				/>
-			)}
+			</Animated.View>
+		);
+	}
+
+	return (
+		<Animated.View style={StyleSheet.absoluteFillObject} exiting={FadeOut}>
+			<PinPad
+				showBackNavigation={showBackNavigation}
+				showLogoOnPIN={showLogoOnPIN}
+				onSuccess={(): void => onSuccess?.()}
+			/>
 		</Animated.View>
 	);
 };

--- a/src/components/InactivityTracker.tsx
+++ b/src/components/InactivityTracker.tsx
@@ -50,8 +50,10 @@ const InactivityTracker = ({
 		});
 	}, [resetInactivityTimeout]);
 
+	const panProps = pinOnIdle ? panResponder.panHandlers : {};
+
 	return (
-		<View style={styles.root} {...panResponder.panHandlers}>
+		<View style={styles.root} {...panProps}>
 			{children}
 		</View>
 	);

--- a/src/utils/i18n/locales/en/lightning.json
+++ b/src/utils/i18n/locales/en/lightning.json
@@ -41,7 +41,7 @@
 	"setting_up_step4": "Opening Connection",
 	"result_header": "Connecting",
 	"result_text": "Lightning connection initiated. You will be able to use instant payments in ±10 minutes.",
-	"timeout_header": "Timed Out",
+	"timeout_header": "Please keep Bitkit open.",
 	"timeout_text": "Bitkit will keep trying to open your Lightning connection in the background. Please keep the app open.",
 	"awesome": "Awesome!",
 	"transfer_funds": "Transfer Funds",

--- a/src/utils/i18n/locales/en/other.json
+++ b/src/utils/i18n/locales/en/other.json
@@ -73,5 +73,5 @@
 	"high_text2_beta": "Please consider moving some of your funds. We recommend using only small amounts while Bitkit is in beta.",
 	"high_button_more": "Learn More",
 	"caution_header": "Caution:\n<yellow>Beta Risk.</yellow>",
-	"caution_text": "Beta software may put your money at risk. We recommend using only small amounts (like $10) while Bitkit is in beta."
+	"caution_text": "Beta software may put your money at risk. We recommend using only small amounts while Bitkit is in beta."
 }


### PR DESCRIPTION
### Description

Fixes "PIN when idle" feature for Android. Also updates some copy. 

### Linked Issues/Tasks

Closes #1180 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

Make sure the auth check after 90 seconds if the setting is enabled.

Check that interaction with "Clipboard ease-of-use" and PIN works correctly:

1. enable clipboard ease-of-use

- app start / normal -> no redirect
- app start / with deep link -> should redirect
- app start / with clipboard data -> should offer redirect
- app to foreground / normal -> no redirect
- app to foreground / with deep link -> should redirect
- app to foreground / with clipboard data -> should offer redirect

2. enable PIN on launch & PIN when idle

- app start w/ pinOnLaunch / normal -> should show PIN check
- app start w/ pinOnLaunch / with deep link -> should show PIN check and redirect
- app start w/ pinOnLaunch / with clipboard data -> should show PIN check and offer redirect
- app to foreground w/ pinOnIdle / normal -> should show PIN check
- app to foreground w/ pinOnIdle / with deep link -> should show PIN check and redirect
- app to foreground w/ pinOnIdle / with clipboard data -> should show PIN check and offer redirect
