### PR TITLE
fix: get fee in syncLightningTxsWithActivityList call

### DIFF
--- a/src/screens/Activity/ActivityDetail.tsx
+++ b/src/screens/Activity/ActivityDetail.tsx
@@ -891,8 +891,8 @@ const LightningActivityDetail = ({
 							/>
 							<Button
 								style={styles.button}
-								text={t('activity_connection')}
-								icon={<LightningIcon color="purple" />}
+								text={t('activity_explore')}
+								icon={<GitBranchIcon color="purple" />}
 								testID="ActivityTxDetails"
 								onPress={handleExplore}
 							/>

--- a/src/store/actions/lightning.ts
+++ b/src/store/actions/lightning.ts
@@ -389,7 +389,8 @@ export const syncLightningTxsWithActivityList = async (): Promise<
 			message: '',
 			address: '',
 			confirmed: tx.state === 'successful',
-			value: -sats,
+			value: sats,
+			fee: tx.fee_paid_sat ?? 0,
 			timestamp: tx.unix_timestamp * 1000,
 		});
 	}

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -114,7 +114,6 @@
 	"activity_boost": "Boost",
 	"activity_boosted": "Already Boosted",
 	"activity_explore": "Explore",
-	"activity_connection": "Connection",
 	"activity_tx_id": "Transaction ID",
 	"activity_payment_hash": "Payment hash",
 	"activity_address": "Address",


### PR DESCRIPTION
### Description

Get LN tx fee in syncLightningTxsWithActivityList function.

if we have syncLightningTxsWithActivityList called after each LN tx, maybe we don't need activity adding logic in payLightningInvoice?

### Linked Issues/Tasks

#1128 

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video

Insert relevant screenshot / recording

### QA Notes

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce during the Bitkit testing session. You can also leave a video of the PR in action.
