### PR TITLE
fix(receive): #1427 fix show btc invoice if instant payment is disabled

### DIFF
--- a/src/screens/Wallets/Receive/ReceiveQR.tsx
+++ b/src/screens/Wallets/Receive/ReceiveQR.tsx
@@ -425,7 +425,7 @@ const ReceiveQR = ({
 		return (
 			<View style={styles.slide}>
 				<ThemedView style={styles.invoices} color="white04">
-					{!jitInvoice && (
+					{(!jitInvoice || !enableInstant) && (
 						<View style={styles.invoice} testID="ReceiveOnchainInvoice">
 							<View style={styles.invoiceLabel}>
 								<Caption13Up color="gray1">


### PR DESCRIPTION
### Description

Issue: https://github.com/synonymdev/bitkit/issues/1427

I added a condition to show the btc invoice in case the variable that manages the status for instant payment is disabled


https://github.com/synonymdev/bitkit/assets/63161412/5b89e459-7d31-45dd-bbb1-c05e50d3dafb


