### PR TITLE
fix: refresh 410 blocktank order status

### DIFF
--- a/src/utils/blocktank/index.ts
+++ b/src/utils/blocktank/index.ts
@@ -19,7 +19,8 @@ import { setGeoBlock, updateUser } from '../../store/actions/user';
 import { refreshWallet } from '../wallet';
 
 // https://github.com/synonymdev/blocktank-server/blob/master/src/Orders/Order.js#L27
-export const unsettledStatuses = [0, 100, 200, 300, 350, 500];
+// 410 is "expired" status, but we refresh it anyway. This helps with the case where blocktank order was marked as "paid" by hand.
+export const unsettledStatuses = [0, 100, 200, 300, 350, 410, 500];
 
 /**
  * Sets the selectedNetwork for Blocktank.


### PR DESCRIPTION
### Description

Refresh blocktank order, even if it has expired status. This helps resolve situations, where payment eventually was confimed and blocktank operator marked it as PAID. Bitkit will refresh order and catch it up

### Type of change

Refactoring

### Tests

No test

### QA Notes

Hard to test
