### PR TITLE
fix: restart docker before last test try

### DIFF
--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -103,6 +103,12 @@ jobs:
         if: steps.test1.outcome != 'success' && steps.test2.outcome != 'success'
         run: yarn e2e:test:ios-release --record-videos all --take-screenshots all --record-logs all
 
+      - name: Restart docker before last attempt
+        if: steps.test1.outcome != 'success' && steps.test2.outcome != 'success' && steps.test3.outcome != 'success'
+        run: |
+          cd docker && docker-compose down && docker-compose up -d && cd ..
+          while ! nc -z '127.0.0.1' 60001; do sleep 1; done
+
       - name: Test attempt 4
         id: test4
         if: steps.test1.outcome != 'success' && steps.test2.outcome != 'success' && steps.test3.outcome != 'success'


### PR DESCRIPTION
### Description

Restart docker bitcoin + ln test enviroment before last test attempt. This might solve "Channel is not ready" test error


### Type of change

Bug fix

### Tests

Detox test
