### PR TITLE
chore: update react-native-ldk to fix an android crash

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -392,7 +392,7 @@ PODS:
     - React-Core
   - react-native-keep-awake (1.2.2):
     - React-Core
-  - react-native-ldk (0.0.125):
+  - react-native-ldk (0.0.126):
     - React
   - react-native-mmkv (2.10.2):
     - MMKV (>= 1.2.13)
@@ -905,7 +905,7 @@ SPEC CHECKSUMS:
   react-native-flipper: 9c1957af24b76493ba74f46d000a5c1d485e7731
   react-native-image-picker: 2e2e82aba9b6a91a7c78f7d9afde341a2659c7b8
   react-native-keep-awake: ad1d67f617756b139536977a0bf06b27cec0714a
-  react-native-ldk: c78b18c8c8fe218481721f7083e3e0f825aa957e
+  react-native-ldk: f45ad0a5397824c7d3f5c4c32503adea6106b4f4
   react-native-mmkv: 9ae7ca3977e8ef48dbf7f066974eb844c20b5fd7
   react-native-netinfo: 5ddbf20865bcffab6b43d0e4e1fd8b3896beb898
   react-native-quick-base64: a5dbe4528f1453e662fcf7351029500b8b63e7bb

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@synonymdev/blocktank-client": "0.0.50",
     "@synonymdev/blocktank-lsp-http-client": "0.9.0",
     "@synonymdev/feeds": "2.1.1",
-    "@synonymdev/react-native-ldk": "0.0.125",
+    "@synonymdev/react-native-ldk": "0.0.126",
     "@synonymdev/react-native-lnurl": "0.0.7",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "1.0.0-alpha.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3180,10 +3180,10 @@
   dependencies:
     b4a "^1.5.3"
 
-"@synonymdev/react-native-ldk@0.0.125":
-  version "0.0.125"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.125.tgz#f0080bcf2af68e5a419ee5ee7a3d49771c79c01f"
-  integrity sha512-NcyRCSwR2dyUWozsMnNVSJywxWDkfgacKh+q/YKO3PfUDRjlbHNWb95CSAMVRvIs2xCHOVWDZiOk64Uo4LBzIg==
+"@synonymdev/react-native-ldk@0.0.126":
+  version "0.0.126"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.126.tgz#78a2b131768e4808add5209c8b8b1f98bab472af"
+  integrity sha512-tdGisOlxTLe9VblkXjEAyQffaPmXHbZrDuWBw0SBaKenX3j8gW9wm87oOWLl5BrD+D31I6iJqLQoeCo/dp5qZw==
   dependencies:
     bech32 "^2.0.0"
     bitcoinjs-lib "^6.0.2"


### PR DESCRIPTION
### Description

Updates to the latest `react-native-ldk` which integrates the fix for the android crash:


### Linked Issues/Tasks

- #1494

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

n/a

### QA Notes

see linked issue