### PR TITLE
fix(wallet): Re-Adds updateExchangeRates to setupOnChainWallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@synonymdev/web-relay": "1.0.7",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
     "bech32": "2.0.0",
-    "beignet": "0.0.19",
+    "beignet": "0.0.20",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
     "bip39": "3.0.4",

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -40,10 +40,8 @@ import {
 	EAvailableNetworks,
 	EFeeId,
 	getDefaultWalletData,
-	getExchangeRates,
 	getStorageKeyValues,
 	IBoostedTransaction,
-	IExchangeRates,
 	IOnchainFees,
 	IOutput,
 	ISendTransaction,
@@ -53,6 +51,7 @@ import {
 import { ETransactionSpeed } from '../types/settings';
 import { updateOnchainFeeEstimates } from '../utils/fees';
 import { getMaxSendAmount } from '../../utils/wallet/transactions';
+import { getExchangeRates, IExchangeRates } from '../../utils/exchange-rate';
 
 export const updateWallet = (
 	payload: Partial<IWalletStore>,
@@ -814,9 +813,6 @@ export const setWalletData = async <K extends keyof IWalletData>(
 					header: data as IHeader,
 					selectedNetwork: getNetworkFromBeignet(network),
 				});
-				break;
-			case 'exchangeRates':
-				updateExchangeRates(data as IExchangeRates);
 				break;
 			case 'feeEstimates':
 				updateOnchainFeeEstimates({

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -53,6 +53,7 @@ import {
 	generateNewReceiveAddress,
 	getWalletData,
 	setWalletData,
+	updateExchangeRates,
 	updateWallet,
 } from '../../store/actions/wallet';
 import { TCoinSelectPreference } from '../../store/types/settings';
@@ -1569,6 +1570,7 @@ export const setupOnChainWallet = async ({
 			setData: setWalletData,
 		};
 	}
+	updateExchangeRates();
 	const createWalletResponse = await Wallet.create({
 		name,
 		mnemonic,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5563,10 +5563,10 @@ bech32@^1.1.2, bech32@^1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-beignet@0.0.19:
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.19.tgz#9d5242ecb9f6853bc3c3b62e2a79c7c45cc546e2"
-  integrity sha512-A8fCZ3XiCmtWaU3nneXRZ9pJ2XBqVVfHQDyf7F6AXhKFcX9e6VVFBglQDsNEDAgFBUK9wBQmusktpeDYFT+Xpg==
+beignet@0.0.20:
+  version "0.0.20"
+  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.20.tgz#2f11389dacac1957eb36bf26b7bb7319d69ff241"
+  integrity sha512-m816N3mJ/wfIcHpX+bpFMsyrvn6yviXQqekMvmqcB1QNKNJ0MFp4Nt9b3+rRB4HvwmayJqyHDvhI+TAyZ+UUJA==
   dependencies:
     "@bitcoinerlab/secp256k1" "1.0.5"
     bech32 "2.0.0"


### PR DESCRIPTION
### Description
- The latest version of beignet removed `exchangeRates` so this re-adds `updateExchangeRates` to the `setupOnChainWallet` method.
- Cleans up & Applies fix to `lm.start` function params so the electrum network is now read properly from beignet.
- Upgrades `beignet` to `0.0.20`.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (improving code without creating new functionality)

### Tests
- [x] No test
