### PR TITLE
bump(lightning): Upgrade LDK to 118

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@synonymdev/blocktank-client": "0.0.50",
     "@synonymdev/blocktank-lsp-http-client": "0.6.0",
     "@synonymdev/feeds": "2.1.1",
-    "@synonymdev/react-native-ldk": "0.0.120",
+    "@synonymdev/react-native-ldk": "0.0.121",
     "@synonymdev/react-native-lnurl": "0.0.5",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "1.0.0-alpha.6",

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -254,10 +254,13 @@ export const setupLdk = async ({
 			getFees: async () => {
 				const fees = getFeesStore().onchain;
 				return {
-					highPriority: fees.fast,
-					normal: fees.normal,
-					background: fees.slow,
-					mempoolMinimum: fees.minimum,
+					nonAnchorChannelFee: fees.fast,
+					anchorChannelFee: fees.normal,
+					maxAllowedNonAnchorChannelRemoteFee: fees.fast * 3,
+					channelCloseMinimum: fees.minimum,
+					minAllowedAnchorChannelRemoteFee: fees.minimum,
+					minAllowedNonAnchorChannelRemoteFee: fees.minimum,
+					onChainSweep: fees.normal,
 				};
 			},
 			network,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3201,10 +3201,10 @@
   dependencies:
     b4a "^1.5.3"
 
-"@synonymdev/react-native-ldk@0.0.120":
-  version "0.0.120"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.120.tgz#9db6ac5f3f7df6cca1cdd78f2f60b0c9a58de91a"
-  integrity sha512-3/8gZfmSY9MbMl5qRaeo0c9TasuyeudQfBvm9jtwVXtlLlTEv4cVD14x4OSNvwNWvX/muKzLzi1f0isDXOEEVA==
+"@synonymdev/react-native-ldk@0.0.121":
+  version "0.0.121"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.121.tgz#3df8648bae6cddd43088c5e09aa181cfa4aa8b5c"
+  integrity sha512-zRiIgbZKuXhdCpRurqHi93HQXb2bJ4tVNJAcz4Oym9zQj0Z62+MBwtcrDkcoq3qhuYh3Uvi3eRJkuI56jbNlRQ==
   dependencies:
     bitcoinjs-lib "^6.0.2"
 


### PR DESCRIPTION
### Description

- Updates `@synonymdev/react-native-ldk` to v`0.0.121`.
- Updates `getFees` method to the following:
```
nonAnchorChannelFee: fees.fast,
anchorChannelFee: fees.normal,
maxAllowedNonAnchorChannelRemoteFee: fees.fast * 3,
channelCloseMinimum: fees.minimum,
minAllowedAnchorChannelRemoteFee: fees.minimum,
minAllowedNonAnchorChannelRemoteFee: fees.minimum,
onChainSweep: fees.normal,
```
  
Can't imagine we would want something greater than a multiple of three of the fastest estimate for the max remote fee. Don't want it to be too low either, but we can adjust as needed.

### Type of change

- [x] Dep Upgrade

### Tests

- [x] No test
