### PR TITLE
fix: respect bt maxClientBalanceSat in Quick Setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@sayem314/react-native-keep-awake": "^1.2.0",
     "@shopify/react-native-skia": "0.1.182",
     "@synonymdev/blocktank-client": "0.0.50",
-    "@synonymdev/blocktank-lsp-http-client": "^0.6.0",
+    "@synonymdev/blocktank-lsp-http-client": "0.6.0",
     "@synonymdev/feeds": "^2.1.1",
     "@synonymdev/react-native-ldk": "^0.0.114",
     "@synonymdev/react-native-lnurl": "0.0.5",

--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -71,12 +71,17 @@ const QuickSetup = ({
 		return convertToSats(textFieldValue, unit);
 	}, [textFieldValue, unit]);
 
-	const btSpendingLimit = useMemo(() => {
+	const btMaxChannelSizeSat = useMemo(() => {
 		return blocktankInfo.options.maxChannelSizeSat;
 	}, [blocktankInfo.options.maxChannelSizeSat]);
+	const btMaxClientBalanceSat = useMemo(() => {
+		return blocktankInfo.options.maxClientBalanceSat;
+	}, [blocktankInfo.options.maxClientBalanceSat]);
+
 	const diff = 0.01;
-	const btSpendingLimitBalanced = Math.round(
-		btSpendingLimit / 2 - btSpendingLimit * diff,
+	const btSpendingLimitBalanced = Math.min(
+		Math.round(btMaxChannelSizeSat / 2 - btMaxChannelSizeSat * diff),
+		btMaxClientBalanceSat,
 	);
 	const spendableBalance = Math.round(onchainBalance * SPENDING_LIMIT_RATIO);
 	const savingsAmount = onchainBalance - spendingAmount;
@@ -219,7 +224,7 @@ const QuickSetup = ({
 							</View>
 						</AnimatedView>
 
-						{spendingAmount >= Math.round(btSpendingLimitBalanced) && (
+						{spendingAmount > Math.round(btSpendingLimitBalanced) && (
 							<AnimatedView
 								style={styles.note}
 								entering={FadeIn}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2783,7 +2783,7 @@
     cross-fetch "^3.1.4"
     node-fetch "3.1.1"
 
-"@synonymdev/blocktank-lsp-http-client@^0.6.0":
+"@synonymdev/blocktank-lsp-http-client@0.6.0":
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/@synonymdev/blocktank-lsp-http-client/-/blocktank-lsp-http-client-0.6.0.tgz#e1a5eec2087cd01a4c423ac7408bfb2269504839"
   integrity sha512-+iVSusWsRUrq0bRXqiGbUculE8N51VmHJ/9wsJc+nnIKMh9WdOa6Sr7NvRdasX9vHP0Dm6fmljYuoLI1E2GkQw==


### PR DESCRIPTION
### Description

Do not allow user to create a channel with client balance > maxClientBalanceSat

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video

Insert relevant screenshot / recording
