### PR TITLE
fix: do not add same ActivityItem twice

### DIFF
--- a/src/store/reducers/activity.ts
+++ b/src/store/reducers/activity.ts
@@ -9,9 +9,11 @@ const activity = (
 ): IActivity => {
 	switch (action.type) {
 		case actions.ADD_ACTIVITY_ITEM: {
+			const items = state.items.filter((item) => item.id !== action.payload.id);
+
 			return {
 				...state,
-				items: [action.payload, ...state.items],
+				items: [action.payload, ...items],
 			};
 		}
 


### PR DESCRIPTION
### Description

Looks like sometimes LDK fires it's update callbacks twice. 

### Linked Issues/Tasks

closes #1182

### Type of change

Bug fix

### Tests

No test