### PR TITLE
build: #1399 fix bitkit build if using windows

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -112,6 +112,12 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
         }
     }
+    packagingOptions {
+        pickFirst 'lib/x86/liblog.so'
+        pickFirst 'lib/x86_64/liblog.so'
+        pickFirst 'lib/armeabi-v7a/liblog.so'
+        pickFirst 'lib/arm64-v8a/liblog.so'
+    }
 }
 
 dependencies {


### PR DESCRIPTION
### Description

Bug: [#1399](https://github.com/synonymdev/bitkit/issues/1399)


By adding packagingOptions in `android/app/build.gradle` using window you should be able to build bitkit correctly