### PR TITLE
refactor(lightning): keep original structure of ldk.claimableBalances

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -1,5 +1,6 @@
 import {
 	removeKeysFromObject,
+	reduceValue,
 	timeAgo,
 	isObjPartialMatch,
 	ellipsis,
@@ -36,6 +37,57 @@ describe('removeKeysFromObject', () => {
 
 		const result = removeKeysFromObject(input, ['a', 'b']);
 		expect(result).toEqual(expected);
+	});
+});
+
+describe('reduceValue', () => {
+	it('takes an array of objects, and sums all values pertaining to a specific key', () => {
+		const input = [
+			{
+				a: 1,
+				b: 2,
+			},
+			{
+				a: 4,
+				b: 5,
+			},
+		];
+
+		const expected = { value: 7 };
+		const result = reduceValue(input, 'b');
+		expect(result).toEqual(expected);
+	});
+
+	it('works with optional values', () => {
+		const input = [
+			{
+				a: 1,
+				b: 2,
+			},
+			{
+				b: 5,
+			},
+		];
+
+		const expected = { value: 1 };
+		const result = reduceValue(input, 'a');
+		expect(result).toEqual(expected);
+	});
+
+	it('returns an error where the lookup value is not a number', () => {
+		const input = [
+			{
+				a: 1,
+				b: 2,
+			},
+			{
+				a: 'string1',
+				b: 'string2',
+			},
+		];
+
+		const result = reduceValue(input, 'a');
+		expect(result).toHaveProperty('error');
 	});
 });
 

--- a/__tests__/reselect.ts
+++ b/__tests__/reselect.ts
@@ -84,7 +84,9 @@ describe('Reselect', () => {
 				'channel2',
 				'channel3',
 			];
-			lnWallet.claimableBalance.bitcoinRegtest = 3;
+			lnWallet.claimableBalances.bitcoinRegtest = [
+				{ amount_satoshis: 3, type: 'ClaimableOnChannelClose' },
+			];
 
 			assert.deepEqual(balanceSelector(state), {
 				lightningBalance: 7,
@@ -218,7 +220,9 @@ describe('Reselect', () => {
 			const lnWallet = s1.lightning.nodes.wallet0;
 			lnWallet.channels.bitcoinRegtest = { channel1 };
 			lnWallet.openChannelIds.bitcoinRegtest = ['channel1'];
-			lnWallet.claimableBalance.bitcoinRegtest = 3;
+			lnWallet.claimableBalances.bitcoinRegtest = [
+				{ amount_satoshis: 3, type: 'ClaimableOnChannelClose' },
+			];
 
 			expect(lnSetupSelector(s1, 20)).toMatchObject({
 				slider: {

--- a/__tests__/todos.ts
+++ b/__tests__/todos.ts
@@ -171,7 +171,9 @@ describe('Todos selector', () => {
 		} as TChannel;
 		state.lightning.nodes.wallet0.channels.bitcoinRegtest = { channel1 };
 		state.lightning.nodes.wallet0.openChannelIds.bitcoinRegtest = ['channel1'];
-		state.lightning.nodes.wallet0.claimableBalance.bitcoinRegtest = 123;
+		state.lightning.nodes.wallet0.claimableBalances.bitcoinRegtest = [
+			{ amount_satoshis: 123, type: 'ClaimableOnChannelClose' },
+		];
 
 		expect(todosFullSelector(state)).toEqual(
 			expect.arrayContaining([transferToSavingsTodo]),

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -40,7 +40,7 @@ const persistConfig = {
 	key: 'root',
 	storage: mmkvStorage,
 	// increase version after store shape changes
-	version: 29,
+	version: 30,
 	stateReconciler: autoMergeLevel2,
 	blacklist: ['receive', 'ui'],
 	migrate: createMigrate(migrations, { debug: __ENABLE_MIGRATION_DEBUG__ }),

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -305,6 +305,24 @@ const migrations = {
 			},
 		};
 	},
+	30: (state): PersistedState => {
+		const newNodes = { ...state.lightning.nodes };
+		// Loop through all nodes
+		for (const walletName in newNodes) {
+			newNodes[walletName] = {
+				...newNodes[walletName],
+				claimableBalances: getNetworkContent([]),
+			};
+		}
+
+		return {
+			...state,
+			lightning: {
+				...state.lightning,
+				nodes: newNodes,
+			},
+		};
+	},
 };
 
 export default migrations;

--- a/src/store/reselect/todos.ts
+++ b/src/store/reselect/todos.ts
@@ -25,7 +25,7 @@ import {
 import { pinSelector } from './settings';
 import { onboardingProfileStepSelector } from './slashtags';
 import {
-	claimableBalanceSelector,
+	claimableBalancesSelector,
 	closedChannelsSelector,
 	openChannelsSelector,
 	pendingChannelsSelector,
@@ -58,7 +58,7 @@ export const todosFullSelector = createSelector(
 	pendingChannelsSelector,
 	closedChannelsSelector,
 	startCoopCloseTimestampSelector,
-	claimableBalanceSelector,
+	claimableBalancesSelector,
 	blocktankPaidOrdersFullSelector,
 	newChannelsNotificationsSelector,
 	(
@@ -70,7 +70,7 @@ export const todosFullSelector = createSelector(
 		pendingChannels,
 		closedChannels,
 		startCoopCloseTimestamp,
-		claimableBalance,
+		claimableBalances,
 		paidOrders,
 		newChannels,
 	): Array<ITodo> => {
@@ -98,6 +98,12 @@ export const todosFullSelector = createSelector(
 			return Number(new Date(order.orderExpiresAt)) > hide.btFailed;
 		});
 
+		// TODO: wait for improvements to `Balance` in LDK v0.0.120
+		const claimableOnChannelClose = claimableBalances.find(
+			(b) => b.type === 'ClaimableOnChannelClose',
+		);
+		const balanceInTransfer = claimableOnChannelClose;
+
 		// lightning
 		if (showFailedBTOrder) {
 			// failed blocktank order
@@ -108,7 +114,7 @@ export const todosFullSelector = createSelector(
 				res.push(lightningConnectingTodo);
 			} else if (Object.keys(paidOrders.created).length > 0) {
 				res.push(lightningSettingUpTodo);
-			} else if (claimableBalance > 0) {
+			} else if (balanceInTransfer?.amount_satoshis) {
 				res.push(transferToSavingsTodo); // TODO: find a way to distinguish between transfer to and from spendings
 			} else if (!hide.lightning) {
 				res.push(lightningTodo);
@@ -119,7 +125,7 @@ export const todosFullSelector = createSelector(
 				res.push(transferClosingChannel);
 			} else if (Object.keys(paidOrders.created).length > 0) {
 				res.push(transferToSpendingTodo);
-			} else if (claimableBalance > 0) {
+			} else if (balanceInTransfer?.amount_satoshis) {
 				res.push(transferToSavingsTodo); // TODO: find a way to distinguish between transfer to and from spendings
 			}
 		}

--- a/src/store/shapes/lightning.ts
+++ b/src/store/shapes/lightning.ts
@@ -7,7 +7,7 @@ export const defaultLightningShape: TNode = {
 	channels: getNetworkContent({}),
 	openChannelIds: getNetworkContent([]),
 	peers: getNetworkContent([]),
-	claimableBalance: getNetworkContent(0),
+	claimableBalances: getNetworkContent([]),
 };
 
 export const initialLightningState: TLightningState = {

--- a/src/store/slices/lightning.ts
+++ b/src/store/slices/lightning.ts
@@ -1,4 +1,6 @@
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+import { TClaimableBalance } from '@synonymdev/react-native-ldk';
+
 import { initialLightningState } from '../shapes/lightning';
 import { EAvailableNetwork } from '../../utils/networks';
 import { TWalletName } from '../types/wallet';
@@ -72,18 +74,18 @@ export const lightningSlice = createSlice({
 			);
 			state.nodes[selectedWallet].peers[selectedNetwork] = filtered;
 		},
-		updateClaimableBalance: (
+		updateClaimableBalances: (
 			state,
 			action: PayloadAction<{
-				claimableBalance: number;
+				claimableBalances: TClaimableBalance[];
 				selectedNetwork: EAvailableNetwork;
 				selectedWallet: TWalletName;
 			}>,
 		) => {
-			const { claimableBalance, selectedNetwork, selectedWallet } =
+			const { claimableBalances, selectedNetwork, selectedWallet } =
 				action.payload;
-			state.nodes[selectedWallet].claimableBalance[selectedNetwork] =
-				claimableBalance;
+			state.nodes[selectedWallet].claimableBalances[selectedNetwork] =
+				claimableBalances;
 		},
 		updateLdkAccountVersion: (
 			state,
@@ -103,7 +105,7 @@ export const {
 	updateLightningChannels,
 	saveLightningPeer,
 	removeLightningPeer,
-	updateClaimableBalance,
+	updateClaimableBalances,
 	updateLdkAccountVersion,
 	resetLightningState,
 } = actions;

--- a/src/store/types/lightning.ts
+++ b/src/store/types/lightning.ts
@@ -1,5 +1,6 @@
 import {
 	TChannel,
+	TClaimableBalance,
 	TCreatePaymentReq,
 	TInvoice,
 } from '@synonymdev/react-native-ldk';
@@ -25,7 +26,7 @@ export type TNode = {
 	openChannelIds: IWalletItem<TOpenChannelIds>;
 	info: IWalletItem<{}>;
 	peers: IWalletItem<string[]>;
-	claimableBalance: IWalletItem<number>;
+	claimableBalances: IWalletItem<TClaimableBalance[]>;
 };
 
 export type TNodes = {

--- a/src/store/utils/lightning.ts
+++ b/src/store/utils/lightning.ts
@@ -8,7 +8,7 @@ import { updateActivityItems } from '../slices/activity';
 import {
 	removeLightningPeer,
 	saveLightningPeer,
-	updateClaimableBalance,
+	updateClaimableBalances,
 	updateLightningChannels,
 	updateLightningNodeId,
 	updateLightningNodeVersion,
@@ -20,7 +20,7 @@ import { getSelectedNetwork, getSelectedWallet } from '../../utils/wallet';
 import {
 	addPeers,
 	createPaymentRequest,
-	getClaimableBalance,
+	getClaimableBalances,
 	getClaimedLightningPayments,
 	getCustomLightningPeers,
 	getLightningChannels,
@@ -289,31 +289,20 @@ export const removePeer = ({
 	return ok('Successfully Removed Lightning Peer');
 };
 
-export const updateClaimableBalanceThunk = async ({
-	selectedWallet,
-	selectedNetwork,
-}: {
-	selectedWallet?: TWalletName;
-	selectedNetwork?: EAvailableNetwork;
-}): Promise<Result<string>> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
+export const updateClaimableBalancesThunk = async (): Promise<
+	Result<string>
+> => {
+	const selectedWallet = getSelectedWallet();
+	const selectedNetwork = getSelectedNetwork();
 
-	const claimableBalance = await getClaimableBalance({
-		selectedNetwork,
-		selectedWallet,
-	});
+	const claimableBalances = await getClaimableBalances();
 
 	const payload = {
+		claimableBalances,
 		selectedNetwork,
 		selectedWallet,
-		claimableBalance,
 	};
-	dispatch(updateClaimableBalance(payload));
+	dispatch(updateClaimableBalances(payload));
 	return ok('Successfully Updated Claimable Balance.');
 };
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -31,26 +31,26 @@ export const isOnline = async (): Promise<boolean> => {
 };
 
 /**
- * Sum a specific value in an array of objects.
+ * Takes an array of objects, and sums all values pertaining to a specific key.
  * @param arr
- * @param value
+ * @param key
  */
-export const reduceValue = <T>({
-	arr,
-	value,
-}: {
-	arr: T[];
-	value: keyof T;
-}): Result<number> => {
+export const reduceValue = <T extends object>(
+	arr: T[],
+	key: keyof T,
+): Result<number> => {
 	try {
-		if (!value) {
-			return err('Please specify a value.');
-		}
-		return ok(
-			arr.reduce((acc, cur) => {
-				return acc + Number(cur[value]);
-			}, 0) || 0,
-		);
+		const sum = arr.reduce((acc, obj) => {
+			if (key in obj) {
+				if (typeof obj[key] !== 'number') {
+					throw `value for '${String(key)}' is not a number`;
+				}
+				return acc + Number(obj[key]);
+			}
+			return acc + 0;
+		}, 0);
+
+		return ok(sum);
 	} catch (e) {
 		return err(e);
 	}

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -87,6 +87,7 @@ import { moveMetaIncTxTags } from '../../store/utils/metadata';
 import { refreshOrdersList } from '../../store/utils/blocktank';
 import { TNode } from '../../store/types/lightning';
 import { showNewTxPrompt } from '../../store/utils/ui';
+import { reduceValue } from '../helpers';
 import { objectKeys } from '../objectKeys';
 
 bitcoin.initEccLib(ecc);
@@ -2478,7 +2479,7 @@ export const getBalance = ({
 	});
 	const channels = node?.channels[selectedNetwork];
 	const openChannelIds = node?.openChannelIds[selectedNetwork];
-	const claimableBalance = node?.claimableBalance[selectedNetwork];
+	const claimableBalances = node?.claimableBalances[selectedNetwork];
 	const openChannels = Object.values(channels).filter((channel) => {
 		return openChannelIds.includes(channel.channel_id);
 	});
@@ -2494,6 +2495,10 @@ export const getBalance = ({
 			spendingBalance += spendable;
 		}
 	});
+
+	// TODO: filter out some types of claimable balances
+	const result = reduceValue(claimableBalances, 'amount_satoshis');
+	const claimableBalance = result.isOk() ? result.value : 0;
 
 	const onchainBalance = currentWallet.balance[selectedNetwork];
 	const lightningBalance = spendingBalance + reserveBalance + claimableBalance;

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -982,7 +982,7 @@ export const getTransactionOutputValue = ({
 			}
 			outputs = transaction.value.outputs;
 		}
-		const response = reduceValue({ arr: outputs, value: 'value' });
+		const response = reduceValue(outputs, 'value');
 		if (response.isOk()) {
 			return response.value;
 		}
@@ -1026,7 +1026,7 @@ export const getTransactionInputValue = ({
 			inputs = transaction.value.inputs;
 		}
 		if (inputs) {
-			const response = reduceValue({ arr: inputs, value: 'value' });
+			const response = reduceValue(inputs, 'value');
 			if (response.isOk()) {
 				return response.value;
 			}
@@ -1380,10 +1380,7 @@ export const validateTransaction = (
 			}
 		}
 
-		const inputsReduce = reduceValue({
-			arr: inputs,
-			value: 'value',
-		});
+		const inputsReduce = reduceValue(inputs, 'value');
 		if (inputsReduce.isErr()) {
 			return err(inputsReduce.error.message);
 		}
@@ -1394,10 +1391,7 @@ export const validateTransaction = (
 				return output.address !== transaction.changeAddress;
 			});
 		}
-		const outputsReduce = reduceValue({
-			arr: filteredOutputs,
-			value: 'value',
-		});
+		const outputsReduce = reduceValue(filteredOutputs, 'value');
 		if (outputsReduce.isErr()) {
 			return err(outputsReduce.error.message);
 		}


### PR DESCRIPTION
### Description

- Updates store to keep original structure of `ldk.claimableBalances` to be able to filter out by the different [types of balances](https://docs.rs/lightning/latest/lightning/chain/channelmonitor/enum.Balance.html)
- rewrite `reduceValue` and add unit tests

### Linked Issues/Tasks

https://github.com/synonymdev/bitkit/issues/1296

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [x] Unit test
- [ ] No test
