### PR TITLE
chore(lightning): Upgrade react-native-ldk

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -350,7 +350,7 @@ PODS:
     - React-Core
   - react-native-keep-awake (1.2.0):
     - React-Core
-  - react-native-ldk (0.0.110):
+  - react-native-ldk (0.0.111):
     - React
   - react-native-mmkv (2.8.0):
     - MMKV (>= 1.2.13)
@@ -846,7 +846,7 @@ SPEC CHECKSUMS:
   react-native-flipper: 5d8dcbcb905a7e8076c9a61a3709944c23cf48ee
   react-native-image-picker: ec9b713e248760bfa0f879f0715391de4651a7cb
   react-native-keep-awake: caee3ff89eaa21dfe29010f0d143566874a04441
-  react-native-ldk: a69156c3ff99495ef8fb518b4c873418608fc7c1
+  react-native-ldk: 20bafd3ad8ea69c33841d7b4895379b6eb8cf9f6
   react-native-mmkv: 7da5e18e55c04a9af9a7e0ab9792a1e8d33765a1
   react-native-netinfo: 22c082970cbd99071a4e5aa7a612ac20d66b08f0
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@synonymdev/blocktank-client": "0.0.50",
     "@synonymdev/blocktank-lsp-http-client": "^0.3.2",
     "@synonymdev/feeds": "^2.1.1",
-    "@synonymdev/react-native-ldk": "^0.0.110",
+    "@synonymdev/react-native-ldk": "0.0.111",
     "@synonymdev/react-native-lnurl": "0.0.5",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "1.0.0-alpha.6",

--- a/src/screens/Wallets/Receive/ReceiveQR.tsx
+++ b/src/screens/Wallets/Receive/ReceiveQR.tsx
@@ -43,7 +43,7 @@ import { generateNewReceiveAddress } from '../../../store/actions/wallet';
 import { viewControllerIsOpenSelector } from '../../../store/reselect/ui';
 import { useLightningBalance } from '../../../hooks/lightning';
 import { useBottomSheetBackPress } from '../../../hooks/bottomSheet';
-import { refreshLdk, waitForLdk } from '../../../utils/lightning';
+import { waitForLdk } from '../../../utils/lightning';
 import { getUnifiedUri } from '../../../utils/receive';
 import { ellipsis, sleep } from '../../../utils/helpers';
 import { getReceiveAddress } from '../../../utils/wallet';
@@ -180,24 +180,6 @@ const ReceiveQR = ({
 		await sleep(200);
 		setLoading(false);
 	}, [getAddress, getLightningInvoice, loading, receiveNavigationIsOpen]);
-
-	useEffect(() => {
-		if (!receiveNavigationIsOpen) {
-			return;
-		}
-		// Gives the modal animation time to start.
-		sleep(50).then(() => {
-			// Only refresh LDK if we have a remote balance.
-			if (lightningBalance.remoteBalance > 0) {
-				refreshLdk({ selectedWallet, selectedNetwork }).then();
-			}
-		});
-	}, [
-		selectedNetwork,
-		selectedWallet,
-		receiveNavigationIsOpen,
-		lightningBalance.remoteBalance,
-	]);
 
 	useEffect(() => {
 		if (!receiveNavigationIsOpen) {

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -485,10 +485,10 @@ export const refreshLdk = async ({
 		}
 
 		const syncRes = await lm.syncLdk();
-		await lm.setFees();
 		if (syncRes.isErr()) {
 			return err(syncRes.error.message);
 		}
+		await lm.setFees();
 
 		await Promise.all([
 			addPeers({ selectedNetwork, selectedWallet }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2804,10 +2804,10 @@
   dependencies:
     b4a "^1.5.3"
 
-"@synonymdev/react-native-ldk@^0.0.110":
-  version "0.0.110"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.110.tgz#83d636327721e97624ecf339928b520cf6c9cf48"
-  integrity sha512-+2GFXyBVO6ifvhQX85gAmaKdYmxwWKtLE+aqgHQIw2baMFp/8LxdOzIfVGGmJjLRBoZzkdfUeGyNZ7W9sVFC4Q==
+"@synonymdev/react-native-ldk@0.0.111":
+  version "0.0.111"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.111.tgz#33b7fe92df4c41f254d92bc02eedf2afd80aabd2"
+  integrity sha512-08ZAIA2Rp0DCUh4vzEWSG8uJgTLRKrNPf5NxYline2hERuZ0ij888bXUV8CN+UogSH3YyylXlBfqITdq7SXTZg==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 


### PR DESCRIPTION
### Description
- Upgrades `react-native-ldk` to `0.0.111`.
- Removes `refreshLdk` from `ReceiveQR.tsx`.
- Moves `setFees` call to after the sync response check.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency Update

### Tests
- [x] No test
