### PR TITLE
fix(profile): #1397 fix links not opening in app

### DIFF
--- a/src/components/ProfileLinks.tsx
+++ b/src/components/ProfileLinks.tsx
@@ -5,13 +5,13 @@ import {
 	StyleProp,
 	StyleSheet,
 	ViewStyle,
+	Linking,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
 
 import { Caption13Up, Text02M, Text02S } from '../styles/text';
 import { TrashIcon } from '../styles/icons';
 import { LocalLink } from '../store/types/slashtags';
-import { openURL } from '../utils/helpers';
 import { editLink, removeLink } from '../store/actions/slashtags';
 import LabeledInput from './LabeledInput';
 import Divider from './Divider';
@@ -31,6 +31,14 @@ const trimLink = (link: LocalLink): string => {
 	}
 
 	return trimmedUrl.replace('https://', '').replace('www.', '');
+};
+
+const openURL = async (url: string): Promise<void> => {
+	try {
+		await Linking.openURL(url);
+	} catch (err) {
+		console.log('Cannot open url: ', url);
+	}
 };
 
 const ProfileLinks = ({


### PR DESCRIPTION
### Description

If you add a valid link to your profile for example https://www.instagram.com/{username}, if the "Instagram" application is not present on your device, if you click on it it opens the link correctly via browser, but if instead I have the application installed on the device, even if I click it nothing happens.

This PR fixes this bug - https://github.com/synonymdev/bitkit/issues/1397

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/63161412/e39c251f-67ee-407a-9c36-e4f84b0825f1

