### PR TITLE
fix: add migration for widget.showTitle

### DIFF
--- a/src/components/BlocksWidget.tsx
+++ b/src/components/BlocksWidget.tsx
@@ -75,7 +75,7 @@ const BlocksWidget = ({
 		// get data once then subscribe to updates
 		getData();
 
-		let unsubscribe: () => void;
+		let unsubscribe: () => void = () => {};
 
 		// subscriptions are breaking e2e tests
 		if (!__E2E__) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -40,7 +40,7 @@ const persistConfig = {
 	key: 'root',
 	storage: mmkvStorage,
 	// increase version after store shape changes
-	version: 32,
+	version: 33,
 	stateReconciler: autoMergeLevel2,
 	blacklist: ['receive', 'ui'],
 	migrate: createMigrate(migrations, { debug: __ENABLE_MIGRATION_DEBUG__ }),

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -343,6 +343,26 @@ const migrations = {
 			},
 		};
 	},
+	33: (state): PersistedState => {
+		const widgets = state.widgets.widgets;
+
+		for (const url in widgets) {
+			const widget = widgets[url]!;
+			const isFeedWidget = Object.hasOwn(widget, 'type');
+
+			if (isFeedWidget && widget.extras.showTitle === undefined) {
+				widget.extras.showTitle = true;
+			}
+		}
+
+		return {
+			...state,
+			widgets: {
+				...state.widgets,
+				widgets: widgets,
+			},
+		};
+	},
 };
 
 export default migrations;


### PR DESCRIPTION
### Description

Add migration for widget.showTitle, it is set to true if was undefined
Also fix small bug in BlockWidget where unsubscribe is undefined during e2e test

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video

![image](https://github.com/synonymdev/bitkit/assets/155891/abba85e6-ca4d-4c55-997c-62f56c386fc2)
