### PR TITLE
fix: during slashtags migration do not save image

### DIFF
--- a/src/hooks/slashtags2.ts
+++ b/src/hooks/slashtags2.ts
@@ -176,6 +176,13 @@ export const useMigrateSlashtags2 = (): void => {
 		}
 		status.current.profile = true;
 
-		saveProfile2(url, oldProfile, slashtagsProfile);
+		// save everything, except image becase it can be too big
+		const p = {
+			bio: oldProfile.bio,
+			name: oldProfile.name,
+			links: oldProfile.links,
+		};
+
+		saveProfile2(url, p, slashtagsProfile);
 	}, [oldProfile, newProfile, slashtagsProfile, url]);
 };


### PR DESCRIPTION
### Description

During slashtags migration do not save image because it can be too big.

### Linked Issues/Tasks

closes #1325

### Type of change

Bug fix

### Tests

No test
