### PR TITLE
fix: replace hard coded MINIMUM_AMOUNT with blocktank.options.minChannelSizeSat

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -392,7 +392,7 @@ PODS:
     - React-Core
   - react-native-keep-awake (1.2.2):
     - React-Core
-  - react-native-ldk (0.0.122):
+  - react-native-ldk (0.0.123):
     - React
   - react-native-mmkv (2.10.2):
     - MMKV (>= 1.2.13)
@@ -915,7 +915,7 @@ SPEC CHECKSUMS:
   react-native-flipper: 9c1957af24b76493ba74f46d000a5c1d485e7731
   react-native-image-picker: 2e2e82aba9b6a91a7c78f7d9afde341a2659c7b8
   react-native-keep-awake: ad1d67f617756b139536977a0bf06b27cec0714a
-  react-native-ldk: 3fd5d959c60676bbb5f414a4c5e8a2cd3a4fb227
+  react-native-ldk: e242bbc0c8ca5356409e2e065b80364dadb270b6
   react-native-mmkv: 9ae7ca3977e8ef48dbf7f066974eb844c20b5fd7
   react-native-netinfo: 5ddbf20865bcffab6b43d0e4e1fd8b3896beb898
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846

--- a/src/screens/Wallets/Receive/ReceiveAmount.tsx
+++ b/src/screens/Wallets/Receive/ReceiveAmount.tsx
@@ -26,10 +26,6 @@ import { blocktankInfoSelector } from '../../../store/reselect/blocktank';
 import { refreshBlocktankInfo } from '../../../store/actions/blocktank';
 import type { ReceiveScreenProps } from '../../../navigation/types';
 
-// hardcoded to be above fee (1092)
-// TODO: fee is dynamic so this should be fetched from the API
-const MINIMUM_AMOUNT = 5000;
-
 const ReceiveAmount = ({
 	navigation,
 }: ReceiveScreenProps<'ReceiveAmount'>): ReactElement => {
@@ -83,7 +79,8 @@ const ReceiveAmount = ({
 	};
 
 	const continueDisabled =
-		invoice.amount < MINIMUM_AMOUNT || invoice.amount > maxAmount;
+		invoice.amount < blocktank.options.minChannelSizeSat ||
+		invoice.amount > maxAmount;
 
 	return (
 		<GradientView style={styles.container}>
@@ -103,7 +100,11 @@ const ReceiveAmount = ({
 							<Caption13Up style={styles.minimumText} color="gray1">
 								{t('minimum')}
 							</Caption13Up>
-							<Money sats={MINIMUM_AMOUNT} size="text02m" symbol={true} />
+							<Money
+								sats={blocktank.options.minChannelSizeSat}
+								size="text02m"
+								symbol={true}
+							/>
 						</View>
 						<View style={styles.actionButtons}>
 							<View style={styles.actionButtonContainer}>

--- a/src/screens/Wallets/Receive/ReceiveDetails.tsx
+++ b/src/screens/Wallets/Receive/ReceiveDetails.tsx
@@ -49,10 +49,6 @@ import { lightningSelector } from '../../../store/reselect/lightning';
 
 const imageSrc = require('../../../assets/illustrations/coin-stack-4.png');
 
-// hardcoded to be above fee (1092)
-// TODO: fee is dynamic so this should be fetched from the API
-const MINIMUM_AMOUNT = 5000;
-
 const ReceiveDetails = ({
 	navigation,
 	route,
@@ -94,7 +90,10 @@ const ReceiveDetails = ({
 		const maxAmount = maxChannelSizeSat / 2;
 
 		// Ensure the CJIT entry is within an acceptable range.
-		if (invoice.amount >= MINIMUM_AMOUNT && invoice.amount <= maxAmount) {
+		if (
+			invoice.amount >= blocktank.options.minChannelSizeSat &&
+			invoice.amount <= maxAmount
+		) {
 			const cJitEntryResponse = await createCJitEntry({
 				channelSizeSat: maxChannelSizeSat,
 				invoiceSat: invoice.amount,
@@ -119,6 +118,7 @@ const ReceiveDetails = ({
 		lightning.accountVersion,
 		lightningBalance.remoteBalance,
 		navigation,
+		blocktank.options.minChannelSizeSat,
 	]);
 
 	const onNavigateBack = useCallback(async () => {


### PR DESCRIPTION
fix: replace hard coded MINIMUM_AMOUNT with blocktank.options.minChannelSizeSat

### Description

We should use blocktank.options.minChannelSizeSat instead of hard coded MINIMUM_AMOUNT

### Linked Issues/Tasks

#1323

### Type of change

Bug fix

### Tests

No test
