### PR TITLE
feat(settings): add option to trust web relay

### DIFF
--- a/src/components/SwitchRow.tsx
+++ b/src/components/SwitchRow.tsx
@@ -1,4 +1,4 @@
-import React, { memo, ReactElement } from 'react';
+import React, { memo, ReactElement, ReactNode } from 'react';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import { Switch } from '../styles/components';
 import { IThemeColors } from '../styles/themes';
@@ -11,7 +11,7 @@ const SwitchRow = ({
 	showDivider = true,
 	onPress,
 }: {
-	children: ReactElement;
+	children: ReactNode;
 	color?: keyof IThemeColors;
 	isEnabled: boolean;
 	showDivider?: boolean;

--- a/src/hooks/slashtags2.ts
+++ b/src/hooks/slashtags2.ts
@@ -12,7 +12,6 @@ import { addContacts, cacheProfile2 } from '../store/actions/slashtags';
 import {
 	ISlashtagsContext2,
 	SlashtagsContext2,
-	webRelayClient,
 } from '../components/SlashtagsProvider2';
 import { useSlashtags } from '../components/SlashtagsProvider';
 import { __E2E__ } from '../constants/env';
@@ -39,7 +38,7 @@ export const useProfile2 = (
 	profile: BasicProfile;
 	url: string;
 } => {
-	const { webRelayUrl } = useSlashtags2();
+	const { webRelayClient, webRelayUrl } = useSlashtags2();
 	const [resolving, setResolving] = useState(true);
 	const [url, profileUrl] = useMemo(() => {
 		const parsed = parse(origUrl);
@@ -112,7 +111,7 @@ export const useProfile2 = (
 			unsubscribe();
 			unmounted = true;
 		};
-	}, [profileUrl, shouldResolve]);
+	}, [webRelayClient, profileUrl, shouldResolve]);
 
 	return {
 		resolving,

--- a/src/screens/Settings/WebRelay/index.tsx
+++ b/src/screens/Settings/WebRelay/index.tsx
@@ -5,13 +5,15 @@ import Url from 'url-parse';
 import { useTranslation } from 'react-i18next';
 
 import { View, TextInput, ScrollView } from '../../../styles/components';
-import { Caption13Up, Text01S } from '../../../styles/text';
+import { Caption13Up, Text01S, Text02S } from '../../../styles/text';
 import { ScanIcon } from '../../../styles/icons';
 import { updateSettings } from '../../../store/actions/settings';
 import NavigationHeader from '../../../components/NavigationHeader';
 import SafeAreaInset from '../../../components/SafeAreaInset';
+import SwitchRow from '../../../components/SwitchRow';
 import Button from '../../../components/Button';
 import { showToast } from '../../../utils/notifications';
+import { saveProfile2, updateSlashPayConfig2 } from '../../../utils/slashtags2';
 import type { SettingsScreenProps } from '../../../navigation/types';
 import { __WEB_RELAY__ } from '../../../constants/env';
 import {
@@ -19,7 +21,6 @@ import {
 	useSelectedSlashtag2,
 	useSlashtags2,
 } from '../../../hooks/slashtags2';
-import { saveProfile2, updateSlashPayConfig2 } from '../../../utils/slashtags2';
 
 const validateInput = (
 	url: string,
@@ -46,6 +47,7 @@ const WebRelay = ({
 	const {
 		webRelayClient,
 		webRelayUrl,
+		isWebRelayTrusted,
 		profile: slashtagsProfile,
 	} = useSlashtags2();
 	const { url: myProfileUrl } = useSelectedSlashtag2();
@@ -129,6 +131,10 @@ const WebRelay = ({
 		navigation.navigate('Scanner', { onScan: connectAndSave });
 	};
 
+	const onToggle = (): void => {
+		updateSettings({ isWebRelayTrusted: !isWebRelayTrusted });
+	};
+
 	const hasEdited = webRelayUrl !== url;
 
 	return (
@@ -168,6 +174,16 @@ const WebRelay = ({
 					returnKeyType="done"
 					testID="UrlInput"
 				/>
+
+				<View style={styles.switch}>
+					<SwitchRow
+						isEnabled={isWebRelayTrusted}
+						showDivider={false}
+						onPress={onToggle}>
+						<Text01S>{t('wr.trust')}</Text01S>
+						<Text02S color="gray1">{t('wr.trust_description')}</Text02S>
+					</SwitchRow>
+				</View>
 
 				<View style={styles.buttons}>
 					<Button
@@ -212,7 +228,7 @@ const styles = StyleSheet.create({
 		justifyContent: 'center',
 	},
 	label: {
-		marginTop: 32,
+		marginTop: 16,
 		marginBottom: 4,
 	},
 	connectedPeer: {
@@ -221,7 +237,10 @@ const styles = StyleSheet.create({
 	textInput: {
 		minHeight: 52,
 		marginTop: 12,
-		marginBottom: 32,
+		marginBottom: 16,
+	},
+	switch: {
+		marginBottom: 16,
 	},
 	buttons: {
 		marginTop: 16,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -37,7 +37,7 @@ const persistConfig = {
 	key: 'root',
 	storage: mmkvStorage,
 	// increase version after store shape changes
-	version: 23,
+	version: 24,
 	stateReconciler: autoMergeLevel2,
 	blacklist: ['receive', 'ui'],
 	migrate: createMigrate(migrations, { debug: __ENABLE_MIGRATION_DEBUG__ }),

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -230,6 +230,15 @@ const migrations = {
 			todos: defaultTodosShape,
 		};
 	},
+	24: (state): PersistedState => {
+		return {
+			...state,
+			settings: {
+				...state.settings,
+				isWebRelayTrusted: false,
+			},
+		};
+	},
 };
 
 export default migrations;

--- a/src/store/reselect/settings.ts
+++ b/src/store/reselect/settings.ts
@@ -146,3 +146,8 @@ export const webRelaySelector = createSelector(
 	[settingsState],
 	(settings): string => settings.webRelay,
 );
+
+export const webRelayTrustedSelector = createSelector(
+	[settingsState],
+	(settings) => settings.isWebRelayTrusted,
+);

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -118,6 +118,7 @@ export const defaultSettingsShape: Readonly<ISettings> = {
 	enableDevOptions: __DEV__,
 	treasureChests: [],
 	webRelay: __WEB_RELAY__,
+	isWebRelayTrusted: false,
 };
 
 export const getDefaultSettingsShape = (): ISettings => {

--- a/src/store/types/settings.ts
+++ b/src/store/types/settings.ts
@@ -73,4 +73,5 @@ export interface ISettings {
 	enableDevOptions: boolean;
 	treasureChests: TChest[];
 	webRelay: string;
+	isWebRelayTrusted: boolean;
 }

--- a/src/utils/i18n/locales/en/settings.json
+++ b/src/utils/i18n/locales/en/settings.json
@@ -182,6 +182,8 @@
 		"error_https": "Not a valid HTTPS url.",
 		"error_healthcheck": "Healthcheck Failed",
 		"url_updated_title": "Web Relay Updated",
-		"url_updated_message": "Successfully connected to {url}"
+		"url_updated_message": "Successfully connected to {url}",
+		"trust": "Trust this relay",
+		"trust_description": "Skip record verification for this web relay"
 	}
 }


### PR DESCRIPTION
### Description

Adds a toggle in Web Relay settings to trust the relay and skip record verification.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

![Screenshot_1697197444](https://github.com/synonymdev/bitkit/assets/8538369/8006fc8a-11fc-4377-8d5c-36bbd304831d)
