### PR TITLE
fix: throw error if LNURL withdraw min > max

### DIFF
--- a/src/utils/i18n/locales/en/other.json
+++ b/src/utils/i18n/locales/en/other.json
@@ -58,6 +58,7 @@
 	"lnurl_withdr_error_no_capacity": "Not enough inbound/receiving capacity to complete lnurl-withdraw request.",
 	"lnurl_withdr_error_create_invoice": "Unable to successfully create invoice for lnurl-withdraw.",
 	"lnurl_withdr_error_connect": "Unable to connect to LNURL withdraw server.",
+	"lnurl_withdr_error_minmax": "Wrong LNURL withdraw params, min/max not set correctly.",
 	"lnurl_withdr_success_title": "Withdraw Requested",
 	"lnurl_withdr_success_msg": "LNURL Withdraw was successfully requested.",
 	"bt_error_retrieve": "Unable To Retrieve Order Information",

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -872,6 +872,17 @@ export const handleData = async ({
 			params.minWithdrawable = Math.floor(params.minWithdrawable / 1000);
 			params.maxWithdrawable = Math.floor(params.maxWithdrawable / 1000);
 
+			if (params.minWithdrawable > params.maxWithdrawable) {
+				showToast({
+					type: 'error',
+					title: i18n.t('other:lnurl_withdr_error'),
+					description: i18n.t('other:lnurl_withdr_error_minmax'),
+				});
+				return err(
+					'Wrong lnurl-withdraw params: minWithdrawable > maxWithdrawable.',
+				);
+			}
+
 			// Determine if we have enough receiving capacity before proceeding.
 			const lightningBalance = getLightningBalance({
 				selectedWallet,


### PR DESCRIPTION
### Description

LN Markets generate wrong LNURLWithdraw, validate it and show error if it is not valid

### Linked Issues/Tasks

closes #942

### Type of change

Bug fix

### Tests

No test

### QA Notes

test LN Markets LNURL withdraw
