### PR TITLE
feat(settings): add profiler

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -408,6 +408,9 @@ PODS:
     - React-Core
   - react-native-randombytes (3.6.1):
     - React-Core
+  - react-native-release-profiler (0.1.6):
+    - RCT-Folly (= 2021.07.22.00)
+    - React-Core
   - react-native-restart (0.0.27):
     - React-Core
   - react-native-safe-area-context (4.7.4):
@@ -645,6 +648,7 @@ DEPENDENCIES:
   - react-native-quick-base64 (from `../node_modules/react-native-quick-base64`)
   - react-native-quick-crypto (from `../node_modules/react-native-quick-crypto`)
   - react-native-randombytes (from `../node_modules/react-native-randombytes`)
+  - react-native-release-profiler (from `../node_modules/react-native-release-profiler`)
   - react-native-restart (from `../node_modules/react-native-restart`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-skia (from `../node_modules/@shopify/react-native-skia`)"
@@ -778,6 +782,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-quick-crypto"
   react-native-randombytes:
     :path: "../node_modules/react-native-randombytes"
+  react-native-release-profiler:
+    :path: "../node_modules/react-native-release-profiler"
   react-native-restart:
     :path: "../node_modules/react-native-restart"
   react-native-safe-area-context:
@@ -911,6 +917,7 @@ SPEC CHECKSUMS:
   react-native-quick-base64: a5dbe4528f1453e662fcf7351029500b8b63e7bb
   react-native-quick-crypto: 455c1b411db006dba1026a30681ececb19180187
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
+  react-native-release-profiler: 5cf11f861bdb8f4b90d0cef3b002d82cfa7043ad
   react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
   react-native-safe-area-context: 2cd91d532de12acdb0a9cbc8d43ac72a8e4c897c
   react-native-skia: a395bbbb438d593e525f65d0886c36d1c30f0604

--- a/ios/bitkit.xcodeproj/project.pbxproj
+++ b/ios/bitkit.xcodeproj/project.pbxproj
@@ -8,16 +8,16 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* bitkitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* bitkitTests.m */; };
+		12DDECE6DB6F04C489311159 /* libPods-bitkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E82FA9E64FA69625137C3E /* libPods-bitkit.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		567C8B7A7734CB223E1D3C42 /* libPods-bitkit-bitkitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 375987267538AB596CB234D8 /* libPods-bitkit-bitkitTests.a */; };
 		777F5BE129EDEB75005E0E4B /* InterTight-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 777F5BDD29EDEB75005E0E4B /* InterTight-Bold.ttf */; };
 		777F5BE229EDEB75005E0E4B /* InterTight-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 777F5BDE29EDEB75005E0E4B /* InterTight-Regular.ttf */; };
 		777F5BE329EDEB75005E0E4B /* InterTight-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 777F5BDF29EDEB75005E0E4B /* InterTight-SemiBold.ttf */; };
 		777F5BE429EDEB75005E0E4B /* InterTight-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 777F5BE029EDEB75005E0E4B /* InterTight-Medium.ttf */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
-		EA399CF262993ABC899372BE /* libPods-bitkit-bitkitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 257540823C179C3916DBC2CD /* libPods-bitkit-bitkitTests.a */; };
-		EED03195AC51DE5CD4681342 /* libPods-bitkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E0D15B3D685BED85C2AEF14B /* libPods-bitkit.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,23 +34,23 @@
 		00E356EE1AD99517003FC87E /* bitkitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = bitkitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* bitkitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bitkitTests.m; sourceTree = "<group>"; };
+		0D53BC92A62A7EE80BB4DBC9 /* Pods-bitkit-bitkitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.debug.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* bitkit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = bitkit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = bitkit/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = bitkit/AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = bitkit/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = bitkit/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = bitkit/main.m; sourceTree = "<group>"; };
-		257540823C179C3916DBC2CD /* libPods-bitkit-bitkitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit-bitkitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		354C379BD300695F3EE7A40E /* Pods-bitkit-bitkitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.release.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.release.xcconfig"; sourceTree = "<group>"; };
+		375987267538AB596CB234D8 /* libPods-bitkit-bitkitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit-bitkitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		777F5BDD29EDEB75005E0E4B /* InterTight-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "InterTight-Bold.ttf"; sourceTree = "<group>"; };
 		777F5BDE29EDEB75005E0E4B /* InterTight-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "InterTight-Regular.ttf"; sourceTree = "<group>"; };
 		777F5BDF29EDEB75005E0E4B /* InterTight-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "InterTight-SemiBold.ttf"; sourceTree = "<group>"; };
 		777F5BE029EDEB75005E0E4B /* InterTight-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "InterTight-Medium.ttf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = bitkit/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		8ACF648C06AFB544DF2D6BE2 /* Pods-bitkit-bitkitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.release.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.release.xcconfig"; sourceTree = "<group>"; };
-		AE807EE532D15679B162FB0A /* Pods-bitkit-bitkitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.debug.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.debug.xcconfig"; sourceTree = "<group>"; };
-		D516AE4DD8DE53821B34AC30 /* Pods-bitkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.release.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.release.xcconfig"; sourceTree = "<group>"; };
-		DCF501CACCB24AC5EAD33026 /* Pods-bitkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.debug.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.debug.xcconfig"; sourceTree = "<group>"; };
-		E0D15B3D685BED85C2AEF14B /* libPods-bitkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9B2123A1E473C9CBAFE25212 /* Pods-bitkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.debug.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.debug.xcconfig"; sourceTree = "<group>"; };
+		C1E82FA9E64FA69625137C3E /* libPods-bitkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C377ED0D202043E3FF7A0C4E /* Pods-bitkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.release.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -59,7 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EA399CF262993ABC899372BE /* libPods-bitkit-bitkitTests.a in Frameworks */,
+				567C8B7A7734CB223E1D3C42 /* libPods-bitkit-bitkitTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -67,7 +67,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EED03195AC51DE5CD4681342 /* libPods-bitkit.a in Frameworks */,
+				12DDECE6DB6F04C489311159 /* libPods-bitkit.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -108,8 +108,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				E0D15B3D685BED85C2AEF14B /* libPods-bitkit.a */,
-				257540823C179C3916DBC2CD /* libPods-bitkit-bitkitTests.a */,
+				C1E82FA9E64FA69625137C3E /* libPods-bitkit.a */,
+				375987267538AB596CB234D8 /* libPods-bitkit-bitkitTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -161,10 +161,10 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				DCF501CACCB24AC5EAD33026 /* Pods-bitkit.debug.xcconfig */,
-				D516AE4DD8DE53821B34AC30 /* Pods-bitkit.release.xcconfig */,
-				AE807EE532D15679B162FB0A /* Pods-bitkit-bitkitTests.debug.xcconfig */,
-				8ACF648C06AFB544DF2D6BE2 /* Pods-bitkit-bitkitTests.release.xcconfig */,
+				9B2123A1E473C9CBAFE25212 /* Pods-bitkit.debug.xcconfig */,
+				C377ED0D202043E3FF7A0C4E /* Pods-bitkit.release.xcconfig */,
+				0D53BC92A62A7EE80BB4DBC9 /* Pods-bitkit-bitkitTests.debug.xcconfig */,
+				354C379BD300695F3EE7A40E /* Pods-bitkit-bitkitTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -176,12 +176,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "bitkitTests" */;
 			buildPhases = (
-				851E2B919AAD431FC5A703ED /* [CP] Check Pods Manifest.lock */,
+				D0B2D6AAF02D3E8F8F31443B /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				A6D855DE6BFB21F0A0F2340D /* [CP] Embed Pods Frameworks */,
-				CCE34C56B7B45EBCC2C38502 /* [CP] Copy Pods Resources */,
+				A742D333941DC1C722CF692D /* [CP] Embed Pods Frameworks */,
+				6F6FB320C9A4CA35B7A16EC1 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -197,18 +197,18 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "bitkit" */;
 			buildPhases = (
-				05C7D06B93803F54D3572C18 /* [CP] Check Pods Manifest.lock */,
+				2B35F90A69012C67CDE681FE /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				AAB639AAE1F516592DF37544 /* [CP] Embed Pods Frameworks */,
-				CD3C60493379C2C8269FE418 /* [CP] Copy Pods Resources */,
-				BAAA7359DAC94CEB1E0A412E /* [CP-User] [NODEJS MOBILE] Copy Node.js Project files */,
-				4FA8E5683F153007B92B8F27 /* [CP-User] [NODEJS MOBILE] Build Native Modules */,
-				DD84F8980CDE7E4B50EAF996 /* [CP-User] [NODEJS MOBILE] Sign Native Modules */,
-				F66225DC6ECD465D7FDE107B /* [CP-User] [NODEJS MOBILE] Remove Simulator Strip */,
+				0FBF2245AF91AC7E48263E57 /* [CP] Embed Pods Frameworks */,
+				09E298217A4D7521AF54D065 /* [CP] Copy Pods Resources */,
+				B7D3385FA9C9AE91C340765C /* [CP-User] [NODEJS MOBILE] Copy Node.js Project files */,
+				71D57A8D9ADC35D76226E259 /* [CP-User] [NODEJS MOBILE] Build Native Modules */,
+				766E60A6079B97D1B23E5D4C /* [CP-User] [NODEJS MOBILE] Sign Native Modules */,
+				61F0354FF2020C4ECB9B98EC /* [CP-User] [NODEJS MOBILE] Remove Simulator Strip */,
 			);
 			buildRules = (
 			);
@@ -295,7 +295,41 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		05C7D06B93803F54D3572C18 /* [CP] Check Pods Manifest.lock */ = {
+		09E298217A4D7521AF54D065 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		0FBF2245AF91AC7E48263E57 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		2B35F90A69012C67CDE681FE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -317,7 +351,34 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		4FA8E5683F153007B92B8F27 /* [CP-User] [NODEJS MOBILE] Build Native Modules */ = {
+		61F0354FF2020C4ECB9B98EC /* [CP-User] [NODEJS MOBILE] Remove Simulator Strip */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			name = "[CP-User] [NODEJS MOBILE] Remove Simulator Strip";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/sh\nset -e\n\nFRAMEWORK_BINARY_PATH=\"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/NodeMobile.framework/NodeMobile\"\nFRAMEWORK_STRIPPED_PATH=\"$FRAMEWORK_BINARY_PATH-strip\"\n\nif [ \"$PLATFORM_NAME\" != \"iphonesimulator\" ]; then\n  if $(lipo \"$FRAMEWORK_BINARY_PATH\" -verify_arch \"x86_64\") ; then\n    lipo -output \"$FRAMEWORK_STRIPPED_PATH\" -remove \"x86_64\" \"$FRAMEWORK_BINARY_PATH\"\n    rm \"$FRAMEWORK_BINARY_PATH\"\n    mv \"$FRAMEWORK_STRIPPED_PATH\" \"$FRAMEWORK_BINARY_PATH\"\n    echo \"Removed simulator strip from NodeMobile.framework\"\n  fi\nfi\n";
+		};
+		6F6FB320C9A4CA35B7A16EC1 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		71D57A8D9ADC35D76226E259 /* [CP-User] [NODEJS MOBILE] Build Native Modules */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -327,7 +388,44 @@
 			shellPath = /bin/sh;
 			shellScript = "#!/bin/sh\nset -e\n\nif [ -f ./.xcode.env ]; then\n  source \"./.xcode.env\";\nfi\nif [ -f ./.xcode.env.local ]; then\n  source \"./.xcode.env.local\";\nfi\n\nDESIRED_NODE_VERSION=\"18\"\nCURRENT_NODE_VERSION=\"$(node -p \"process.versions.node.split('.')[0]\")\"\nif [ \"$CURRENT_NODE_VERSION\" -ne \"$DESIRED_NODE_VERSION\" ]; then\n  echo \"nodejs-mobile-react-native requires Node.js version \\\n$DESIRED_NODE_VERSION accessible from Xcode, but found \\\n$(node -p 'process.versions.node')\"\n  exit 1\nfi\n\n# This is our nodejs-project folder that was copied to the Xcode build folder\nNODEPROJ=\"$CODESIGNING_FOLDER_PATH/nodejs-project\"\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, look for it in the project's\n#nodejs-assets/BUILD_NATIVE_MODULES.txt file.\nNODEJS_ASSETS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../nodejs-assets/ && pwd )\"\nPREFERENCE_FILE_PATH=\"$NODEJS_ASSETS_DIR/BUILD_NATIVE_MODULES.txt\"\n  if [ -f \"$PREFERENCE_FILE_PATH\" ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=\"$(cat $PREFERENCE_FILE_PATH | xargs)\"\n  fi\nfi\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, try to find .gyp files\n#to turn it on.\n  gypfiles=($(find \"$NODEPROJ\" -type f -name \"*.gyp\"))\n  if [ ${#gypfiles[@]} -gt 0 ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=1\n  else\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=0\n  fi\nfi\n\nif [ \"1\" != \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then exit 0; fi\n\n# Delete object files that may already come from within the npm package.\nfind \"$NODEPROJ\" -name \"*.o\" -type f -delete\nfind \"$NODEPROJ\" -name \"*.a\" -type f -delete\n\n# Function to skip compilation of a prebuilt module\npreparePrebuiltModule()\n{\n  local DOT_NODE_PATH=\"$1\"\n  local DOT_NODE_FULL=\"$(cd \"$(dirname -- \"$DOT_NODE_PATH\")\" >/dev/null; pwd -P)/$(basename -- \"$DOT_NODE_PATH\")\"\n  local MODULE_ROOT=\"$(cd $DOT_NODE_PATH && cd .. && cd .. && cd .. && pwd)\"\n  local MODULE_NAME=\"$(basename $MODULE_ROOT)\"\n  echo \"Preparing to use the prebuild in $MODULE_NAME\"\n  # Move the prebuild to the correct folder:\n  rm -rf $MODULE_ROOT/build\n  mkdir -p $MODULE_ROOT/build/Release\n  mv $DOT_NODE_FULL $MODULE_ROOT/build/Release/\n  # Hack the npm package to forcefully disable compile-on-install:\n  rm -rf $MODULE_ROOT/binding.gyp\n  sed -i.bak 's/\"install\"/\"dontinstall\"/g; s/\"rebuild\"/\"dontrebuild\"/g; s/\"gypfile\"/\"dontgypfile\"/g' $MODULE_ROOT/package.json\n}\n\n# Delete bundle contents that may be there from previous builds.\n# Handle the special case where the module has a prebuild that we want to use\nif [ \"$PLATFORM_PREFERRED_ARCH\" == \"arm64\" ]; then\n  PREBUILD_ARCH=\"arm64\"\nelse\n  PREBUILD_ARCH=\"x64\"\nfi\nif [ \"$PLATFORM_NAME\" == \"iphonesimulator\" ] && [ \"$NATIVE_ARCH\" == \"arm64\" ]; then\n  SUFFIX=\"-simulator\"\n  PREBUILD_ARCH=\"arm64\"\nelse\n  SUFFIX=\"\"\nfi\nfind -E \"$NODEPROJ\" \\\n    ! -regex \".*/prebuilds/ios-$PREBUILD_ARCH$SUFFIX\" \\\n    -regex '.*/prebuilds/[^/]*$' -type d \\\n    -prune -exec rm -rf \"{}\" \\;\nfind -E \"$NODEPROJ\" \\\n    ! -regex \".*/prebuilds/ios-$PREBUILD_ARCH$SUFFIX/.*\\.node$\" \\\n    -name '*.node' -type f \\\n    -exec rm \"{}\" \\;\nfind \"$NODEPROJ\" \\\n    -name \"*.framework\" -type d \\\n    -prune -exec rm -rf \"{}\" \\;\nfor DOT_NODE in `find -E \"$NODEPROJ\" -regex \".*/prebuilds/ios-$PREBUILD_ARCH$SUFFIX/.*\\.node$\"`; do\n  preparePrebuiltModule \"$DOT_NODE\"\ndone\n\n# Apply patches to the modules package.json\nif [ -d \"$NODEPROJ\"/node_modules/ ]; then\n  PATCH_SCRIPT_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/scripts/ && pwd )\"\n  NODEJS_PROJECT_MODULES_DIR=\"$( cd \"$NODEPROJ\" && cd node_modules && pwd )\"\n  node \"$PATCH_SCRIPT_DIR\"/patch-package.js $NODEJS_PROJECT_MODULES_DIR\nfi\n\n# Get the nodejs-mobile-gyp location\nNODEJS_MOBILE_GYP_BIN_FILE=\"$( cd \"$PROJECT_DIR\" && cd .. && node -p 'require.resolve(`nodejs-mobile-gyp/bin/node-gyp.js`)' )\"\n\n# Support building neon-bindings (Rust) native modules\nif [ -f ~/.cargo/env ]; then\n  source ~/.cargo/env;\nfi\n\n# Rebuild modules with right environment\nNODEJS_HEADERS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/ios/libnode/ && pwd )\"\npushd $NODEPROJ\nif [ \"$PLATFORM_NAME\" == \"iphoneos\" ]; then\n  GYP_DEFINES=\"OS=ios\" \\\n  CARGO_BUILD_TARGET=\"aarch64-apple-ios iossim=false\" \\\n  NODEJS_MOBILE_GYP=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_node_gyp=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_nodedir=\"$NODEJS_HEADERS_DIR\" \\\n  npm_config_platform=\"ios\" \\\n  npm_config_format=\"make-ios\" \\\n  npm_config_arch=\"arm64\" \\\n  npm --verbose --foreground-scripts rebuild --build-from-source\nelif [ \"$NATIVE_ARCH\" == \"arm64\" ]; then\n  GYP_DEFINES=\"OS=ios target_arch=arm64 iossim=true\" \\\n  CARGO_BUILD_TARGET=\"aarch64-apple-ios-sim\" \\\n  NODEJS_MOBILE_GYP=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_node_gyp=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_nodedir=\"$NODEJS_HEADERS_DIR\" \\\n  npm_config_platform=\"ios\" \\\n  npm_config_format=\"make-ios\" \\\n  npm_config_arch=\"arm64\" \\\n  npm --verbose --foreground-scripts rebuild --build-from-source\nelse\n  GYP_DEFINES=\"OS=ios target_arch=x64 iossim=true\" \\\n  CARGO_BUILD_TARGET=\"x86_64-apple-ios\" \\\n  NODEJS_MOBILE_GYP=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_node_gyp=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_nodedir=\"$NODEJS_HEADERS_DIR\" \\\n  npm_config_platform=\"ios\" \\\n  npm_config_format=\"make-ios\" \\\n  npm_config_arch=\"x64\" \\\n  npm --verbose --foreground-scripts rebuild --build-from-source\nfi\npopd\n";
 		};
-		851E2B919AAD431FC5A703ED /* [CP] Check Pods Manifest.lock */ = {
+		766E60A6079B97D1B23E5D4C /* [CP-User] [NODEJS MOBILE] Sign Native Modules */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			name = "[CP-User] [NODEJS MOBILE] Sign Native Modules";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/sh\nset -e\n\nif [ -f ./.xcode.env ]; then\n  source \"./.xcode.env\";\nfi\nif [ -f ./.xcode.env.local ]; then\n  source \"./.xcode.env.local\";\nfi\n\nDESIRED_NODE_VERSION=\"18\"\nCURRENT_NODE_VERSION=\"$(node -p \"process.versions.node.split('.')[0]\")\"\nif [ \"$CURRENT_NODE_VERSION\" -ne \"$DESIRED_NODE_VERSION\" ]; then\n  echo \"nodejs-mobile-react-native's ios-build-native-modules script requires \\\nNode.js version $DESIRED_NODE_VERSION, but found \\\n$(node -p 'process.versions.node')\"\n  exit 1\nfi\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, look for it in the project's\n#nodejs-assets/BUILD_NATIVE_MODULES.txt file.\nNODEJS_ASSETS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../nodejs-assets/ && pwd )\"\nPREFERENCE_FILE_PATH=\"$NODEJS_ASSETS_DIR/BUILD_NATIVE_MODULES.txt\"\n  if [ -f \"$PREFERENCE_FILE_PATH\" ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=\"$(cat $PREFERENCE_FILE_PATH | xargs)\"\n  fi\nfi\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, try to find .gyp files\n#to turn it on.\n  gypfiles=($(find \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -type f -name \"*.gyp\"))\n  if [ ${#gypfiles[@]} -gt 0 ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=1\n  else\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=0\n  fi\nfi\n\nif [ \"1\" != \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then exit 0; fi\n\n# Delete object files\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.o\" -type f -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.a\" -type f -delete\n\n# Create Info.plist for each framework built and loader override.\nPATCH_SCRIPT_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/scripts/ && pwd )\"\nNODEJS_PROJECT_DIR=\"$( cd \"$CODESIGNING_FOLDER_PATH\" && cd nodejs-project/ && pwd )\"\nnode \"$PATCH_SCRIPT_DIR\"/ios-create-plists-and-dlopen-override.js $NODEJS_PROJECT_DIR\n\n# Embed every resulting .framework in the application and delete them afterwards.\nembed_framework()\n{\n  FRAMEWORK_NAME=\"$(basename \"$1\")\"\n  cp -r \"$1\" \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/\"\n  /usr/bin/codesign --force --sign $EXPANDED_CODE_SIGN_IDENTITY --preserve-metadata=identifier,entitlements,flags --timestamp=none \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$FRAMEWORK_NAME\"\n}\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.framework\" -type d | while read frmwrk_path; do embed_framework \"$frmwrk_path\"; done\n\n#Delete gyp temporary .deps dependency folders from the project structure.\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -path \"*/.deps/*\" -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \".deps\" -type d -delete\n\n#Delete frameworks from their build paths\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -path \"*/*.framework/*\" -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.framework\" -type d -delete\n";
+		};
+		A742D333941DC1C722CF692D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B7D3385FA9C9AE91C340765C /* [CP-User] [NODEJS MOBILE] Copy Node.js Project files */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			name = "[CP-User] [NODEJS MOBILE] Copy Node.js Project files";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/sh\nset -e\n\nNODEJS_ASSETS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../nodejs-assets/ && pwd )\"\nNODEJS_BUILT_IN_MODULES_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/install/resources/nodejs-modules/ && pwd )\"\n\nif [ -d \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" ]; then\n  rm -rf \"$CODESIGNING_FOLDER_PATH/nodejs-project/\"\nfi\n\nif [ -d \"$CODESIGNING_FOLDER_PATH/builtin_modules/\" ]; then\n  rm -rf \"$CODESIGNING_FOLDER_PATH/builtin_modules/\"\nfi\n\nrsync --archive --delete \"$NODEJS_ASSETS_DIR/nodejs-project\" \"$CODESIGNING_FOLDER_PATH\"\nrsync --archive --delete \"$NODEJS_BUILT_IN_MODULES_DIR/builtin_modules\" \"$CODESIGNING_FOLDER_PATH\"\n";
+		};
+		D0B2D6AAF02D3E8F8F31443B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -348,104 +446,6 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
-		};
-		A6D855DE6BFB21F0A0F2340D /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		AAB639AAE1F516592DF37544 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		BAAA7359DAC94CEB1E0A412E /* [CP-User] [NODEJS MOBILE] Copy Node.js Project files */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			name = "[CP-User] [NODEJS MOBILE] Copy Node.js Project files";
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\nset -e\n\nNODEJS_ASSETS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../nodejs-assets/ && pwd )\"\nNODEJS_BUILT_IN_MODULES_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/install/resources/nodejs-modules/ && pwd )\"\n\nif [ -d \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" ]; then\n  rm -rf \"$CODESIGNING_FOLDER_PATH/nodejs-project/\"\nfi\n\nif [ -d \"$CODESIGNING_FOLDER_PATH/builtin_modules/\" ]; then\n  rm -rf \"$CODESIGNING_FOLDER_PATH/builtin_modules/\"\nfi\n\nrsync --archive --delete \"$NODEJS_ASSETS_DIR/nodejs-project\" \"$CODESIGNING_FOLDER_PATH\"\nrsync --archive --delete \"$NODEJS_BUILT_IN_MODULES_DIR/builtin_modules\" \"$CODESIGNING_FOLDER_PATH\"\n";
-		};
-		CCE34C56B7B45EBCC2C38502 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		CD3C60493379C2C8269FE418 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		DD84F8980CDE7E4B50EAF996 /* [CP-User] [NODEJS MOBILE] Sign Native Modules */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			name = "[CP-User] [NODEJS MOBILE] Sign Native Modules";
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\nset -e\n\nif [ -f ./.xcode.env ]; then\n  source \"./.xcode.env\";\nfi\nif [ -f ./.xcode.env.local ]; then\n  source \"./.xcode.env.local\";\nfi\n\nDESIRED_NODE_VERSION=\"18\"\nCURRENT_NODE_VERSION=\"$(node -p \"process.versions.node.split('.')[0]\")\"\nif [ \"$CURRENT_NODE_VERSION\" -ne \"$DESIRED_NODE_VERSION\" ]; then\n  echo \"nodejs-mobile-react-native's ios-build-native-modules script requires \\\nNode.js version $DESIRED_NODE_VERSION, but found \\\n$(node -p 'process.versions.node')\"\n  exit 1\nfi\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, look for it in the project's\n#nodejs-assets/BUILD_NATIVE_MODULES.txt file.\nNODEJS_ASSETS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../nodejs-assets/ && pwd )\"\nPREFERENCE_FILE_PATH=\"$NODEJS_ASSETS_DIR/BUILD_NATIVE_MODULES.txt\"\n  if [ -f \"$PREFERENCE_FILE_PATH\" ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=\"$(cat $PREFERENCE_FILE_PATH | xargs)\"\n  fi\nfi\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, try to find .gyp files\n#to turn it on.\n  gypfiles=($(find \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -type f -name \"*.gyp\"))\n  if [ ${#gypfiles[@]} -gt 0 ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=1\n  else\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=0\n  fi\nfi\n\nif [ \"1\" != \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then exit 0; fi\n\n# Delete object files\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.o\" -type f -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.a\" -type f -delete\n\n# Create Info.plist for each framework built and loader override.\nPATCH_SCRIPT_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/scripts/ && pwd )\"\nNODEJS_PROJECT_DIR=\"$( cd \"$CODESIGNING_FOLDER_PATH\" && cd nodejs-project/ && pwd )\"\nnode \"$PATCH_SCRIPT_DIR\"/ios-create-plists-and-dlopen-override.js $NODEJS_PROJECT_DIR\n\n# Embed every resulting .framework in the application and delete them afterwards.\nembed_framework()\n{\n  FRAMEWORK_NAME=\"$(basename \"$1\")\"\n  cp -r \"$1\" \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/\"\n  /usr/bin/codesign --force --sign $EXPANDED_CODE_SIGN_IDENTITY --preserve-metadata=identifier,entitlements,flags --timestamp=none \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$FRAMEWORK_NAME\"\n}\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.framework\" -type d | while read frmwrk_path; do embed_framework \"$frmwrk_path\"; done\n\n#Delete gyp temporary .deps dependency folders from the project structure.\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -path \"*/.deps/*\" -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \".deps\" -type d -delete\n\n#Delete frameworks from their build paths\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -path \"*/*.framework/*\" -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.framework\" -type d -delete\n";
-		};
-		F66225DC6ECD465D7FDE107B /* [CP-User] [NODEJS MOBILE] Remove Simulator Strip */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			name = "[CP-User] [NODEJS MOBILE] Remove Simulator Strip";
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\nset -e\n\nFRAMEWORK_BINARY_PATH=\"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/NodeMobile.framework/NodeMobile\"\nFRAMEWORK_STRIPPED_PATH=\"$FRAMEWORK_BINARY_PATH-strip\"\n\nif [ \"$PLATFORM_NAME\" != \"iphonesimulator\" ]; then\n  if $(lipo \"$FRAMEWORK_BINARY_PATH\" -verify_arch \"x86_64\") ; then\n    lipo -output \"$FRAMEWORK_STRIPPED_PATH\" -remove \"x86_64\" \"$FRAMEWORK_BINARY_PATH\"\n    rm \"$FRAMEWORK_BINARY_PATH\"\n    mv \"$FRAMEWORK_STRIPPED_PATH\" \"$FRAMEWORK_BINARY_PATH\"\n    echo \"Removed simulator strip from NodeMobile.framework\"\n  fi\nfi\n";
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -499,7 +499,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = AE807EE532D15679B162FB0A /* Pods-bitkit-bitkitTests.debug.xcconfig */;
+			baseConfigurationReference = 0D53BC92A62A7EE80BB4DBC9 /* Pods-bitkit-bitkitTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -527,7 +527,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8ACF648C06AFB544DF2D6BE2 /* Pods-bitkit-bitkitTests.release.xcconfig */;
+			baseConfigurationReference = 354C379BD300695F3EE7A40E /* Pods-bitkit-bitkitTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -552,12 +552,12 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DCF501CACCB24AC5EAD33026 /* Pods-bitkit.debug.xcconfig */;
+			baseConfigurationReference = 9B2123A1E473C9CBAFE25212 /* Pods-bitkit.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 96;
-				DEVELOPMENT_TEAM = KYH47R284B;
+				DEVELOPMENT_TEAM = G864RK99VK;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = bitkit/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Bitkit;
@@ -573,7 +573,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = to.synonym.bitkit;
+				PRODUCT_BUNDLE_IDENTIFIER = to.synonym.bitkitDev;
 				PRODUCT_NAME = bitkit;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -583,12 +583,12 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D516AE4DD8DE53821B34AC30 /* Pods-bitkit.release.xcconfig */;
+			baseConfigurationReference = C377ED0D202043E3FF7A0C4E /* Pods-bitkit.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = 96;
-				DEVELOPMENT_TEAM = KYH47R284B;
+				DEVELOPMENT_TEAM = G864RK99VK;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = bitkit/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = Bitkit;
@@ -604,7 +604,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = to.synonym.bitkit;
+				PRODUCT_BUNDLE_IDENTIFIER = to.synonym.bitkitDev;
 				PRODUCT_NAME = bitkit;
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "react-native-randombytes": "3.6.1",
     "react-native-reanimated": "3.6.1",
     "react-native-reanimated-carousel": "3.5.1",
+    "react-native-release-profiler": "^0.1.6",
     "react-native-restart": "0.0.27",
     "react-native-safe-area-context": "4.7.4",
     "react-native-screens": "3.27.0",

--- a/src/store/shapes/ui.ts
+++ b/src/store/shapes/ui.ts
@@ -34,6 +34,7 @@ export const initialUiState: TUiState = {
 	isConnectedToElectrum: true,
 	isOnline: true,
 	isLDKReady: false, // LDK node running and connected
+	isProfiling: false,
 	language: 'en',
 	profileLink: { title: '', url: '' },
 	timeZone: 'UTC',

--- a/src/store/types/ui.ts
+++ b/src/store/types/ui.ts
@@ -71,6 +71,7 @@ export type TUiState = {
 	isConnectedToElectrum: boolean;
 	isOnline: boolean;
 	isLDKReady: boolean;
+	isProfiling: boolean;
 	profileLink: TProfileLink;
 	viewControllers: TUiViewController;
 	timeZone: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3307,6 +3307,15 @@
     execa "^5.0.0"
     prompts "^2.4.0"
 
+"@react-native-community/cli-clean@12.3.5":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-12.3.5.tgz#74426c70b2740ca2cdb70928a5df042574a76276"
+  integrity sha512-EsC1B3kOao+KCTq7vHICnFlQKnVh+bqRFnDq0gFheDzdWFxLHnBujyOaQ7t/gnEafosIGhSh6sOt1GIcVQXgzA==
+  dependencies:
+    "@react-native-community/cli-tools" "12.3.5"
+    chalk "^4.1.2"
+    execa "^5.0.0"
+
 "@react-native-community/cli-config@11.3.10":
   version "11.3.10"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-11.3.10.tgz#753510a80a98b136fec852e1ea5fa655c13dbd17"
@@ -3319,10 +3328,29 @@
     glob "^7.1.3"
     joi "^17.2.1"
 
+"@react-native-community/cli-config@12.3.5":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-12.3.5.tgz#9b95589ad2075ba9a610029a824cf171ae188bd6"
+  integrity sha512-K65PzZQslNpx9/MV/2tlLs91fQZgJuy7zELXheC9JA4rvY7uTWGVrdOjrI7ZaX/4htIBsek+Gu0TKZW/DUo3Dw==
+  dependencies:
+    "@react-native-community/cli-tools" "12.3.5"
+    chalk "^4.1.2"
+    cosmiconfig "^5.1.0"
+    deepmerge "^4.3.0"
+    glob "^7.1.3"
+    joi "^17.2.1"
+
 "@react-native-community/cli-debugger-ui@11.3.10":
   version "11.3.10"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-11.3.10.tgz#b16ebf770ba3cc76bf46580f101d00dacf919824"
   integrity sha512-kyitGV3RsjlXIioq9lsuawha2GUBPCTAyXV6EBlm3qlyF3dMniB3twEvz+fIOid/e1ZeucH3Tzy5G3qcP8yWoA==
+  dependencies:
+    serve-static "^1.13.1"
+
+"@react-native-community/cli-debugger-ui@12.3.5":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-12.3.5.tgz#d4e2d56a8490d1553dfbbc0401ab349939201a28"
+  integrity sha512-zvJYbrxj98flvdvMoIfG5g7Cmi8kkPvdKor59B7A6jM9h4Km0Pu7n/bMvDhj3SW7qjn3HMG3JWw+i1/SMJ2JAA==
   dependencies:
     serve-static "^1.13.1"
 
@@ -3350,6 +3378,29 @@
     wcwidth "^1.0.1"
     yaml "^2.2.1"
 
+"@react-native-community/cli-doctor@12.3.5":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-12.3.5.tgz#11bfdab98690e62c05513770f08916bd85d9396c"
+  integrity sha512-1/kaUgMxSjc86X2oIdwas5cqbY/pMQCkGSn5m89SIQ9FJp5LDEuutNoWlGjpcnm4/gFBAZwTqsNE68SeSsjVpQ==
+  dependencies:
+    "@react-native-community/cli-config" "12.3.5"
+    "@react-native-community/cli-platform-android" "12.3.5"
+    "@react-native-community/cli-platform-ios" "12.3.5"
+    "@react-native-community/cli-tools" "12.3.5"
+    chalk "^4.1.2"
+    command-exists "^1.2.8"
+    deepmerge "^4.3.0"
+    envinfo "^7.10.0"
+    execa "^5.0.0"
+    hermes-profile-transformer "^0.0.6"
+    ip "^1.1.5"
+    node-stream-zip "^1.9.1"
+    ora "^5.4.1"
+    semver "^7.5.2"
+    strip-ansi "^5.2.0"
+    wcwidth "^1.0.1"
+    yaml "^2.2.1"
+
 "@react-native-community/cli-hermes@11.3.10":
   version "11.3.10"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-11.3.10.tgz#f3d4f069ca472b1d8b4e8132cf9c44097a58ca19"
@@ -3357,6 +3408,17 @@
   dependencies:
     "@react-native-community/cli-platform-android" "11.3.10"
     "@react-native-community/cli-tools" "11.3.10"
+    chalk "^4.1.2"
+    hermes-profile-transformer "^0.0.6"
+    ip "^1.1.5"
+
+"@react-native-community/cli-hermes@12.3.5":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-12.3.5.tgz#48b3b100cbd3e67c0797afa400b5e7a407cf2f0b"
+  integrity sha512-sxHA26edHULMiSYG0YWtuObm8MNN0TvpVJciROEp7vJfy/Ajdi3MJ75FiAW0xZzEhVTfVDMbwkZVhSlJsxCFXA==
+  dependencies:
+    "@react-native-community/cli-platform-android" "12.3.5"
+    "@react-native-community/cli-tools" "12.3.5"
     chalk "^4.1.2"
     hermes-profile-transformer "^0.0.6"
     ip "^1.1.5"
@@ -3372,12 +3434,36 @@
     glob "^7.1.3"
     logkitty "^0.7.1"
 
+"@react-native-community/cli-platform-android@12.3.5":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-12.3.5.tgz#7bf23aa72059e9dba5cc0797b23ccd246c683e65"
+  integrity sha512-vkoEoP2qKwdf8jxkrL2b35k+9eTNRFO9J6QhkVJS8AgSDcwLDvSEUCHoDBNCHaohFHP1wDWixYG4QwDOx+GfFw==
+  dependencies:
+    "@react-native-community/cli-tools" "12.3.5"
+    chalk "^4.1.2"
+    execa "^5.0.0"
+    fast-xml-parser "^4.2.4"
+    glob "^7.1.3"
+    logkitty "^0.7.1"
+
 "@react-native-community/cli-platform-ios@11.3.10":
   version "11.3.10"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-11.3.10.tgz#f8a9bca1181802f12ed15714d5a496e60096cbed"
   integrity sha512-JjduMrBM567/j4Hvjsff77dGSLMA0+p9rr0nShlgnKPcc+0J4TDy0hgWpUceM7OG00AdDjpetAPupz0kkAh4cQ==
   dependencies:
     "@react-native-community/cli-tools" "11.3.10"
+    chalk "^4.1.2"
+    execa "^5.0.0"
+    fast-xml-parser "^4.0.12"
+    glob "^7.1.3"
+    ora "^5.4.1"
+
+"@react-native-community/cli-platform-ios@12.3.5":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-12.3.5.tgz#95bb6451e268883f00a445da84ce6ccb950e0bd8"
+  integrity sha512-jfp4epfJ6PzJNHtyN66VydVKtGzmDdH9QTk2Dw7sHj6p7DY75QgQ9jKgNWeyMIV+u/1EGek7HGWlmwp6fkiTDg==
+  dependencies:
+    "@react-native-community/cli-tools" "12.3.5"
     chalk "^4.1.2"
     execa "^5.0.0"
     fast-xml-parser "^4.0.12"
@@ -3401,6 +3487,11 @@
     metro-runtime "0.76.8"
     readline "^1.3.0"
 
+"@react-native-community/cli-plugin-metro@12.3.5":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-12.3.5.tgz#93ef47d3a540d60262a5d29abe662c43ea3a26be"
+  integrity sha512-O2fGpGOGf0BCpVutfQBozYyyU7qPL594/BoVVIUt9ovfm7uZHjaxtt90RzUJSNu6mE2PLEh3vtxJcszrIXTQuA==
+
 "@react-native-community/cli-server-api@11.3.10":
   version "11.3.10"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-11.3.10.tgz#2c4940d921711f2c78f0b61f126e8dbbbef6277c"
@@ -3408,6 +3499,21 @@
   dependencies:
     "@react-native-community/cli-debugger-ui" "11.3.10"
     "@react-native-community/cli-tools" "11.3.10"
+    compression "^1.7.1"
+    connect "^3.6.5"
+    errorhandler "^1.5.1"
+    nocache "^3.0.1"
+    pretty-format "^26.6.2"
+    serve-static "^1.13.1"
+    ws "^7.5.1"
+
+"@react-native-community/cli-server-api@12.3.5":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-12.3.5.tgz#6cb2a25f83339bf2e499fba0383903394fb7f5f8"
+  integrity sha512-Wyv0hSvjcYHx0+CW3RIDYfFuP3H4AGcw7Co0kAx2D6fhSTCqBappwdWUpKHyq07yQGrgQk0vdO3jAZOkVjfJpA==
+  dependencies:
+    "@react-native-community/cli-debugger-ui" "12.3.5"
+    "@react-native-community/cli-tools" "12.3.5"
     compression "^1.7.1"
     connect "^3.6.5"
     errorhandler "^1.5.1"
@@ -3431,10 +3537,33 @@
     semver "^7.5.2"
     shell-quote "^1.7.3"
 
+"@react-native-community/cli-tools@12.3.5":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-12.3.5.tgz#1ab33a9188d7df2856f747c6d2a07529a4872d93"
+  integrity sha512-Q7LKvu9pt3dR8XngcMfqo42XVEKzOad+4vaqRkpBUkKkZwXv41UFDxeK16NmUP87rDpHQNBbgCjJcpSq57hWsw==
+  dependencies:
+    appdirsjs "^1.2.4"
+    chalk "^4.1.2"
+    find-up "^5.0.0"
+    mime "^2.4.1"
+    node-fetch "^2.6.0"
+    open "^6.2.0"
+    ora "^5.4.1"
+    semver "^7.5.2"
+    shell-quote "^1.7.3"
+    sudo-prompt "^9.0.0"
+
 "@react-native-community/cli-types@11.3.10":
   version "11.3.10"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-11.3.10.tgz#cb02186cd247108bcea5ff93c4c97bb3c8dd8f22"
   integrity sha512-0FHK/JE7bTn0x1y8Lk5m3RISDHIBQqWLltO2Mf7YQ6cAeKs8iNOJOeKaHJEY+ohjsOyCziw+XSC4cY57dQrwNA==
+  dependencies:
+    joi "^17.2.1"
+
+"@react-native-community/cli-types@12.3.5":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-12.3.5.tgz#5116615cd9c3b5ea257551d784bc357b2b94cfcc"
+  integrity sha512-QP9/gRQsQWyQOPI7Xny/WJ1iCGobzn8G/DCp+c1JcksB6I8FCWb39WBvbu8r+3hJoyZ0v6mV1lio33gZHPGKLQ==
   dependencies:
     joi "^17.2.1"
 
@@ -3459,6 +3588,30 @@
     fs-extra "^8.1.0"
     graceful-fs "^4.1.3"
     prompts "^2.4.0"
+    semver "^7.5.2"
+
+"@react-native-community/cli@^12.2.1":
+  version "12.3.5"
+  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-12.3.5.tgz#0af88222fe382c84e8d99d7cd86c0b6a42d4a7e5"
+  integrity sha512-Kw/ZnQIIs7m35n26AVb4tzv106ZgX2vrPflRbXE3GQ72rpQ+O8UpEqvWTKqs5Sjt8eLgcUbbV8VR8Bxjorwohw==
+  dependencies:
+    "@react-native-community/cli-clean" "12.3.5"
+    "@react-native-community/cli-config" "12.3.5"
+    "@react-native-community/cli-debugger-ui" "12.3.5"
+    "@react-native-community/cli-doctor" "12.3.5"
+    "@react-native-community/cli-hermes" "12.3.5"
+    "@react-native-community/cli-plugin-metro" "12.3.5"
+    "@react-native-community/cli-server-api" "12.3.5"
+    "@react-native-community/cli-tools" "12.3.5"
+    "@react-native-community/cli-types" "12.3.5"
+    chalk "^4.1.2"
+    commander "^9.4.1"
+    deepmerge "^4.3.0"
+    execa "^5.0.0"
+    find-up "^4.1.0"
+    fs-extra "^8.1.0"
+    graceful-fs "^4.1.3"
+    prompts "^2.4.2"
     semver "^7.5.2"
 
 "@react-native-community/eslint-config@^3.2.0":
@@ -6515,6 +6668,11 @@ commander@^10.0.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-10.0.1.tgz#881ee46b4f77d1c1dccc5823433aa39b022cbe06"
   integrity sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==
 
+commander@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
+  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
+
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -7412,6 +7570,11 @@ entities@^4.2.0, entities@^4.4.0:
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
+envinfo@^7.10.0:
+  version "7.11.1"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.11.1.tgz#2ffef77591057081b0129a8fd8cf6118da1b94e1"
+  integrity sha512-8PiZgZNIB4q/Lw4AhOvAfB/ityHAd2bli3lESSWmWSzSsl5dKpy5N1d1Rfkd2teq/g9xN90lc6o98DOjMeYHpg==
+
 envinfo@^7.7.2:
   version "7.8.1"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.8.1.tgz#06377e3e5f4d379fea7ac592d5ad8927e0c4d475"
@@ -7970,6 +8133,13 @@ fast-xml-parser@^4.0.12:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.2.2.tgz#cb7310d1e9cf42d22c687b0fae41f3c926629368"
   integrity sha512-DLzIPtQqmvmdq3VUKR7T6omPK/VCRNqgFlGtbESfyhcH2R4I8EzK1/K6E8PkRCK2EabWrUHK32NjYRbEFnnz0Q==
+  dependencies:
+    strnum "^1.0.5"
+
+fast-xml-parser@^4.2.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-4.3.4.tgz#385cc256ad7bbc57b91515a38a22502a9e1fca0d"
+  integrity sha512-utnwm92SyozgA3hhH2I8qldf2lBqm6qHOICawRNRFu1qMe3+oqr+GcXjGqTmXTMGE5T4eC03kr/rlh5C1IRdZA==
   dependencies:
     strnum "^1.0.5"
 
@@ -12053,7 +12223,7 @@ promise@^8.3.0:
   dependencies:
     asap "~2.0.6"
 
-prompts@^2.0.1, prompts@^2.4.0:
+prompts@^2.0.1, prompts@^2.4.0, prompts@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.2.tgz#7b57e73b3a48029ad10ebd44f74b01722a4cb069"
   integrity sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==
@@ -12604,6 +12774,14 @@ react-native-reanimated@3.6.1:
     "@babel/preset-typescript" "^7.16.7"
     convert-source-map "^2.0.0"
     invariant "^2.2.4"
+
+react-native-release-profiler@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/react-native-release-profiler/-/react-native-release-profiler-0.1.6.tgz#e1429b50bbba7e446ae87f6180523a66a8c88b44"
+  integrity sha512-kSAPYjO3PDzV4xbjgj2NoiHtL7EaXmBira/WOcyz6S7mz1MVBoF0Bj74z5jAZo6BoBJRKqmQWI4ep+m0xvoF+g==
+  dependencies:
+    "@react-native-community/cli" "^12.2.1"
+    commander "^11.1.0"
 
 react-native-restart@0.0.27:
   version "0.0.27"


### PR DESCRIPTION
### Description

Adds [react-native-release-profiler](https://github.com/margelo/react-native-release-profiler) to dev settings. Trace file will be saved to downloads folder and can be loaded into https://www.speedscope.app/ to explore.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/8538369/72335048-a87e-48e6-93e1-725f2842b51e

For example when adding the price widget calls to `crypto_sign_verify_detached()` are taking anywhere from 100ms to 1000ms with `sodium-react-native` module replacement disabled, afterwards down to 2-20ms.

before:
[profile-9A7AB7F4-7AD7-4FB7-B5AD-9841D2CC791C-75503-00000DFFFC6FE561-converted.json](https://github.com/synonymdev/bitkit/files/14166029/profile-9A7AB7F4-7AD7-4FB7-B5AD-9841D2CC791C-75503-00000DFFFC6FE561-converted.json)

after:
[profile-02DB5297-3A2F-483B-881F-2915BF047A72-88677-00000E1065B2BCB6-converted.json](https://github.com/synonymdev/bitkit/files/14166097/profile-02DB5297-3A2F-483B-881F-2915BF047A72-88677-00000E1065B2BCB6-converted.json)

For the simulator these commands will pull the file to host:
iOS: `npx react-native-release-profiler --local <path to profile>`
Android: `npx react-native-release-profiler --fromDownload --appId <your appId>`