### PR TITLE
fix: sleep before .tapReturn()

### DIFF
--- a/e2e/lightning.e2e.js
+++ b/e2e/lightning.e2e.js
@@ -206,6 +206,7 @@ d('Lightning', () => {
 			await element(by.id('RecipientManual')).tap();
 			await element(by.id('RecipientInput')).replaceText(invoice3);
 			await element(by.id('RecipientInput')).tapReturnKey();
+			await sleep(1000); // wait for keyboard to hide
 			await element(by.id('AddressContinue')).tap();
 			await element(
 				by.id('N1').withAncestor(by.id('SendAmountNumberPad')),
@@ -230,6 +231,7 @@ d('Lightning', () => {
 			await element(by.id('RecipientManual')).tap();
 			await element(by.id('RecipientInput')).replaceText(invoice4);
 			await element(by.id('RecipientInput')).tapReturnKey();
+			await sleep(1000); // wait for keyboard to hide
 			await element(by.id('AddressContinue')).tap();
 
 			// Review & Send

--- a/e2e/onchain.e2e.js
+++ b/e2e/onchain.e2e.js
@@ -100,6 +100,7 @@ d('Onchain', () => {
 			await element(by.id('RecipientManual')).tap();
 			await element(by.id('RecipientInput')).replaceText(coreAddress);
 			await element(by.id('RecipientInput')).tapReturnKey();
+			await sleep(1000); // wait for keyboard to hide
 			await element(by.id('AddressContinue')).tap();
 
 			// Amount / NumberPad
@@ -272,6 +273,7 @@ d('Onchain', () => {
 			await element(by.id('RecipientManual')).tap();
 			await element(by.id('RecipientInput')).replaceText(coreAddress);
 			await element(by.id('RecipientInput')).tapReturnKey();
+			await sleep(1000); // wait for keyboard to hide
 			await element(by.id('AddressContinue')).tap();
 
 			// enter amount that would leave dust

--- a/e2e/security.e2e.js
+++ b/e2e/security.e2e.js
@@ -130,6 +130,7 @@ d('Settings Security And Privacy', () => {
 		await element(by.id('RecipientManual')).tap();
 		await element(by.id('RecipientInput')).replaceText(coreAddress);
 		await element(by.id('RecipientInput')).tapReturnKey();
+		await sleep(1000); // wait for keyboard to hide
 		await element(by.id('AddressContinue')).tap();
 		await element(by.id('N1').withAncestor(by.id('SendAmountNumberPad'))).tap();
 		await element(
@@ -192,6 +193,7 @@ d('Settings Security And Privacy', () => {
 		await element(by.id('RecipientManual')).tap();
 		await element(by.id('RecipientInput')).replaceText(coreAddress);
 		await element(by.id('RecipientInput')).tapReturnKey();
+		await sleep(1000); // wait for keyboard to hide
 		await element(by.id('AddressContinue')).tap();
 		await element(by.id('N1').withAncestor(by.id('SendAmountNumberPad'))).tap();
 		await element(


### PR DESCRIPTION
### Description

Before submit address enter form we need to wait for keyboard to close and for address to be validated

### Linked Issues/Tasks



### Type of change

Bug fix

### Tests

Detox test
