### PR TITLE
refactor(wallet): Remove Generate Mnemonic

### DIFF
--- a/nodejs-assets/nodejs-project/bitcoin-actions.js
+++ b/nodejs-assets/nodejs-project/bitcoin-actions.js
@@ -46,22 +46,6 @@ class BitcoinActions {
         });
     }
 
-    generateMnemonic({
-        id,
-        method = 'generateMnemonic',
-        data: {
-            strength = 128,
-        }}) {
-        return new Promise((resolve) => {
-            try {
-                const mnemonic = bip39.generateMnemonic(strength);
-                return resolve({id, method, error: false, value: mnemonic});
-            } catch (e) {
-                return resolve({id, method, error: true, value: e});
-            }
-        });
-    }
-
     getPrivateKey({
         id,
         method = 'getPrivateKey',

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "beignet": "0.0.22",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
-    "bip39": "3.0.4",
+    "bip39": "3.1.0",
     "bitcoin-address-validation": "2.2.3",
     "bitcoin-units": "0.3.0",
     "bitcoinjs-lib": "6.1.5",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@synonymdev/web-relay": "1.0.7",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
     "bech32": "2.0.0",
-    "beignet": "0.0.20",
+    "beignet": "0.0.22",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
     "bip39": "3.0.4",

--- a/src/utils/nodejs-mobile/index.ts
+++ b/src/utils/nodejs-mobile/index.ts
@@ -16,7 +16,6 @@ import {
 let isSetup = false;
 const methods = {
 	[ENodeJsMethod.setup]: {},
-	[ENodeJsMethod.generateMnemonic]: {},
 	[ENodeJsMethod.getPrivateKey]: {},
 	[ENodeJsMethod.getScriptHash]: {},
 	[ENodeJsMethod.getAddress]: {},

--- a/src/utils/nodejs-mobile/shapes.ts
+++ b/src/utils/nodejs-mobile/shapes.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import {
 	ENodeJsMethod,
-	INodeJsGenerateMnemonic,
 	INodeJsGetAddress,
 	INodeJsGetPrivateKey,
 	INodeJsGetScriptHash,
@@ -17,15 +16,6 @@ export const DefaultNodeJsMethodsShape = {
 				mnemonic: '',
 				bip39Passphrase: '',
 				selectedNetwork: undefined,
-			},
-		};
-	},
-	generateMnemonic: (): INodeJsGenerateMnemonic => {
-		return {
-			id: uuidv4(),
-			method: ENodeJsMethod.generateMnemonic,
-			data: {
-				strength: 256,
 			},
 		};
 	},

--- a/src/utils/nodejs-mobile/types.ts
+++ b/src/utils/nodejs-mobile/types.ts
@@ -2,7 +2,6 @@ import { EAvailableNetwork } from '../networks';
 
 export enum ENodeJsMethod {
 	setup = 'setup',
-	generateMnemonic = 'generateMnemonic',
 	getPrivateKey = 'getPrivateKey',
 	getScriptHash = 'getScriptHash',
 	getAddress = 'getAddress',
@@ -11,7 +10,6 @@ export enum ENodeJsMethod {
 export type TNodeJsMethodsData =
 	| INodeJsSetup
 	| INodeJsGetPrivateKey
-	| INodeJsGenerateMnemonic
 	| INodeJsGetAddress
 	| INodeJsGetScriptHash;
 
@@ -26,14 +24,6 @@ export interface INodeJsSetup {
 		mnemonic: string;
 		bip39Passphrase?: string;
 		selectedNetwork?: EAvailableNetwork;
-	};
-}
-
-export interface INodeJsGenerateMnemonic {
-	id: string;
-	method: ENodeJsMethod.generateMnemonic;
-	data: {
-		strength?: number;
 	};
 }
 

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -2,7 +2,6 @@ import { InteractionManager } from 'react-native';
 import { err, ok, Result } from '@synonymdev/result';
 
 import {
-	generateMnemonic,
 	getAddressTypesToMonitor,
 	getBip39Passphrase,
 	getMnemonicPhrase,
@@ -24,7 +23,7 @@ import { promiseTimeout } from '../helpers';
 import { EAvailableNetwork } from '../networks';
 import { TWalletName } from '../../store/types/wallet';
 import { runChecks } from '../wallet/checks';
-import { TServer } from 'beignet';
+import { generateMnemonic, TServer } from 'beignet';
 
 /**
  * Creates a new wallet from scratch
@@ -35,7 +34,7 @@ export const createNewWallet = async ({
 }: {
 	bip39Passphrase?: string;
 } = {}): Promise<Result<string>> => {
-	const mnemonic = await generateMnemonic();
+	const mnemonic = generateMnemonic();
 	if (!mnemonic) {
 		return err('Unable to generate mnemonic.');
 	}

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -395,26 +395,6 @@ export const getMnemonicPhrase = async (
 };
 
 /**
- * Generate a mnemonic phrase.
- * @async
- * @param {number} strength
- * @return {Promise<string>}
- */
-export const generateMnemonic = async (strength = 128): Promise<string> => {
-	try {
-		const data = DefaultNodeJsMethodsShape.generateMnemonic();
-		data.data.strength = strength;
-		const generatedMnemonic = await invokeNodeJsMethod<string>(data);
-		if (generatedMnemonic.error) {
-			return '';
-		}
-		return generatedMnemonic.value;
-	} catch (e) {
-		return '';
-	}
-};
-
-/**
  * Get bip39 passphrase for a specified wallet.
  * @async
  * @param {TWalletName} selectedWallet

--- a/yarn.lock
+++ b/yarn.lock
@@ -4780,11 +4780,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.18.tgz#1d3ca764718915584fcd9f6344621b7672665c67"
   integrity sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==
 
-"@types/node@11.11.6":
-  version "11.11.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
-  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
-
 "@types/node@>=12.12.47":
   version "20.3.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.3.2.tgz#fa6a90f2600e052a03c18b8cb3fd83dd4e599898"
@@ -5817,16 +5812,6 @@ bip32@^2.0.6:
     tiny-secp256k1 "^1.1.3"
     typeforce "^1.11.5"
     wif "^2.0.6"
-
-bip39@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
-  integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
-  dependencies:
-    "@types/node" "11.11.6"
-    create-hash "^1.1.0"
-    pbkdf2 "^3.0.9"
-    randombytes "^2.0.1"
 
 bip39@3.1.0, bip39@^3.0.4:
   version "3.1.0"
@@ -11986,7 +11971,7 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pbkdf2@^3.0.3, pbkdf2@^3.0.9:
+pbkdf2@^3.0.3:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
   integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5716,10 +5716,10 @@ bech32@^1.1.2, bech32@^1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-beignet@0.0.20:
-  version "0.0.20"
-  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.20.tgz#2f11389dacac1957eb36bf26b7bb7319d69ff241"
-  integrity sha512-m816N3mJ/wfIcHpX+bpFMsyrvn6yviXQqekMvmqcB1QNKNJ0MFp4Nt9b3+rRB4HvwmayJqyHDvhI+TAyZ+UUJA==
+beignet@0.0.22:
+  version "0.0.22"
+  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.22.tgz#07fb67299b4c7c99c2537252e9adaa27a51f57c0"
+  integrity sha512-Xb/L7HPUdc0yC/dy2kv1/AoZ6Alej8k8IGQGx2QIuAKTeu9kVVispJFDwe30xcyAuTFMwj2AYM8GJmoAuwkFdA==
   dependencies:
     "@bitcoinerlab/secp256k1" "1.0.5"
     bech32 "2.0.0"
@@ -5732,7 +5732,7 @@ beignet@0.0.20:
     ecpair "2.1.0"
     lodash.clonedeep "4.5.0"
     net "1.0.2"
-    rn-electrum-client "0.0.10"
+    rn-electrum-client "0.0.11"
 
 bencode@^2.0.0, bencode@^2.0.3:
   version "2.0.3"
@@ -13309,10 +13309,10 @@ rn-android-keyboard-adjust@2.1.2:
   resolved "https://registry.yarnpkg.com/rn-android-keyboard-adjust/-/rn-android-keyboard-adjust-2.1.2.tgz#f2b792628700dcb026215420192317ce43fd954f"
   integrity sha512-pUYiMT7aucw5YnV4geGdalyl6o6rEwRYhDnw2oPQwDym1BZHtmKsxFLupky1Kj2ZNkNKadpEyoyHOElLo+f3sA==
 
-rn-electrum-client@0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/rn-electrum-client/-/rn-electrum-client-0.0.10.tgz#a889e30967484b1312c2afd260501e9b19cd845d"
-  integrity sha512-sYP9mdPGEnDjQZtMrv1JWc4pWEFTUBcGqe/K64whnmmz67aYppUAyblPCzyndsNr3Eu4KdjUK3tgmMh+Ha4v9g==
+rn-electrum-client@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.yarnpkg.com/rn-electrum-client/-/rn-electrum-client-0.0.11.tgz#150372294c9712ffd54b237820042c63a5b38081"
+  integrity sha512-XfpUPyWf+/Bqcc67DmvBvCtlzc/FLaCSikOrUtFaba6zunWDCmXRgNNtvHQEoC40FrfDIo1bh8wv4oymyx+2xg==
 
 "rn-electrum-client@github:synonymdev/react-native-electrum-client#a32a292d4e4918a04d280137e24e5961c74c543f":
   version "0.0.8"


### PR DESCRIPTION
### Description
- Removes `generateMnemonic` function from `nodejs-mobile` since there is no performance gain to be made.
- Switches to `generateMnemonic` from `beignet` instead.
- Upgrades `beignet` to `0.0.22`.
- Upgrades `bip39` to `3.1.0`.

### Type of change
- [x] Refactoring (improving code without creating new functionality)

### Tests
- [x] No test

### QA Notes
New wallets should continue generating 12-word mnemonics as expected.
