### PR TITLE
fix: do not show SettingUp screen in case of non 0conf BT order

### DIFF
--- a/e2e/channels.e2e.js
+++ b/e2e/channels.e2e.js
@@ -131,6 +131,8 @@ d('LN Channel Onboarding', () => {
 				.toBeVisible()
 				.withTimeout(10000);
 
+			await rpc.generateToAddress(1, await rpc.getNewAddress());
+
 			// CustomSetup
 			await launchAndWait();
 			await waitFor(element(by.id('Suggestion-lightningSettingUp')))

--- a/src/screens/Lightning/CustomConfirm.tsx
+++ b/src/screens/Lightning/CustomConfirm.tsx
@@ -72,7 +72,8 @@ const CustomConfirm = ({
 			setLoading(false);
 			return;
 		}
-		navigation.navigate('SettingUp');
+		const zeroConf = order.zeroConf && !res.value.useUnconfirmedInputs;
+		navigation.navigate(zeroConf ? 'SettingUp' : 'Success');
 	};
 
 	const updateOrderExpiration = async (): Promise<void> => {

--- a/src/screens/Lightning/QuickConfirm.tsx
+++ b/src/screens/Lightning/QuickConfirm.tsx
@@ -73,7 +73,8 @@ const QuickConfirm = ({
 			setLoading(false);
 			return;
 		}
-		navigation.navigate('SettingUp');
+		const zeroConf = order?.zeroConf && !res.value.useUnconfirmedInputs;
+		navigation.navigate(zeroConf ? 'SettingUp' : 'Success');
 	};
 
 	return (


### PR DESCRIPTION
### Description

I case if BT order is non-0-conf or we use unconfirmed inputs to pay for the order, do not show SettingUp screen and instead go to Success screen directly

### Type of change

Refactoring

### Tests

No test

### Screenshot / Video

Simulator Screen Recording - iPhone 15 Pro 

https://github.com/synonymdev/bitkit/assets/155891/d5940f64-56e5-40db-95db-897974ceece2
