### PR TITLE
fix(wallet): Updated SwipeBalance option also in Wallet details screen

### DIFF
--- a/src/screens/Wallets/WalletsDetail/index.tsx
+++ b/src/screens/Wallets/WalletsDetail/index.tsx
@@ -44,7 +44,10 @@ import SafeAreaInset from '../../../components/SafeAreaInset';
 import Money from '../../../components/Money';
 import BlurView from '../../../components/BlurView';
 import { updateSettings } from '../../../store/slices/settings';
-import { hideBalanceSelector } from '../../../store/reselect/settings';
+import {
+	hideBalanceSelector,
+	enableSwipeToHideBalanceSelector,
+} from '../../../store/reselect/settings';
 import { capitalize } from '../../../utils/helpers';
 import DetectSwipe from '../../../components/DetectSwipe';
 import type { WalletScreenProps } from '../../../navigation/types';
@@ -87,6 +90,9 @@ const WalletsDetail = ({
 	const { assetType } = route.params;
 	const { totalBalance } = useBalance();
 	const dispatch = useAppDispatch();
+	const enableSwipeToHideBalance = useAppSelector(
+		enableSwipeToHideBalanceSelector,
+	);
 	const hideBalance = useAppSelector(hideBalanceSelector);
 	const [_, switchUnit] = useSwitchUnit();
 	const colors = useColors();
@@ -213,6 +219,7 @@ const WalletsDetail = ({
 									exiting={FadeOut}>
 									<View color="transparent" style={styles.balanceContainer}>
 										<DetectSwipe
+											enabled={enableSwipeToHideBalance}
 											onSwipeLeft={toggleHideBalance}
 											onSwipeRight={toggleHideBalance}>
 											<TouchableOpacity

--- a/src/screens/Wallets/WalletsDetail/index.tsx
+++ b/src/screens/Wallets/WalletsDetail/index.tsx
@@ -32,7 +32,7 @@ import {
 } from '@shopify/react-native-skia';
 
 import { AnimatedView, View } from '../../../styles/components';
-import { BitcoinCircleIcon } from '../../../styles/icons';
+import { BitcoinCircleIcon, EyeIcon } from '../../../styles/icons';
 import { Title } from '../../../styles/text';
 import NavigationHeader from '../../../components/NavigationHeader';
 import useColors from '../../../hooks/colors';
@@ -230,6 +230,14 @@ const WalletsDetail = ({
 													enableHide={true}
 													highlight={true}
 												/>
+												{hideBalance && (
+													<TouchableOpacity
+														style={styles.toggle}
+														testID="ShowBalance"
+														onPress={toggleHideBalance}>
+														<EyeIcon />
+													</TouchableOpacity>
+												)}
 											</TouchableOpacity>
 										</DetectSwipe>
 									</View>
@@ -273,6 +281,8 @@ const styles = StyleSheet.create({
 	},
 	largeValueContainer: {
 		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
 	},
 	txListContainer: {
 		flex: 1,
@@ -294,6 +304,9 @@ const styles = StyleSheet.create({
 	},
 	title: {
 		marginLeft: 16,
+	},
+	toggle: {
+		marginTop: 6,
 	},
 });
 


### PR DESCRIPTION
### Description

Updated SwipeBalance option also in Wallet details screen
Now when you disable the option from settings you are not able to swipeBalance even from the Wallet details screen

### Linked Issues/Tasks

https://github.com/synonymdev/bitkit/issues/1491

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [X] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/63161412/99f1df02-dfc4-4c13-b3d5-5091a845da75


