### PR TITLE
feat: show loading screen if LDK is not ready yet

### DIFF
--- a/src/components/LightningSyncing.tsx
+++ b/src/components/LightningSyncing.tsx
@@ -1,0 +1,121 @@
+import React, { ReactElement, useEffect, useState } from 'react';
+import { StyleSheet, View, ViewStyle } from 'react-native';
+import Animated, {
+	Easing,
+	cancelAnimation,
+	runOnJS,
+	useSharedValue,
+	withRepeat,
+	withTiming,
+} from 'react-native-reanimated';
+import { useTranslation } from 'react-i18next';
+import { useSelector } from 'react-redux';
+
+import { Text01S, Text02M } from '../styles/text';
+import { AnimatedView } from '../styles/components';
+import SafeAreaInset from './SafeAreaInset';
+import BottomSheetNavigationHeader from './BottomSheetNavigationHeader';
+import GlowImage from './GlowImage';
+import GradientView from './GradientView';
+import { isLDKReadySelector } from '../store/reselect/ui';
+import { __E2E__ } from '../constants/env';
+
+const imageSrc = require('../assets/illustrations/lightning.png');
+
+const LightningSyncing = ({
+	style,
+	title,
+}: {
+	style: ViewStyle;
+	title: string;
+}): ReactElement => {
+	const { t } = useTranslation('lightning');
+	const glowOpacity = useSharedValue(0.5);
+	const rootOpacity = useSharedValue(1);
+	const isLDKReady = useSelector(isLDKReadySelector);
+	const [hidden, setHidden] = useState(isLDKReady);
+
+	useEffect(() => {
+		// ldk is ready and LightningSyncing is already hidden, do nothing
+		if (isLDKReady && hidden) {
+			return;
+		}
+
+		// ldk is ready, but LightningSyncing is not yet hidden, let's hide it
+		if (isLDKReady && !hidden) {
+			rootOpacity.value = withTiming(0, { duration: 200 }, () => {
+				cancelAnimation(glowOpacity);
+				runOnJS(() => setHidden(true));
+			});
+		}
+
+		// if LightningSyncing is already hidden, do nothing
+		if (hidden || __E2E__) {
+			return;
+		}
+
+		// run glowing animation
+		glowOpacity.value = withRepeat(
+			withTiming(1, { duration: 2500, easing: Easing.inOut(Easing.quad) }),
+			-1,
+			true,
+		);
+	}, [isLDKReady, hidden, glowOpacity, rootOpacity]);
+
+	if (hidden) {
+		return <></>;
+	}
+
+	return (
+		<AnimatedView
+			testID="LightningSyncing"
+			style={[style, { opacity: rootOpacity }]}>
+			<GradientView style={styles.gradient}>
+				<BottomSheetNavigationHeader title={title} />
+				<View style={styles.content}>
+					<Text01S style={styles.description} color="gray1">
+						{t('wait_text_top')}
+					</Text01S>
+
+					<Animated.View style={[styles.glow, { opacity: glowOpacity }]}>
+						<GlowImage image={imageSrc} glowColor="purple" />
+					</Animated.View>
+
+					<View style={styles.bottomContainer}>
+						<Text02M style={styles.bottom} color="white32">
+							{t('wait_text_bottom')}
+						</Text02M>
+					</View>
+				</View>
+				<SafeAreaInset type="bottom" minPadding={16} />
+			</GradientView>
+		</AnimatedView>
+	);
+};
+
+const styles = StyleSheet.create({
+	glow: {
+		flex: 1,
+	},
+	gradient: {
+		flex: 1,
+	},
+	content: {
+		flex: 1,
+		marginTop: 8,
+		paddingHorizontal: 16,
+	},
+	description: {
+		marginTop: 16,
+		marginBottom: 16,
+	},
+	bottomContainer: {
+		flexDirection: 'row',
+		justifyContent: 'center',
+	},
+	bottom: {
+		marginVertical: 18,
+	},
+});
+
+export default LightningSyncing;

--- a/src/screens/Wallets/LNURLWithdraw/Confirm.tsx
+++ b/src/screens/Wallets/LNURLWithdraw/Confirm.tsx
@@ -18,6 +18,7 @@ import { handleLnurlWithdraw } from '../../../utils/lnurl';
 import { closeBottomSheet } from '../../../store/actions/ui';
 import { Text01S } from '../../../styles/text';
 import { showToast } from '../../../utils/notifications';
+import LightningSyncing from '../../../components/LightningSyncing';
 
 const imageSrc = require('../../../assets/illustrations/transfer.png');
 
@@ -79,6 +80,7 @@ const Confirm = ({ route }: LNURLWithdrawProps<'Confirm'>): ReactElement => {
 				</View>
 				<SafeAreaInset type="bottom" minPadding={16} />
 			</GradientView>
+			<LightningSyncing style={styles.syncing} title={t('lnurl_w_title')} />
 		</>
 	);
 };
@@ -96,6 +98,9 @@ const styles = StyleSheet.create({
 	},
 	buttonContainer: {
 		marginTop: 'auto',
+	},
+	syncing: {
+		...StyleSheet.absoluteFillObject,
 	},
 });
 

--- a/src/screens/Wallets/Send/ReviewAndSend.tsx
+++ b/src/screens/Wallets/Send/ReviewAndSend.tsx
@@ -80,6 +80,7 @@ import { truncate } from '../../../utils/helpers';
 import Money from '../../../components/Money';
 import { EUnit } from '../../../store/types/wallet';
 import AmountToggle from '../../../components/AmountToggle';
+import LightningSyncing from '../../../components/LightningSyncing';
 
 const Section = memo(
 	({
@@ -811,6 +812,10 @@ const ReviewAndSend = ({
 					}}
 				/>
 			)}
+
+			{transaction.lightningInvoice && (
+				<LightningSyncing style={styles.syncing} title={t('send_review')} />
+			)}
 		</>
 	);
 };
@@ -864,6 +869,9 @@ const styles = StyleSheet.create({
 	fee: {
 		flexDirection: 'row',
 		alignItems: 'center',
+	},
+	syncing: {
+		...StyleSheet.absoluteFillObject,
 	},
 });
 

--- a/src/store/reselect/ui.ts
+++ b/src/store/reselect/ui.ts
@@ -77,6 +77,11 @@ export const isOnlineSelector = createSelector(
 	(ui): boolean => ui.isOnline,
 );
 
+export const isLDKReadySelector = createSelector(
+	[uiState],
+	(ui): boolean => ui.isLDKReady,
+);
+
 export const isConnectedToElectrumSelector = createSelector(
 	[uiState],
 	(ui): boolean => ui.isConnectedToElectrum,

--- a/src/store/shapes/ui.ts
+++ b/src/store/shapes/ui.ts
@@ -32,6 +32,7 @@ export const defaultUiShape: IUi = {
 	isAuthenticated: false,
 	isConnectedToElectrum: true,
 	isOnline: true,
+	isLDKReady: false, // LDK node running and connected
 	language: 'en',
 	profileLink: { title: '', url: '' },
 	timeZone: 'UTC',

--- a/src/store/types/ui.ts
+++ b/src/store/types/ui.ts
@@ -66,6 +66,7 @@ export interface IUi {
 	isAuthenticated: boolean;
 	isConnectedToElectrum: boolean;
 	isOnline: boolean;
+	isLDKReady: boolean;
 	profileLink: TProfileLink;
 	viewControllers: TUiViewController;
 	timeZone: string;

--- a/src/utils/i18n/locales/en/lightning.json
+++ b/src/utils/i18n/locales/en/lightning.json
@@ -135,5 +135,7 @@
 		"expired": "Order expired",
 		"closed": "Connection closed",
 		"open": "Connection open"
-	}
+	},
+	"wait_text_top": "Please wait for Bitkit to connect to the payment network (±10 seconds).",
+	"wait_text_bottom": "Connecting & Syncing..."
 }

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -67,7 +67,11 @@ import {
 	IWalletItem,
 	TWalletName,
 } from '../../store/types/wallet';
-import { closeBottomSheet, showBottomSheet } from '../../store/actions/ui';
+import {
+	closeBottomSheet,
+	showBottomSheet,
+	updateUi,
+} from '../../store/actions/ui';
 import { updateSlashPayConfig } from '../slashtags';
 import { sdk } from '../../components/SlashtagsProvider';
 import { TLightningNodeVersion } from '../../store/types/lightning';
@@ -473,7 +477,7 @@ export const refreshLdk = async ({
 		]);
 		await updateClaimableBalance({ selectedNetwork, selectedWallet });
 		await syncLightningTxsWithActivityList();
-
+		updateUi({ isLDKReady: true });
 		return ok('');
 	} catch (e) {
 		console.log(e);


### PR DESCRIPTION
### Description

If ldk is not connected to any peers, it can't pay or receive any payments. So while it is not ready yet we should show nice animated screen.

### Linked Issues/Tasks

closes #1204

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/155891/d9d057a7-5bf3-4824-9eab-0f45911170c1

