### PR TITLE
fix(widgets): fix taps not registered

### DIFF
--- a/src/components/Widgets.tsx
+++ b/src/components/Widgets.tsx
@@ -66,7 +66,7 @@ const Widgets = (): ReactElement => {
 
 			const _drag = (): void => {
 				// only allow dragging if there are more than 1 widget
-				if (sortedWidgets.length > 1) {
+				if (sortedWidgets.length > 1 && editing) {
 					drag();
 				}
 			};
@@ -167,7 +167,7 @@ const Widgets = (): ReactElement => {
 				keyExtractor={(item): string => item[0]}
 				renderItem={renderItem}
 				scrollEnabled={false}
-				dragHitSlop={{ top: editing ? 0 : -1000 }}
+				activationDistance={editing ? 0 : 100}
 				onDragEnd={onDragEnd}
 			/>
 

--- a/src/screens/Widgets/WidgetEdit.tsx
+++ b/src/screens/Widgets/WidgetEdit.tsx
@@ -53,10 +53,6 @@ const WidgetEdit = ({
 	const defaultSettings = getDefaultSettings(config);
 	const hasEdited = !isEqual(settings, defaultSettings);
 
-	console.log({ settings });
-	console.log({ defaultSettings });
-	console.log({ hasEdited });
-
 	const onSave = (): void => {
 		navigation.navigate('Widget', { url, preview: settings });
 	};


### PR DESCRIPTION
### Description

Fixes an issue where taps are not registered for widgets on the home screen.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
