### PR TITLE
feat(wallet): Show info toast when switching balance unit

### DIFF
--- a/src/components/BalanceHeader.tsx
+++ b/src/components/BalanceHeader.tsx
@@ -6,7 +6,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import { Caption13Up } from '../styles/text';
 import { EyeIcon } from '../styles/icons';
 import Money from './Money';
-import { useBalance, useSwitchUnit } from '../hooks/wallet';
+import { useBalance, useSwitchUnitAnnounced } from '../hooks/wallet';
 import { updateSettings } from '../store/slices/settings';
 import {
 	primaryUnitSelector,
@@ -18,7 +18,7 @@ import {
  */
 const BalanceHeader = (): ReactElement => {
 	const { t } = useTranslation('wallet');
-	const [_, switchUnit] = useSwitchUnit();
+	const onSwitchUnit = useSwitchUnitAnnounced();
 	const { totalBalance, claimableBalance } = useBalance();
 	const dispatch = useAppDispatch();
 	const unit = useAppSelector(primaryUnitSelector);
@@ -57,7 +57,7 @@ const BalanceHeader = (): ReactElement => {
 			<TouchableOpacity
 				style={styles.row}
 				testID="TotalBalance"
-				onPress={switchUnit}>
+				onPress={onSwitchUnit}>
 				<Money
 					sats={totalBalance}
 					unit={unit}

--- a/src/screens/Wallets/WalletsDetail/index.tsx
+++ b/src/screens/Wallets/WalletsDetail/index.tsx
@@ -37,7 +37,7 @@ import { Title } from '../../../styles/text';
 import NavigationHeader from '../../../components/NavigationHeader';
 import useColors from '../../../hooks/colors';
 import { useAppDispatch, useAppSelector } from '../../../hooks/redux';
-import { useBalance, useSwitchUnit } from '../../../hooks/wallet';
+import { useBalance, useSwitchUnitAnnounced } from '../../../hooks/wallet';
 import ActivityList from '../../Activity/ActivityList';
 import BitcoinBreakdown from './BitcoinBreakdown';
 import SafeAreaInset from '../../../components/SafeAreaInset';
@@ -101,7 +101,7 @@ const WalletsDetail = ({
 	const ignoresHideBalanceToast = useAppSelector(
 		ignoresHideBalanceToastSelector,
 	);
-	const [_, switchUnit] = useSwitchUnit();
+	const onSwitchUnit = useSwitchUnitAnnounced();
 	const colors = useColors();
 	const size = useSharedValue({ width: 0, height: 0 });
 	const title = capitalize(assetType);
@@ -217,7 +217,7 @@ const WalletsDetail = ({
 										style={styles.cell}
 										entering={FadeIn}
 										exiting={FadeOut}>
-										<TouchableOpacity onPress={switchUnit}>
+										<TouchableOpacity onPress={onSwitchUnit}>
 											<Money
 												sats={totalBalance}
 												enableHide={true}
@@ -240,7 +240,7 @@ const WalletsDetail = ({
 											onSwipeLeft={toggleHideBalance}
 											onSwipeRight={toggleHideBalance}>
 											<TouchableOpacity
-												onPress={switchUnit}
+												onPress={onSwitchUnit}
 												style={styles.largeValueContainer}>
 												<Money
 													sats={totalBalance}

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -339,6 +339,7 @@ const migrations = {
 			user: {
 				...state.user,
 				ignoresHideBalanceToast: false,
+				ignoresSwitchUnitToast: false,
 			},
 		};
 	},

--- a/src/store/reselect/user.ts
+++ b/src/store/reselect/user.ts
@@ -58,3 +58,8 @@ export const ignoresHideBalanceToastSelector = createSelector(
 	[userState],
 	(user): boolean => user.ignoresHideBalanceToast,
 );
+
+export const ignoresSwitchUnitToastSelector = createSelector(
+	[userState],
+	(user): boolean => user.ignoresSwitchUnitToast,
+);

--- a/src/store/slices/user.ts
+++ b/src/store/slices/user.ts
@@ -14,6 +14,7 @@ export type TUser = {
 	requiresRemoteRestore: boolean;
 	startCoopCloseTimestamp: number;
 	ignoresHideBalanceToast: boolean;
+	ignoresSwitchUnitToast: boolean;
 };
 
 export const initialUserState: TUser = {
@@ -28,6 +29,7 @@ export const initialUserState: TUser = {
 	requiresRemoteRestore: false,
 	startCoopCloseTimestamp: 0,
 	ignoresHideBalanceToast: false,
+	ignoresSwitchUnitToast: false,
 };
 
 export const userSlice = createSlice({
@@ -66,6 +68,9 @@ export const userSlice = createSlice({
 		ignoreHideBalanceToast: (state) => {
 			state.ignoresHideBalanceToast = true;
 		},
+		ignoreSwitchUnitToast: (state) => {
+			state.ignoresSwitchUnitToast = true;
+		},
 		resetUserState: () => initialUserState,
 	},
 });
@@ -83,6 +88,7 @@ export const {
 	verifyBackup,
 	acceptBetaRisk,
 	ignoreHideBalanceToast,
+	ignoreSwitchUnitToast,
 	resetUserState,
 } = actions;
 

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -193,5 +193,7 @@
 	"lnurl_p_title": "Send Bitcoin",
 	"lnurl_p_max": "Maximum amount",
 	"balance_hidden_title" : "Wallet Balance Hidden",
-	"balance_hidden_message" : "Swipe your wallet balance to reveal it again."
+	"balance_hidden_message" : "Swipe your wallet balance to reveal it again.",
+	"balance_unit_switched_title" : "Switched to {unit}",
+	"balance_unit_switched_message" : "Tap your wallet balance to switch it back to {unit}."
 }


### PR DESCRIPTION
### Description

Added a toast message to clarify balance unit switch actions.

Works in both balance headers:
- Wallet overview (Home)
- Bitcoin assets (Wallet detail)

Toast gets displayed only once: on first use.

### Linked Issues/Tasks

[Bitkit v45 prototype → Toast for balance unit switch](https://app.asana.com/0/1206229374951491/1206354352883296/f) (Asana)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/4588074/4e4e93e6-5dda-41b1-874d-8318df35432d

### QA Notes

See above video

### Dev Notes
1. I'm not sure if I broke a few rules on how we approach these things when creating the reusable `useSwitchUnitAnnounced` hook.
  Happy to get feedback / suggestions for alternative approaches if it feels needed.
2. I'm targeting the PR for the [hide balance toast](https://github.com/synonymdev/bitkit/pull/1498) as base branch to avoid having to do 2 redux store migrations and also because that PR isn't yet merged due to unsuccessful e2e tests. This changeset could've been just a push to that PR but then it would make it less easy to review.