### PR TITLE
feat(wallet): Show info toast when hiding balance

### DIFF
--- a/src/components/BalanceHeader.tsx
+++ b/src/components/BalanceHeader.tsx
@@ -6,7 +6,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Caption13Up } from '../styles/text';
 import { EyeIcon } from '../styles/icons';
 import Money from './Money';
-import { useBalance, useSwitchUnit } from '../hooks/wallet';
+import { useBalance, useSwitchUnitAnnounced } from '../hooks/wallet';
 import { updateSettings } from '../store/slices/settings';
 import {
 	primaryUnitSelector,
@@ -18,7 +18,7 @@ import {
  */
 const BalanceHeader = (): ReactElement => {
 	const { t } = useTranslation('wallet');
-	const [_, switchUnit] = useSwitchUnit();
+	const onSwitchUnit = useSwitchUnitAnnounced();
 	const { totalBalance, claimableBalance } = useBalance();
 	const dispatch = useAppDispatch();
 	const unit = useAppSelector(primaryUnitSelector);
@@ -57,7 +57,7 @@ const BalanceHeader = (): ReactElement => {
 			<TouchableOpacity
 				style={styles.row}
 				testID="TotalBalance"
-				onPress={switchUnit}>
+				onPress={onSwitchUnit}>
 				<Money
 					sats={totalBalance}
 					unit={unit}

--- a/src/screens/Wallets/WalletsDetail/index.tsx
+++ b/src/screens/Wallets/WalletsDetail/index.tsx
@@ -37,7 +37,7 @@ import { Title } from '../../../styles/text';
 import NavigationHeader from '../../../components/NavigationHeader';
 import useColors from '../../../hooks/colors';
 import { useAppDispatch, useAppSelector } from '../../../hooks/redux';
-import { useBalance, useSwitchUnit } from '../../../hooks/wallet';
+import { useBalance, useSwitchUnitAnnounced } from '../../../hooks/wallet';
 import ActivityList from '../../Activity/ActivityList';
 import BitcoinBreakdown from './BitcoinBreakdown';
 import SafeAreaInset from '../../../components/SafeAreaInset';
@@ -101,7 +101,7 @@ const WalletsDetail = ({
 	const ignoresHideBalanceToast = useAppSelector(
 		ignoresHideBalanceToastSelector,
 	);
-	const [_, switchUnit] = useSwitchUnit();
+	const onSwitchUnit = useSwitchUnitAnnounced();
 	const colors = useColors();
 	const size = useSharedValue({ width: 0, height: 0 });
 	const title = capitalize(assetType);
@@ -217,7 +217,7 @@ const WalletsDetail = ({
 										style={styles.cell}
 										entering={FadeIn}
 										exiting={FadeOut}>
-										<TouchableOpacity onPress={switchUnit}>
+										<TouchableOpacity onPress={onSwitchUnit}>
 											<Money
 												sats={totalBalance}
 												enableHide={true}
@@ -240,7 +240,7 @@ const WalletsDetail = ({
 											onSwipeLeft={toggleHideBalance}
 											onSwipeRight={toggleHideBalance}>
 											<TouchableOpacity
-												onPress={switchUnit}
+												onPress={onSwitchUnit}
 												style={styles.largeValueContainer}>
 												<Money
 													sats={totalBalance}

--- a/src/screens/Wallets/WalletsDetail/index.tsx
+++ b/src/screens/Wallets/WalletsDetail/index.tsx
@@ -51,6 +51,10 @@ import {
 import { capitalize } from '../../../utils/helpers';
 import DetectSwipe from '../../../components/DetectSwipe';
 import type { WalletScreenProps } from '../../../navigation/types';
+import { showToast } from '../../../utils/notifications';
+import { useTranslation } from 'react-i18next';
+import { ignoresHideBalanceToastSelector } from '../../../store/reselect/user';
+import { ignoreHideBalanceToast } from '../../../store/slices/user';
 
 const updateHeight = ({ height, toValue = 0, duration = 250 }): void => {
 	try {
@@ -94,6 +98,9 @@ const WalletsDetail = ({
 		enableSwipeToHideBalanceSelector,
 	);
 	const hideBalance = useAppSelector(hideBalanceSelector);
+	const ignoresHideBalanceToast = useAppSelector(
+		ignoresHideBalanceToastSelector,
+	);
 	const [_, switchUnit] = useSwitchUnit();
 	const colors = useColors();
 	const size = useSharedValue({ width: 0, height: 0 });
@@ -102,6 +109,7 @@ const WalletsDetail = ({
 	const [radiusContainerHeight, setRadiusContainerHeight] = useState(400);
 	const [headerHeight, setHeaderHeight] = useState(0);
 	const height = useSharedValue(0);
+	const { t } = useTranslation('wallet');
 
 	const activityPadding = useMemo(
 		() => ({ paddingTop: radiusContainerHeight, paddingBottom: 230 }),
@@ -113,7 +121,16 @@ const WalletsDetail = ({
 	}, [height, headerHeight]);
 
 	const toggleHideBalance = (): void => {
-		dispatch(updateSettings({ hideBalance: !hideBalance }));
+		const enabled = !hideBalance;
+		dispatch(updateSettings({ hideBalance: enabled }));
+		if (!ignoresHideBalanceToast && enabled) {
+			showToast({
+				type: 'info',
+				title: t('balance_hidden_title'),
+				description: t('balance_hidden_message'),
+			});
+			dispatch(ignoreHideBalanceToast());
+		}
 	};
 
 	const onScroll = useCallback(

--- a/src/screens/Wallets/index.tsx
+++ b/src/screens/Wallets/index.tsx
@@ -34,6 +34,10 @@ import {
 	hideOnboardingMessageSelector,
 	showWidgetsSelector,
 } from '../../store/reselect/settings';
+import { showToast } from '../../utils/notifications';
+import { useTranslation } from 'react-i18next';
+import { ignoresHideBalanceToastSelector } from '../../store/reselect/user';
+import { ignoreHideBalanceToast } from '../../store/slices/user';
 
 // Workaround for crash on Android
 // https://github.com/software-mansion/react-native-reanimated/issues/4306#issuecomment-1538184321
@@ -51,6 +55,9 @@ const Wallets = ({ navigation, onFocus }: Props): ReactElement => {
 		enableSwipeToHideBalanceSelector,
 	);
 	const hideBalance = useAppSelector(hideBalanceSelector);
+	const ignoresHideBalanceToast = useAppSelector(
+		ignoresHideBalanceToastSelector,
+	);
 	const hideOnboardingSetting = useAppSelector(hideOnboardingMessageSelector);
 	const showWidgets = useAppSelector(showWidgetsSelector);
 	const widgets = useAppSelector(widgetsSelector);
@@ -59,6 +66,7 @@ const Wallets = ({ navigation, onFocus }: Props): ReactElement => {
 	const empty = useMemo(() => {
 		return noTransactions && Object.values(widgets).length === 0;
 	}, [noTransactions, widgets]);
+	const { t } = useTranslation('wallet');
 
 	// tell WalletNavigator that this screen is focused
 	useFocusEffect(
@@ -69,7 +77,16 @@ const Wallets = ({ navigation, onFocus }: Props): ReactElement => {
 	);
 
 	const toggleHideBalance = (): void => {
-		dispatch(updateSettings({ hideBalance: !hideBalance }));
+		const enabled = !hideBalance;
+		dispatch(updateSettings({ hideBalance: enabled }));
+		if (!ignoresHideBalanceToast && enabled) {
+			showToast({
+				type: 'info',
+				title: t('balance_hidden_title'),
+				description: t('balance_hidden_message'),
+			});
+			dispatch(ignoreHideBalanceToast());
+		}
 	};
 
 	const navigateToScanner = (): void => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -40,7 +40,7 @@ const persistConfig = {
 	key: 'root',
 	storage: mmkvStorage,
 	// increase version after store shape changes
-	version: 31,
+	version: 32,
 	stateReconciler: autoMergeLevel2,
 	blacklist: ['receive', 'ui'],
 	migrate: createMigrate(migrations, { debug: __ENABLE_MIGRATION_DEBUG__ }),

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -339,6 +339,7 @@ const migrations = {
 			user: {
 				...state.user,
 				ignoresHideBalanceToast: false,
+				ignoresSwitchUnitToast: false,
 			},
 		};
 	},

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -333,6 +333,15 @@ const migrations = {
 			},
 		};
 	},
+	32: (state): PersistedState => {
+		return {
+			...state,
+			user: {
+				...state.user,
+				ignoresHideBalanceToast: false,
+			},
+		};
+	},
 };
 
 export default migrations;

--- a/src/store/reselect/user.ts
+++ b/src/store/reselect/user.ts
@@ -58,3 +58,8 @@ export const ignoresHideBalanceToastSelector = createSelector(
 	[userState],
 	(user): boolean => user.ignoresHideBalanceToast,
 );
+
+export const ignoresSwitchUnitToastSelector = createSelector(
+	[userState],
+	(user): boolean => user.ignoresSwitchUnitToast,
+);

--- a/src/store/reselect/user.ts
+++ b/src/store/reselect/user.ts
@@ -53,3 +53,8 @@ export const betaRiskAcceptedSelector = createSelector(
 	[userState],
 	(user): boolean => user.betaRiskAccepted,
 );
+
+export const ignoresHideBalanceToastSelector = createSelector(
+	[userState],
+	(user): boolean => user.ignoresHideBalanceToast,
+);

--- a/src/store/slices/user.ts
+++ b/src/store/slices/user.ts
@@ -14,6 +14,7 @@ export type TUser = {
 	requiresRemoteRestore: boolean;
 	startCoopCloseTimestamp: number;
 	ignoresHideBalanceToast: boolean;
+	ignoresSwitchUnitToast: boolean;
 };
 
 export const initialUserState: TUser = {
@@ -28,6 +29,7 @@ export const initialUserState: TUser = {
 	requiresRemoteRestore: false,
 	startCoopCloseTimestamp: 0,
 	ignoresHideBalanceToast: false,
+	ignoresSwitchUnitToast: false,
 };
 
 export const userSlice = createSlice({
@@ -66,6 +68,9 @@ export const userSlice = createSlice({
 		ignoreHideBalanceToast: (state) => {
 			state.ignoresHideBalanceToast = true;
 		},
+		ignoreSwitchUnitToast: (state) => {
+			state.ignoresSwitchUnitToast = true;
+		},
 		resetUserState: () => initialUserState,
 	},
 });
@@ -83,6 +88,7 @@ export const {
 	verifyBackup,
 	acceptBetaRisk,
 	ignoreHideBalanceToast,
+	ignoreSwitchUnitToast,
 	resetUserState,
 } = actions;
 

--- a/src/store/slices/user.ts
+++ b/src/store/slices/user.ts
@@ -13,6 +13,7 @@ export type TUser = {
 	lightningSettingUpStep: number;
 	requiresRemoteRestore: boolean;
 	startCoopCloseTimestamp: number;
+	ignoresHideBalanceToast: boolean;
 };
 
 export const initialUserState: TUser = {
@@ -26,6 +27,7 @@ export const initialUserState: TUser = {
 	lightningSettingUpStep: 0,
 	requiresRemoteRestore: false,
 	startCoopCloseTimestamp: 0,
+	ignoresHideBalanceToast: false,
 };
 
 export const userSlice = createSlice({
@@ -61,6 +63,9 @@ export const userSlice = createSlice({
 		acceptBetaRisk: (state) => {
 			state.betaRiskAccepted = true;
 		},
+		ignoreHideBalanceToast: (state) => {
+			state.ignoresHideBalanceToast = true;
+		},
 		resetUserState: () => initialUserState,
 	},
 });
@@ -77,6 +82,7 @@ export const {
 	clearCoopCloseTimer,
 	verifyBackup,
 	acceptBetaRisk,
+	ignoreHideBalanceToast,
 	resetUserState,
 } = actions;
 

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -193,5 +193,7 @@
 	"lnurl_p_title": "Send Bitcoin",
 	"lnurl_p_max": "Maximum amount",
 	"balance_hidden_title" : "Wallet Balance Hidden",
-	"balance_hidden_message" : "Swipe your wallet balance to reveal it again."
+	"balance_hidden_message" : "Swipe your wallet balance to reveal it again.",
+	"balance_unit_switched_title" : "Switched to {unit}",
+	"balance_unit_switched_message" : "Tap your wallet balance to switch it back to {unit}."
 }

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -191,5 +191,7 @@
 	"lnurl_w_success_title": "Success",
 	"lnurl_w_success_description": "Withdraw Requested Successful",
 	"lnurl_p_title": "Send Bitcoin",
-	"lnurl_p_max": "Maximum amount"
+	"lnurl_p_max": "Maximum amount",
+	"balance_hidden_title" : "Wallet Balance Hidden",
+	"balance_hidden_message" : "Swipe your wallet balance to reveal it again."
 }


### PR DESCRIPTION
### Description

Added a toast message to explain the hidden wallet balance state for user clarity and resolution.

Works on both:
- wallets overview (home) and
- asset (Bitcoin) overview.

### Linked Issues/Tasks

Design v45 (see slack message or Figma file)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/4588074/c480a1dc-6cc8-4d60-9bee-b8eab383e4c0

### QA Notes

See above video.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206354352883295