### PR TITLE
fix(lightning): lnSetupSelector Fix

### DIFF
--- a/__tests__/reselect.ts
+++ b/__tests__/reselect.ts
@@ -99,11 +99,6 @@ describe('Reselect', () => {
 	});
 
 	describe('lnSetupSelector', () => {
-		it('should throw if onchain balance is 0', () => {
-			const state = cloneDeep(s);
-			expect(() => lnSetupSelector(state, 0)).toThrow(TypeError);
-		});
-
 		it('should calculate percentage corectly', () => {
 			const state = cloneDeep(s);
 			// balance under maxChannelSizeSat

--- a/src/store/reselect/aggregations.ts
+++ b/src/store/reselect/aggregations.ts
@@ -58,10 +58,6 @@ export const lnSetupSelector = createSelector(
 		(_, spendingAmount): number => spendingAmount,
 	],
 	(blocktankInfo, balance, spendingAmount: number): TLnSetup => {
-		if (balance.onchainBalance === 0) {
-			throw new TypeError('Cannot setup LN with 0 onchain balance');
-		}
-
 		const totalBalance = balance.totalBalance;
 		const lightningBalance = balance.lightningBalance;
 


### PR DESCRIPTION
### Description

- Removes throw from `lnSetupSelector` when onchain balance is zero. This stops the app from crashing when the user has a lightning balance with zero on-chain balance when navigating to the Transfer view.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Tests

- [x] No test
