### PR TITLE
chore(wallet): Upgrade react-native-mmkv

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -394,7 +394,7 @@ PODS:
     - React-Core
   - react-native-ldk (0.0.127):
     - React
-  - react-native-mmkv (2.10.2):
+  - react-native-mmkv (2.11.0):
     - MMKV (>= 1.2.13)
     - React-Core
   - react-native-netinfo (11.0.0):
@@ -906,7 +906,7 @@ SPEC CHECKSUMS:
   react-native-image-picker: 2e2e82aba9b6a91a7c78f7d9afde341a2659c7b8
   react-native-keep-awake: ad1d67f617756b139536977a0bf06b27cec0714a
   react-native-ldk: 4ab3d26d5e1356313c572814289cc516dc18dd88
-  react-native-mmkv: 9ae7ca3977e8ef48dbf7f066974eb844c20b5fd7
+  react-native-mmkv: e97c0c79403fb94577e5d902ab1ebd42b0715b43
   react-native-netinfo: 5ddbf20865bcffab6b43d0e4e1fd8b3896beb898
   react-native-quick-base64: a5dbe4528f1453e662fcf7351029500b8b63e7bb
   react-native-quick-crypto: 455c1b411db006dba1026a30681ececb19180187

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "react-native-keyboard-accessory": "0.1.16",
     "react-native-keychain": "8.1.2",
     "react-native-localize": "3.0.2",
-    "react-native-mmkv": "2.10.2",
+    "react-native-mmkv": "2.11.0",
     "react-native-modal": "13.0.1",
     "react-native-permissions": "3.10.1",
     "react-native-polyfill-globals": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10648,10 +10648,10 @@ react-native-mmkv-flipper-plugin@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-native-mmkv-flipper-plugin/-/react-native-mmkv-flipper-plugin-1.0.0.tgz#f87f747d8cea51d2b12a1e711287feff5f212788"
   integrity sha512-e3owMIBzXez45Wz8Ac84Vf1FmfwMXFVUpf/gCDWDLq19w7iCipVezQjlZo8ISVza8aQf1G4ggaK/r+qqtGmRlg==
 
-react-native-mmkv@2.10.2:
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-2.10.2.tgz#73f06bb710388f67bade031e7b8e42a6d2358e40"
-  integrity sha512-hNrZzwvIFyogJkqf//rVSw7EwceYqkx/jl3hb5tzct6qqwEmS1L9ybvnDjzDkaMyDeouQIqAnsdnb6AuDSrgQQ==
+react-native-mmkv@2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-2.11.0.tgz#51b9985f6a5c09fe9c16d8c1861cc2901856ace1"
+  integrity sha512-28PdUHjZJmAw3q+8zJDAAdohnZMpDC7WgRUJxACOMkcmJeqS3u5cKS/lSq2bhf1CvaeIiHYHUWiyatUjMRCDQQ==
 
 react-native-modal@13.0.1:
   version "13.0.1"


### PR DESCRIPTION
### Description
- Upgrades `react-native-mmkv` to `2.11.0` for security/vulnerability fixes.

### Type of change
- [x] Dependency Upgrade

### Tests
- [x] No test
