### PR TITLE
fix(settings): Fix ui issues on app status screen

### DIFF
--- a/src/components/NavigationHeader.tsx
+++ b/src/components/NavigationHeader.tsx
@@ -173,6 +173,7 @@ const styles = StyleSheet.create({
 	},
 	title: {
 		textAlign: 'center',
+		width: '100%',
 	},
 	action: {
 		flex: 1,

--- a/src/screens/Settings/AppStatus/index.tsx
+++ b/src/screens/Settings/AppStatus/index.tsx
@@ -202,25 +202,20 @@ const AppStatus = ({}: SettingsScreenProps<'AppStatus'>): ReactElement => {
 	];
 
 	return (
-		<ThemedView style={styles.container}>
-			<SettingsView
-				title={t('status.title')}
-				fullHeight={true}
-				showBackNavigation={true}>
-				<ScrollView style={styles.statusRoot}>
-					{items.map((it) => (
-						<Status key={it.item} {...it} />
-					))}
-				</ScrollView>
-			</SettingsView>
-		</ThemedView>
+		<SettingsView
+			title={t('status.title')}
+			fullHeight={true}
+			showBackNavigation={true}>
+			<ScrollView style={styles.statusRoot}>
+				{items.map((it) => (
+					<Status key={it.item} {...it} />
+				))}
+			</ScrollView>
+		</SettingsView>
 	);
 };
 
 const styles = StyleSheet.create({
-	container: {
-		flex: 1,
-	},
 	statusRoot: {
 		flex: 1,
 	},
@@ -228,7 +223,7 @@ const styles = StyleSheet.create({
 		marginHorizontal: 16,
 		borderBottomWidth: 1,
 		borderBottomColor: 'rgba(255, 255, 255, 0.1)',
-		height: 56,
+		height: 76,
 		flexDirection: 'row',
 		alignItems: 'center',
 	},


### PR DESCRIPTION
### Description
Fixes the 2 issues reported on the `Support` → `App Status` screen:

1. Page title getting trimmed
   <img width="315" src="https://github.com/synonymdev/bitkit/assets/63161412/1377a8f1-d78c-486e-af94-ea8686c5536e">
3. Set List item height to `76` to better match the Figma design
   <img width="600" src="https://github.com/synonymdev/bitkit/assets/4588074/eff13a9c-f0e8-4c37-bf3d-ab8676199a3a">

### Linked Issues/Tasks

- #1523

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Tests

- [x] No test

### Screenshot / Video

N/a

### QA Notes

- Check linked issue.
- Check other screens with long titles to make sure it doesn't break anything (PS. didn't for me, but then again in my case I couldn't repro the trimming bug)