### PR TITLE
fix: remove lnurl pay comment

### DIFF
--- a/src/utils/lnurl.ts
+++ b/src/utils/lnurl.ts
@@ -71,7 +71,10 @@ export const handleLnurlPay = async ({
 	const callbackRes = await lnurlPay({
 		params,
 		milliSats,
-		comment: 'Bitkit LNURL-Pay',
+		// comment should only be included if server asks for it with "commentAllowed"
+		// https://github.com/lnurl/luds/blob/luds/12.md
+		// comment: 'Bitkit LNURL-Pay',
+		comment: '',
 	});
 
 	if (callbackRes.isErr()) {


### PR DESCRIPTION
### Description

Comment should only be included if server asks for it with "commentAllowed"
https://github.com/lnurl/luds/blob/luds/12.md

Some services, like https://btcoriginstories.com/ fails if it is there 

### Linked Issues/Tasks

closes #1203

### Type of change

Bug fix

### Tests

No test

### QA Notes

test https://btcoriginstories.com/
