### PR TITLE
feat(widgets): Show a different news each time on Headlines widget

### DIFF
--- a/src/components/HeadlinesWidget.tsx
+++ b/src/components/HeadlinesWidget.tsx
@@ -66,7 +66,10 @@ const HeadlinesWidget = ({
 					`${url}?relay=${webRelayUrl}`,
 				);
 
-				const _article = await reader.getLatestArtible();
+				const allArticles = await reader.getAllArticles();
+				const _article = allArticles
+					.sort((a, b) => b.published - a.published)
+					.slice(0, 10)[Math.floor(Math.random() * 10)];
 
 				if (!unmounted && _article) {
 					setArticle(_article);


### PR DESCRIPTION
### Description

Currently if the user uses the "Headlines" widget the latest article is shown because the `getLatestArticle()` function is used.

In this PR I use the `getAllArticles()` function to show a random article to the user each time.

### Linked Issues/Tasks

https://github.com/synonymdev/bitkit/issues/1467

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [X] No test

### Screenshot / Video


https://github.com/synonymdev/bitkit/assets/63161412/e7922010-0b54-4009-92af-1bde43e92513
