### PR TITLE
fix: on app start watch only for CREATED BT orders

### DIFF
--- a/src/utils/blocktank/index.ts
+++ b/src/utils/blocktank/index.ts
@@ -265,8 +265,10 @@ export const openChannel = async (
  * @returns {void}
  */
 export const watchPendingOrders = (): void => {
-	const pendingOrders = getPendingOrders();
-	pendingOrders.forEach((order) => watchOrder(order.id));
+	const orders = getBlocktankStore().orders.filter((order) => {
+		return order.state === BtOrderState.CREATED;
+	});
+	orders.forEach((order) => watchOrder(order.id));
 };
 
 /**


### PR DESCRIPTION
### Description

Bitkit makes too much requests to BT when app starts. This fix reduces it

### Linked Issues/Tasks

https://app.asana.com/0/home/1201997517558994/1205821036778035

### Type of change

Bug fix

### Tests

No test
