### PR TITLE
fix: navigation.pop(2) after disable PIN

### DIFF
--- a/src/screens/Settings/PIN/DisablePin.tsx
+++ b/src/screens/Settings/PIN/DisablePin.tsx
@@ -25,7 +25,7 @@ const DisablePin = ({
 				// hack needed for Android
 				setTimeout(() => {
 					removePin();
-					navigation.replace('SecuritySettings');
+					navigation.pop(2);
 				}, 100);
 			},
 		});


### PR DESCRIPTION
### Description

Use navigation.pop to remove screens from history, so that goback action shows correct screen after disabling PIN

### Linked Issues/Tasks

closes #1231

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video

Before:

https://github.com/synonymdev/bitkit/assets/155891/ec62b49b-a1c5-4706-9206-f863a6ad5539

After:

https://github.com/synonymdev/bitkit/assets/155891/bd106bb3-506f-433d-af05-bd84186ed1f6

