### PR TITLE
feat: ldk update 0.0.117

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@sayem314/react-native-keep-awake": "^1.2.0",
     "@shopify/react-native-skia": "0.1.182",
     "@synonymdev/blocktank-client": "0.0.50",
-    "@synonymdev/blocktank-lsp-http-client": "^0.3.2",
+    "@synonymdev/blocktank-lsp-http-client": "^0.6.0",
     "@synonymdev/feeds": "^2.1.1",
     "@synonymdev/react-native-ldk": "^0.0.114",
     "@synonymdev/react-native-lnurl": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@synonymdev/blocktank-client": "0.0.50",
     "@synonymdev/blocktank-lsp-http-client": "^0.3.2",
     "@synonymdev/feeds": "^2.1.1",
-    "@synonymdev/react-native-ldk": "0.0.111",
+    "@synonymdev/react-native-ldk": "^0.0.114",
     "@synonymdev/react-native-lnurl": "0.0.5",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "1.0.0-alpha.6",

--- a/src/screens/Settings/Lightning/ChannelDetails.tsx
+++ b/src/screens/Settings/Lightning/ChannelDetails.tsx
@@ -323,9 +323,9 @@ const ChannelDetails = ({
 	};
 
 	let channelCloseTime: string | undefined;
-	if (blocktankOrder?.channel?.closingTxId) {
+	if (blocktankOrder?.channel?.close) {
 		channelCloseTime = tTime('dateTime', {
-			v: new Date().toLocaleString(),
+			v: new Date(blocktankOrder.channel.close.registeredAt),
 			formatParams: {
 				v: {
 					year: 'numeric',

--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -126,10 +126,7 @@ const getPendingBlocktankChannels = (
 		if (order.state === BtOrderState.CREATED) {
 			pendingOrders.push(fakeChannel);
 		}
-		if (
-			order.state === BtOrderState.EXPIRED ||
-			order.state === BtOrderState.CLOSED
-		) {
+		if (order.state === BtOrderState.EXPIRED) {
 			failedOrders.push(fakeChannel);
 		}
 	});

--- a/src/screens/Transfer/Availability.tsx
+++ b/src/screens/Transfer/Availability.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, memo } from 'react';
+import React, { ReactElement, memo, useState } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSelector } from 'react-redux';
 import { Trans, useTranslation } from 'react-i18next';
@@ -24,6 +24,7 @@ const Availability = ({
 	navigation,
 }: TransferScreenProps<'Availability'>): ReactElement => {
 	const { t } = useTranslation('lightning');
+	const [isLoading, setIsLoading] = useState(false);
 	const selectedWallet = useSelector(selectedWalletSelector);
 	const selectedNetwork = useSelector(selectedNetworkSelector);
 
@@ -32,6 +33,7 @@ const Availability = ({
 	};
 
 	const onContinue = async (): Promise<void> => {
+		setIsLoading(true);
 		const closeResponse = await closeAllChannels({
 			selectedNetwork,
 			selectedWallet,
@@ -81,6 +83,7 @@ const Availability = ({
 						style={styles.button}
 						text={t('ok')}
 						size="large"
+						loading={isLoading}
 						onPress={onContinue}
 					/>
 				</View>

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -1196,7 +1196,7 @@ export const updateTransactions = async ({
 		// check if tx is a payment from Blocktank (i.e. transfer to savings)
 		const isTransferToSavings = !!blocktankOrders.find((order) => {
 			return !!transactions[txid].vin.find(
-				(input) => input.txid === order.channel?.closingTxId,
+				(input) => input.txid === order.channel?.close?.txId,
 			);
 		});
 

--- a/src/store/shapes/blocktank.ts
+++ b/src/store/shapes/blocktank.ts
@@ -23,6 +23,7 @@ export const defaultBlocktankInfoShape: IBtInfo = {
 		minPaymentConfirmations: 0,
 		minHighRiskPaymentConfirmations: 1,
 		max0ConfClientBalanceSat: 856487,
+		maxClientBalanceSat: 856487,
 	},
 };
 

--- a/src/utils/activity/index.ts
+++ b/src/utils/activity/index.ts
@@ -41,7 +41,7 @@ export const onChainTransactionToActivityItem = ({
 	// check if tx is a payment from Blocktank (i.e. transfer to savings)
 	const isTransferToSavings = !!blocktankOrders.find((order) => {
 		return !!transaction.vin.find(
-			(input) => input.txid === order.channel?.closingTxId,
+			(input) => input.txid === order.channel?.close?.txId,
 		);
 	});
 

--- a/src/utils/blocktank/index.ts
+++ b/src/utils/blocktank/index.ts
@@ -97,6 +97,7 @@ export const createOrder = async (
 				...data.options,
 				couponCode: data.options?.couponCode ?? 'bitkit',
 				turboChannel: true,
+				zeroReserve: true,
 			},
 		);
 		if (buyRes?.id) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2804,10 +2804,10 @@
   dependencies:
     b4a "^1.5.3"
 
-"@synonymdev/react-native-ldk@0.0.111":
-  version "0.0.111"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.111.tgz#33b7fe92df4c41f254d92bc02eedf2afd80aabd2"
-  integrity sha512-08ZAIA2Rp0DCUh4vzEWSG8uJgTLRKrNPf5NxYline2hERuZ0ij888bXUV8CN+UogSH3YyylXlBfqITdq7SXTZg==
+"@synonymdev/react-native-ldk@^0.0.114":
+  version "0.0.114"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.114.tgz#e1da2913cc75eaefaf42501be6ca7640ca6d92c1"
+  integrity sha512-Ath/IzKzzl2NcTEnNK1gfpdqTX5u6SvrcTKVwrsI4L+hgjjQ9YmPtdeY4uF6hu35b6phky4ByqTqjYtBUnSgYQ==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2783,10 +2783,10 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/blocktank-lsp-http-client@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@synonymdev/blocktank-lsp-http-client/-/blocktank-lsp-http-client-0.3.2.tgz#098b6709dfc3cbe1f3a45e2b65975973f915c015"
-  integrity sha512-gWB4IJ37AV6rHjLq5rHSay10N6W1JHuXhv4ErdgghcmtOZt0cu/ZxImH+EFH4vgwOKbXxWDCUzgzYc7AG/OsRQ==
+"@synonymdev/blocktank-lsp-http-client@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@synonymdev/blocktank-lsp-http-client/-/blocktank-lsp-http-client-0.6.0.tgz#e1a5eec2087cd01a4c423ac7408bfb2269504839"
+  integrity sha512-+iVSusWsRUrq0bRXqiGbUculE8N51VmHJ/9wsJc+nnIKMh9WdOa6Sr7NvRdasX9vHP0Dm6fmljYuoLI1E2GkQw==
   dependencies:
     axios "^1.4.0"
 


### PR DESCRIPTION
### Description

- Updates react-native-ldk (LDK 0.0.117)
- Updates blocktank-lsp-http-client
- Sets zero reserve for BT channels

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

- Users should not lose funds after closing turbo channels
- Local reserve channel balance should be 354 sats