### PR TITLE
fix(widgets): disable web-relay client cache globally

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@synonymdev/slashtags-widget-facts-feed": "1.1.0",
     "@synonymdev/slashtags-widget-news-feed": "1.1.0",
     "@synonymdev/slashtags-widget-price-feed": "1.1.0",
-    "@synonymdev/web-relay": "1.0.2",
+    "@synonymdev/web-relay": "1.0.3",
     "assert": "^2.0.0",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
     "bech32": "^2.0.0",

--- a/src/components/SlashtagsProvider2.tsx
+++ b/src/components/SlashtagsProvider2.tsx
@@ -140,6 +140,7 @@ export const SlashtagsProvider2 = ({
 				relay: webRelayUrl,
 				keyPair,
 				store,
+				_skipCache: true,
 			});
 
 			profile = new SlashtagsProfile(webRelayClient);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2984,10 +2984,10 @@
     "@synonymdev/feeds" "^2.0.0"
     node-fetch "^2.6.12"
 
-"@synonymdev/web-relay@1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@synonymdev/web-relay/-/web-relay-1.0.2.tgz#1e66b519e5545034513b91d59e6b63ff226357de"
-  integrity sha512-bc/NYmwnWCYfHgUeeAacS3Wkr+0AGB3AJM7HllGhqCUGjFYNsDPOpx35f5PBeAilE55ZECWCohu3w0KcIY+cBQ==
+"@synonymdev/web-relay@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@synonymdev/web-relay/-/web-relay-1.0.3.tgz#e163358092115ff51cd0c33a74830994ee965f4e"
+  integrity sha512-Gk0CbBOQHcSGYCNvEA4sdqfFgy4LTMAERMVTIoNuxyexcgfmcjwzYvMnOA8e704Bf2FUAylRmcbewmveSAclDg==
   dependencies:
     "@synonymdev/slashtags-url" "^1.0.0"
     b4a "1.6.4"


### PR DESCRIPTION
### Description

Disables slashtags web relay client cache globally so that we always get fresh data from the start. Should leave cache disabled until `Client.subscribe()` works in react-native.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/1264

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
