### PR TITLE
fix: improve BT order watching

### DIFF
--- a/src/screens/Lightning/CustomSetup.tsx
+++ b/src/screens/Lightning/CustomSetup.tsx
@@ -33,6 +33,7 @@ import {
 } from '../../utils/conversion';
 import { getFiatDisplayValues } from '../../utils/displayValues';
 import { showToast } from '../../utils/notifications';
+import { estimateOrderFee } from '../../utils/blocktank';
 import { startChannelPurchase } from '../../store/utils/blocktank';
 import { EUnit } from '../../store/types/wallet';
 import {
@@ -272,35 +273,23 @@ const CustomSetup = ({
 		}
 
 		const getChannelOpenCost = async (): Promise<void> => {
-			// TODO: replace with estimateOrderFee
-			// const response2 = await estimateOrderFee({
-			// 	lspBalanceSat: spendingAmount,
-			// 	channelExpiryWeeks: DEFAULT_CHANNEL_DURATION,
-			// 	options: {
-			// 		clientBalanceSat: amount,
-			// 		couponCode: 'bitkit',
-			// 		lspNodeId: blocktankInfo.nodes[0].pubkey,
-			// 	}
-			// 	// localBalance: amount,
-			// 	// selectedWallet,
-			// 	// selectedNetwork,
-			// });
-			const response = await startChannelPurchase({
-				remoteBalance: spendingAmount,
-				localBalance: amount,
-				channelExpiry: DEFAULT_CHANNEL_DURATION,
-				selectedWallet,
-				selectedNetwork,
-				lspNodeId: blocktankInfo.nodes[0].pubkey,
-				turboChannel:
-					spendingAmount <= blocktankInfo.options.max0ConfClientBalanceSat,
+			const res = await estimateOrderFee({
+				lspBalanceSat: amount,
+				channelExpiryWeeks: DEFAULT_CHANNEL_DURATION,
+				options: {
+					clientBalanceSat: spendingAmount,
+					couponCode: 'bitkit',
+					lspNodeId: blocktankInfo.nodes[0].pubkey,
+					turboChannel:
+						spendingAmount <= blocktankInfo.options.max0ConfClientBalanceSat,
+				},
 			});
-			if (response.isErr()) {
+			if (res.isErr()) {
 				return;
 			}
+
 			const { fiatSymbol, fiatValue } = getFiatDisplayValues({
-				satoshis:
-					response.value.channelOpenFee + response.value.transactionFeeEstimate,
+				satoshis: res.value,
 			});
 
 			setChannelOpenFee((value) => ({

--- a/src/screens/Transfer/Setup.tsx
+++ b/src/screens/Transfer/Setup.tsx
@@ -137,7 +137,6 @@ const Setup = ({ navigation }: TransferScreenProps<'Setup'>): ReactElement => {
 			localBalance,
 			turboChannel:
 				remoteBalance <= blocktankInfo.options.max0ConfClientBalanceSat,
-			channelExpiry: 12,
 		});
 
 		setLoading(false);

--- a/src/store/utils/blocktank.ts
+++ b/src/store/utils/blocktank.ts
@@ -46,6 +46,7 @@ import {
 	updateBlocktankOrder,
 	updateCjitEntry,
 } from '../slices/blocktank';
+import { DEFAULT_CHANNEL_DURATION } from '../../screens/Lightning/CustomConfirm';
 
 /**
  * Retrieves & updates the status of stored orders that may have changed.
@@ -216,7 +217,7 @@ export const refreshBlocktankInfo = async (): Promise<Result<string>> => {
 export const startChannelPurchase = async ({
 	remoteBalance,
 	localBalance,
-	channelExpiry = 6,
+	channelExpiry = DEFAULT_CHANNEL_DURATION,
 	lspNodeId,
 	couponCode,
 	turboChannel = true,


### PR DESCRIPTION
### Description

- protect watchOrder function from starting same order twice
- start watchOrder on start only for paid BT orders
- use estimateOrderFee instead of creating BT order

### Type of change

Refactoring

### Tests

No test
