### PR TITLE
feat(ui): add retry biometrics after failed scan

### DIFF
--- a/src/components/AuthCheck.tsx
+++ b/src/components/AuthCheck.tsx
@@ -7,6 +7,7 @@ import Animated, { FadeOut } from 'react-native-reanimated';
 import GlowingBackground from './GlowingBackground';
 import Biometrics from './Biometrics';
 import PinPad from './PinPad';
+import { biometricsSelector } from '../store/reselect/settings';
 
 type AuthCheckProps = {
 	showBackNavigation?: boolean;
@@ -24,7 +25,7 @@ const AuthCheck = ({
 	route,
 	onSuccess,
 }: AuthCheckProps): ReactElement => {
-	const biometrics = useAppSelector((state) => state.settings.biometrics);
+	const biometrics = useAppSelector(biometricsSelector);
 	const [requireBiometrics, setRequireBiometrics] = useState(biometrics);
 
 	const requirePin = route?.params?.requirePin ?? false;
@@ -48,6 +49,8 @@ const AuthCheck = ({
 			<PinPad
 				showBackNavigation={showBackNavigation}
 				showLogoOnPIN={showLogoOnPIN}
+				allowBiometrics={biometrics && !requirePin}
+				onShowBiotmetrics={(): void => setRequireBiometrics(true)}
 				onSuccess={(): void => onSuccess?.()}
 			/>
 		</Animated.View>

--- a/src/utils/i18n/locales/en/security.json
+++ b/src/utils/i18n/locales/en/security.json
@@ -49,6 +49,7 @@
 	"pin_forgot_text": "Forgot your PIN? Reset and recover your Bitkit wallet with your recovery phrase. Set a new PIN after completing recovery.",
 	"pin_forgot_reset": "Reset (Requires Recovery Phrase)",
 	"pin_send": "Please enter your PIN code to confirm and send out this payment.",
+	"pin_use_biometrics": "Use {biometricsName}",
 	"bio": "Biometrics",
 	"bio_auth_with": "Authenticate with {biometricsName}",
 	"bio_no": "It appears that your device does not support Biometric security.",


### PR DESCRIPTION
### Description

In case sensors are dirty it's helpful to have a button to retry the biometrics check.

### Linked Issues/Tasks

https://app.asana.com/0/0/1205862969450138/f

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

![Simulator Screenshot - iPhone 15 Pro - 2023-12-18 at 15 48 15](https://github.com/synonymdev/bitkit/assets/8538369/2a0cbfee-62ae-427d-8be7-22ffaa8d6b32)

### QA Notes

Fail the biometrics check, a button to retry should show (except for 'Disable PIN' screen)