### PR TITLE
fix: channel purchase error calculation

### DIFF
--- a/src/store/actions/blocktank.ts
+++ b/src/store/actions/blocktank.ts
@@ -254,7 +254,9 @@ export const startChannelPurchase = async ({
 	// Ensure we have enough funds to pay for both the channel and the fee to broadcast the transaction.
 	if (buyChannelData.total_amount + transactionFee > onchainBalance) {
 		// TODO: Attempt to re-calculate a lower fee channel-open that's not instant if unable to pay.
-		const delta = Math.abs(channelOpenCost - onchainBalance);
+		const delta = Math.abs(
+			buyChannelData.total_amount + transactionFee - onchainBalance,
+		);
 		const cost = getDisplayValues({ satoshis: delta });
 		return err(
 			i18n.t('other:bt_channel_purchase_cost_error', {


### PR DESCRIPTION
### Description

Calculation is wrong. Delta should include buyChannelData.total_amount, not just buyChannelData.price

### Linked Issues/Tasks

closes #1207

### Type of change

Bug fix

### Tests

No test

### QA Notes

Send $7 to the wallet. Try open LN channel. Error message should depend on amount of channel you are trying to open
