### PR TITLE
fix(widgets): block height format number

### DIFF
--- a/src/utils/widgets/index.ts
+++ b/src/utils/widgets/index.ts
@@ -45,7 +45,7 @@ export const decodeWidgetFieldValue = (
 			const json = value;
 			const { format } = new Intl.NumberFormat('en-US');
 
-			if (field.name === 'Height') {
+			if (field.name === 'Block') {
 				return format(json);
 			}
 			if (field.name === 'Time') {


### PR DESCRIPTION
### Description

This PR addresses the issue where numbers in the block widget array were not formatted properly. I've implemented a feature to format the numbers, making them more readable. The numbers in the 'Block' field of the data array will now be displayed with commas separating the thousands, for example, turning 812327 into 812,327.

### Linked Issues/Tasks

Add any links to GitHub issues or Asana tasks that are relevant to this pull request.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

![image](https://github.com/synonymdev/bitkit/assets/5798170/ae4b7d7f-3728-4331-9830-050b47a82ebe)


### QA Notes

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce during the Bitkit testing session. You can also leave a video of the PR in action.
