### PR TITLE
fix(lightning): only close channel when ready to avoid ldk hang bug

### DIFF
--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -1418,6 +1418,23 @@ export const closeChannel = async ({
 	try {
 		// Ensure we're fully up-to-date.
 		await refreshLdk();
+
+		//>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> TODO remove after LDK updated to 0.0.118
+		const getChannelsResponse = await getLightningChannels();
+		if (getChannelsResponse.isErr()) {
+			return err(getChannelsResponse.error.message);
+		}
+
+		const channelToClose = getChannelsResponse.value.find(
+			(c) => c.channel_id === channelId,
+		);
+		if (!channelToClose?.is_channel_ready || !channelToClose.is_usable) {
+			return err(
+				'Channel temporarily unavailable for closing. Please try again in a few moments.',
+			);
+		}
+		//<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<  TODO remove after LDK updated to 0.0.118
+
 		return await ldk.closeChannel({ channelId, counterPartyNodeId, force });
 	} catch (e) {
 		console.log(e);


### PR DESCRIPTION
### Description

Avoids crash/hang bug in LDK 117 when channel closed when not ready. Can be removed after updating to LDK 118.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

Insert relevant screenshot / recording

### QA Notes

App should not crash when closing a channel