### PR TITLE
fix(send): multiple dialogs

### DIFF
--- a/e2e/onchain.e2e.js
+++ b/e2e/onchain.e2e.js
@@ -48,7 +48,7 @@ d('Onchain', () => {
 		// - shows correct total balance
 		// - can send total balance and tag the tx
 		// - no exceeding availableAmount
-		// - shows a warning for sending over 50% of total
+		// - shows warnings for sending over 100$ or 50% of total
 		// - avoid creating dust output
 		// - TODO: coin selectiom
 
@@ -125,7 +125,7 @@ d('Onchain', () => {
 			await element(by.id('GRAB')).swipe('right'); // Swipe to confirm
 
 			await sleep(1000); // animation
-			await waitFor(element(by.id('DialogSend50'))) // sending over 50% of balance warning
+			await waitFor(element(by.id('SendDialog2'))) // sending over 50% of balance warning
 				.toBeVisible()
 				.withTimeout(10000);
 			await sleep(1000); // animation
@@ -251,6 +251,13 @@ d('Onchain', () => {
 			await sleep(1000); // animation
 
 			const coreAddress = await rpc.getNewAddress();
+
+			// enable warning for sending over 100$ to test multiple warning dialogs
+			await element(by.id('Settings')).tap();
+			await element(by.id('SecuritySettings')).tap();
+			await element(by.id('SendAmountWarning')).tap();
+			await element(by.id('NavigationClose')).tap();
+
 			await element(by.id('Send')).tap();
 			await sleep(1000); // animation
 			await element(by.id('RecipientInput')).replaceText(coreAddress);
@@ -275,12 +282,22 @@ d('Onchain', () => {
 
 			// TODO: check correct fee
 
+			// sending over 50% of balance warning
 			await sleep(1000); // animation
-			await waitFor(element(by.id('DialogSend50'))) // sending over 50% of balance warning
+			await waitFor(element(by.id('SendDialog2')))
 				.toBeVisible()
 				.withTimeout(10000);
 			await sleep(1000); // animation
 			await element(by.id('DialogConfirm')).tap();
+
+			// sending over 100$ warning
+			await sleep(1000); // animation
+			await waitFor(element(by.id('SendDialog1')))
+				.toBeVisible()
+				.withTimeout(10000);
+			await sleep(1000); // animation
+			await element(by.id('DialogConfirm')).tap();
+
 			await waitFor(element(by.id('SendSuccess')))
 				.toBeVisible()
 				.withTimeout(10000);

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,18 +1,17 @@
 import React, { memo, ReactElement } from 'react';
 import {
-	Modal,
-	ModalProps,
 	StyleSheet,
 	Text,
 	View,
 	Platform,
 	TouchableOpacity,
 } from 'react-native';
+import Modal from 'react-native-modal';
 import { useTranslation } from 'react-i18next';
 
 import colors from '../styles/colors';
 
-type DialogProps = ModalProps & {
+type DialogProps = {
 	visible: boolean;
 	title: string;
 	description: string;
@@ -21,6 +20,7 @@ type DialogProps = ModalProps & {
 	visibleTestID?: string;
 	onCancel?: () => void;
 	onConfirm?: () => void;
+	onHide?: () => void;
 };
 
 const Dialog = ({
@@ -32,7 +32,7 @@ const Dialog = ({
 	visibleTestID,
 	onCancel,
 	onConfirm,
-	onRequestClose,
+	onHide,
 }: DialogProps): ReactElement => {
 	const { t } = useTranslation('common');
 
@@ -44,58 +44,46 @@ const Dialog = ({
 	}
 
 	return (
-		<>
-			{visible && (
-				<View>
-					<Modal
-						animationType="fade"
-						transparent={true}
-						visible={visible}
-						onRequestClose={onRequestClose}>
-						<View style={styles.centeredView}>
-							<View style={styles.view}>
-								<View style={styles.text}>
-									<Text style={styles.title}>{title}</Text>
-									<Text style={styles.description}>{description}</Text>
-								</View>
-								<View
-									style={styles.buttons}
-									testID={visible ? visibleTestID : undefined}>
-									{onCancel && (
-										<TouchableOpacity
-											style={[styles.button, styles.buttonLeft]}
-											onPress={onCancel}
-											testID="DialogCancel">
-											<Text style={styles.buttonText}>{cancelText}</Text>
-										</TouchableOpacity>
-									)}
-									{onConfirm && (
-										<TouchableOpacity
-											style={styles.button}
-											onPress={onConfirm}
-											testID="DialogConfirm">
-											<Text style={styles.buttonText}>{confirmText}</Text>
-										</TouchableOpacity>
-									)}
-								</View>
-							</View>
-						</View>
-					</Modal>
+		<Modal
+			isVisible={visible}
+			animationIn="fadeIn"
+			animationOut="fadeOut"
+			useNativeDriverForBackdrop={true}
+			onModalHide={onHide}>
+			<View style={styles.content}>
+				<View style={styles.text}>
+					<Text style={styles.title}>{title}</Text>
+					<Text style={styles.description}>{description}</Text>
 				</View>
-			)}
-		</>
+				<View
+					style={styles.buttons}
+					testID={visible ? visibleTestID : undefined}>
+					{onCancel && (
+						<TouchableOpacity
+							style={[styles.button, styles.buttonLeft]}
+							onPress={onCancel}
+							testID="DialogCancel">
+							<Text style={styles.buttonText}>{cancelText}</Text>
+						</TouchableOpacity>
+					)}
+					{onConfirm && (
+						<TouchableOpacity
+							style={styles.button}
+							onPress={onConfirm}
+							testID="DialogConfirm">
+							<Text style={styles.buttonText}>{confirmText}</Text>
+						</TouchableOpacity>
+					)}
+				</View>
+			</View>
+		</Modal>
 	);
 };
 
 const styles = StyleSheet.create({
-	centeredView: {
-		backgroundColor: 'rgba(0, 0, 0, 0.6)',
-		flex: 1,
-		justifyContent: 'center',
-		alignItems: 'center',
-	},
-	view: {
+	content: {
 		backgroundColor: 'rgba(49, 49, 49, 1)',
+		alignSelf: 'center',
 		alignItems: 'center',
 		color: colors.white,
 		shadowColor: colors.black,

--- a/src/screens/Settings/Security/index.tsx
+++ b/src/screens/Settings/Security/index.tsx
@@ -58,6 +58,7 @@ const SecuritySettings = ({
 						title: t('security.clipboard'),
 						type: EItemType.switch,
 						enabled: enableAutoReadClipboard,
+						testID: 'AutoReadClipboard',
 						onPress: (): void => {
 							updateSettings({
 								enableAutoReadClipboard: !enableAutoReadClipboard,
@@ -68,6 +69,7 @@ const SecuritySettings = ({
 						title: t('security.warn_100'),
 						type: EItemType.switch,
 						enabled: enableSendAmountWarning,
+						testID: 'SendAmountWarning',
 						onPress: (): void => {
 							updateSettings({
 								enableSendAmountWarning: !enableSendAmountWarning,

--- a/src/screens/Wallets/Send/ReviewAndSend.tsx
+++ b/src/screens/Wallets/Send/ReviewAndSend.tsx
@@ -727,14 +727,12 @@ const ReviewAndSend = ({
 					title={t('are_you_sure')}
 					description={t('send_dialog1')}
 					confirmText={t('send_yes')}
-					onCancel={async (): Promise<void> => {
+					onHide={(): void => confirmPayment(dialogWarnings)}
+					onConfirm={(): void => setShowDialog1(false)}
+					onCancel={(): void => {
 						setShowDialog1(false);
 						setIsLoading(false);
 						setTimeout(() => navigation.goBack(), 300);
-					}}
-					onConfirm={(): void => {
-						setShowDialog1(false);
-						confirmPayment(dialogWarnings);
 					}}
 				/>
 				<Dialog
@@ -742,30 +740,26 @@ const ReviewAndSend = ({
 					title={t('are_you_sure')}
 					description={t('send_dialog2')}
 					confirmText={t('send_yes')}
-					onCancel={async (): Promise<void> => {
+					visibleTestID="DialogSend50"
+					onHide={(): void => confirmPayment(dialogWarnings)}
+					onConfirm={(): void => setShowDialog2(false)}
+					onCancel={(): void => {
 						setShowDialog2(false);
 						setIsLoading(false);
 						setTimeout(() => navigation.goBack(), 300);
 					}}
-					onConfirm={(): void => {
-						setShowDialog2(false);
-						confirmPayment(dialogWarnings);
-					}}
-					visibleTestID="DialogSend50"
 				/>
 				<Dialog
 					visible={showDialog3}
 					title={t('are_you_sure')}
 					description={t('send_dialog3')}
 					confirmText={t('send_yes')}
-					onCancel={async (): Promise<void> => {
+					onHide={(): void => confirmPayment(dialogWarnings)}
+					onConfirm={(): void => setShowDialog3(false)}
+					onCancel={(): void => {
 						setShowDialog3(false);
 						setIsLoading(false);
 						setTimeout(() => navigation.goBack(), 300);
-					}}
-					onConfirm={(): void => {
-						setShowDialog3(false);
-						confirmPayment(dialogWarnings);
 					}}
 				/>
 				<Dialog
@@ -773,14 +767,12 @@ const ReviewAndSend = ({
 					title={t('are_you_sure')}
 					description={t('send_dialog4')}
 					confirmText={t('send_yes')}
-					onCancel={async (): Promise<void> => {
+					onHide={(): void => confirmPayment(dialogWarnings)}
+					onConfirm={(): void => setShowDialog4(false)}
+					onCancel={(): void => {
 						setShowDialog4(false);
 						setIsLoading(false);
 						setTimeout(() => navigation.goBack(), 300);
-					}}
-					onConfirm={(): void => {
-						setShowDialog4(false);
-						confirmPayment(dialogWarnings);
 					}}
 				/>
 				<Dialog
@@ -790,14 +782,12 @@ const ReviewAndSend = ({
 						minimumFee: feeEstimates.minimum,
 					})}
 					confirmText={t('continue')}
+					onHide={(): void => confirmPayment(dialogWarnings)}
+					onConfirm={async (): Promise<void> => setShowDialog5(false)}
 					onCancel={(): void => {
 						setShowDialog5(false);
 						setIsLoading(false);
 						setTimeout(() => navigation.goBack(), 300);
-					}}
-					onConfirm={async (): Promise<void> => {
-						setShowDialog5(false);
-						confirmPayment(dialogWarnings);
 					}}
 				/>
 				<SafeAreaInset type="bottom" minPadding={16} />

--- a/src/screens/Wallets/Send/ReviewAndSend.tsx
+++ b/src/screens/Wallets/Send/ReviewAndSend.tsx
@@ -727,6 +727,7 @@ const ReviewAndSend = ({
 					title={t('are_you_sure')}
 					description={t('send_dialog1')}
 					confirmText={t('send_yes')}
+					visibleTestID="SendDialog1"
 					onHide={(): void => confirmPayment(dialogWarnings)}
 					onConfirm={(): void => setShowDialog1(false)}
 					onCancel={(): void => {
@@ -740,7 +741,7 @@ const ReviewAndSend = ({
 					title={t('are_you_sure')}
 					description={t('send_dialog2')}
 					confirmText={t('send_yes')}
-					visibleTestID="DialogSend50"
+					visibleTestID="SendDialog2"
 					onHide={(): void => confirmPayment(dialogWarnings)}
 					onConfirm={(): void => setShowDialog2(false)}
 					onCancel={(): void => {
@@ -754,6 +755,7 @@ const ReviewAndSend = ({
 					title={t('are_you_sure')}
 					description={t('send_dialog3')}
 					confirmText={t('send_yes')}
+					visibleTestID="SendDialog3"
 					onHide={(): void => confirmPayment(dialogWarnings)}
 					onConfirm={(): void => setShowDialog3(false)}
 					onCancel={(): void => {
@@ -767,6 +769,7 @@ const ReviewAndSend = ({
 					title={t('are_you_sure')}
 					description={t('send_dialog4')}
 					confirmText={t('send_yes')}
+					visibleTestID="SendDialog4"
 					onHide={(): void => confirmPayment(dialogWarnings)}
 					onConfirm={(): void => setShowDialog4(false)}
 					onCancel={(): void => {
@@ -782,8 +785,9 @@ const ReviewAndSend = ({
 						minimumFee: feeEstimates.minimum,
 					})}
 					confirmText={t('continue')}
+					visibleTestID="SendDialog5"
 					onHide={(): void => confirmPayment(dialogWarnings)}
-					onConfirm={async (): Promise<void> => setShowDialog5(false)}
+					onConfirm={(): void => setShowDialog5(false)}
 					onCancel={(): void => {
 						setShowDialog5(false);
 						setIsLoading(false);


### PR DESCRIPTION
### Description

This fixes an issue where if multiple warning dialogs need to be shown in `ReviewAndSend` the UI would only show the first then get stuck on loading. Using `react-native-modal` now since the one shipped per default is buggy.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [x] Detox test
- [ ] Unit test
- [ ] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/8538369/abd65472-1226-4bee-8472-01d95e1486f5
