### PR TITLE
fix: show channel if inbound_scid_alias is not set

### DIFF
--- a/__tests__/todos.ts
+++ b/__tests__/todos.ts
@@ -129,6 +129,31 @@ describe('Todos selector', () => {
 		);
 	});
 
+	it('should return lightningConnectingTodo if there is a pending channel and open channels', () => {
+		const state = cloneDeep(s);
+
+		const channel1 = {
+			channel_id: 'channel1',
+			is_channel_ready: true,
+		} as TChannel;
+		const channel2 = {
+			channel_id: 'channel2',
+			is_channel_ready: false,
+		} as TChannel;
+		state.lightning.nodes.wallet0.channels.bitcoinRegtest = {
+			channel1,
+			channel2,
+		};
+		state.lightning.nodes.wallet0.openChannelIds.bitcoinRegtest = [
+			'channel1',
+			'channel2',
+		];
+
+		expect(todosFullSelector(state)).toEqual(
+			expect.arrayContaining([lightningConnectingTodo]),
+		);
+	});
+
 	it('should return transferClosingChannel if there are gracefully closing channels', () => {
 		const state = cloneDeep(s);
 

--- a/src/hooks/lightning.ts
+++ b/src/hooks/lightning.ts
@@ -140,6 +140,6 @@ export const useLightningChannelName = (
 		return `Connection ${index + 1}`;
 	} else {
 		const shortChannelId = ellipsis(channel.channel_id, 10);
-		return channel.inbound_scid_alias ?? shortChannelId;
+		return channel.inbound_scid_alias || shortChannelId;
 	}
 };

--- a/src/store/reselect/todos.ts
+++ b/src/store/reselect/todos.ts
@@ -127,6 +127,8 @@ export const todosFullSelector = createSelector(
 				res.push(transferToSpendingTodo);
 			} else if (balanceInTransfer?.amount_satoshis) {
 				res.push(transferToSavingsTodo); // TODO: find a way to distinguish between transfer to and from spendings
+			} else if (pendingChannels.length > 0) {
+				res.push(lightningConnectingTodo);
 			}
 		}
 


### PR DESCRIPTION
### Description

When I'm opening a channel using LNURL-channel from Blocktank I see no channel id on channels list screen.
This is because `inbound_scid_alias` is set to empty string.

For example:
```
{ user_channel_id: 'a9a7f5d70c3f0cae011c66adceda72d4',
  outbound_capacity_sat: 46053,
  inbound_capacity_sat: 45407,
  unspendable_punishment_reserve: 354,
  confirmations: 0,
  channel_id: '080ab26d5d95f343ae632418fc674b13d7c75003df1b2318bb6ce539d5f1e823',
  counterparty_node_id: '03b9a456fb45d5ac98c02040d39aec77fa3eeb41fd22cf40b862b393bcfc43473a',
  inbound_payment_scid: null,
  config_forwarding_fee_proportional_millionths: 0,
  is_channel_ready: false,
  balance_sat: 46407,
  is_public: false,
  funding_txid: '23e8f1d539e56cbb18231bdf0350c7d7134b67fc182463ae43f3955d6db20a08',
  confirmations_required: 1,
  is_outbound: false,
  config_forwarding_fee_base_msat: 1000,
  channel_type: '401000',
  force_close_spend_delay: 144,
  short_channel_id: '',
  channel_value_satoshis: 92814,
  is_usable: false,
  inbound_scid_alias: '' }
  ```

Also I've fixed LN connection card now shows during second LN channel opening

### Linked Issues/Tasks

closes #1490

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video

![Simulator Screenshot - iPhone 15 Pro - 2024-01-16 at 12 21 29](https://github.com/synonymdev/bitkit/assets/155891/ea6d99a2-d512-4849-b639-7cfc920bfe98)
