### PR TITLE
refactor(wallet): Relocate fromAddressViewer

### DIFF
--- a/src/screens/Settings/AddressViewer/index.tsx
+++ b/src/screens/Settings/AddressViewer/index.tsx
@@ -67,7 +67,7 @@ import {
 	updateSendTransaction,
 	updateWallet,
 } from '../../../store/actions/wallet';
-import { showBottomSheet } from '../../../store/actions/ui';
+import { showBottomSheet, updateUi } from '../../../store/actions/ui';
 import Store from '../../../store/types';
 import SearchInput from '../../../components/SearchInput';
 import AddressViewerListItem from './AddressViewerListItem';
@@ -710,11 +710,11 @@ const AddressViewer = ({
 				transaction: {
 					...transactionRes.value,
 					outputs: [{ address: receiveAddress.value, value: 0, index: 0 }],
-					fromAddressViewer: true,
 				},
 				selectedWallet,
 				selectedNetwork,
 			});
+			updateUi({ fromAddressViewer: true });
 			sendMax({ selectedWallet, selectedNetwork });
 			showBottomSheet('sendNavigation');
 		},

--- a/src/screens/Wallets/Send/Recipient.tsx
+++ b/src/screens/Wallets/Send/Recipient.tsx
@@ -33,8 +33,9 @@ import {
 import {
 	resetSendTransaction,
 	setupOnChainTransaction,
-	updateSendTransaction,
 } from '../../../store/actions/wallet';
+import { fromAddressViewerSelector } from '../../../store/reselect/ui';
+import { updateUi } from '../../../store/actions/ui';
 
 const imageSrc = require('../../../assets/illustrations/coin-stack-logo.png');
 
@@ -47,6 +48,7 @@ const Recipient = ({
 	const { keyboardShown } = useKeyboard();
 	const [textFieldValue, setTextFieldValue] = useState('');
 	const [isValid, setIsValid] = useState(false);
+	const fromAddressViewer = useSelector(fromAddressViewerSelector);
 	const transaction = useSelector(transactionSelector);
 	const selectedWallet = useSelector(selectedWalletSelector);
 	const selectedNetwork = useSelector(selectedNetworkSelector);
@@ -118,15 +120,9 @@ const Recipient = ({
 	const onContinue = async (): Promise<void> => {
 		await Keyboard.dismiss();
 
-		if (transaction?.fromAddressViewer) {
+		if (fromAddressViewer) {
 			//Skip processInputData if from address viewer so-as to not lose inputs.
-			updateSendTransaction({
-				selectedWallet,
-				selectedNetwork,
-				transaction: {
-					fromAddressViewer: false,
-				},
-			});
+			updateUi({ fromAddressViewer: false });
 		} else {
 			// make sure transaction is up-to-date when navigating back and forth
 			await processInputData({

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -37,7 +37,7 @@ const persistConfig = {
 	key: 'root',
 	storage: mmkvStorage,
 	// increase version after store shape changes
-	version: 17,
+	version: 18,
 	stateReconciler: autoMergeLevel2,
 	blacklist: ['receive', 'ui'],
 	migrate: createMigrate(migrations, { debug: __ENABLE_MIGRATION_DEBUG__ }),

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -179,6 +179,15 @@ const migrations = {
 			widgets: defaultWidgetsShape,
 		};
 	},
+	18: (state): PersistedState => {
+		return {
+			...state,
+			ui: {
+				...state.ui,
+				fromAddressViewer: false,
+			},
+		};
+	},
 };
 
 export default migrations;

--- a/src/store/reselect/ui.ts
+++ b/src/store/reselect/ui.ts
@@ -100,3 +100,8 @@ export const criticalUpdateSelector = createSelector(
 export const timeZoneSelector = createSelector([uiState], (ui) => ui.timeZone);
 
 export const languageSelector = createSelector([uiState], (ui) => ui.language);
+
+export const fromAddressViewerSelector = createSelector(
+	[uiState],
+	(ui) => ui?.fromAddressViewer ?? false,
+);

--- a/src/store/reselect/ui.ts
+++ b/src/store/reselect/ui.ts
@@ -103,5 +103,5 @@ export const languageSelector = createSelector([uiState], (ui) => ui.language);
 
 export const fromAddressViewerSelector = createSelector(
 	[uiState],
-	(ui) => ui?.fromAddressViewer ?? false,
+	(ui) => ui.fromAddressViewer,
 );

--- a/src/store/shapes/ui.ts
+++ b/src/store/shapes/ui.ts
@@ -38,4 +38,5 @@ export const defaultUiShape: IUi = {
 	timeZone: 'UTC',
 	// Used to control bottom-sheets throughout the app
 	viewControllers: defaultViewControllers,
+	fromAddressViewer: false, // When true, ensures tx inputs are not cleared when sweeping from address viewer.
 };

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -124,7 +124,6 @@ export const defaultSendTransaction: ISendTransaction = {
 	max: false,
 	tags: [],
 	lightningInvoice: '',
-	fromAddressViewer: false, //When true, ensures tx inputs are not cleared when sweeping from address viewer.
 };
 
 export const defaultAddressContent: Readonly<IAddress> = {

--- a/src/store/types/ui.ts
+++ b/src/store/types/ui.ts
@@ -71,4 +71,5 @@ export interface IUi {
 	viewControllers: TUiViewController;
 	timeZone: string;
 	language: string;
+	fromAddressViewer: boolean;
 }

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -200,7 +200,6 @@ export interface ISendTransaction {
 	tags: string[];
 	slashTagsUrl?: string;
 	lightningInvoice?: string;
-	fromAddressViewer?: boolean;
 }
 
 export interface IBoostedTransaction {


### PR DESCRIPTION
### Description

- Relocates `fromAddressViewer` out of `wallet.transaction` and into `ui` reducer.

### Type of change

- [x] Refactoring (improving code without creating new functionality)

### Tests

- [x] No test