### PR TITLE
fix(lightning): use min0ConfTxFee only for orders with 0 client balance

### DIFF
--- a/src/screens/Lightning/CustomSetup.tsx
+++ b/src/screens/Lightning/CustomSetup.tsx
@@ -274,6 +274,9 @@ const CustomSetup = ({
 		}
 
 		const getChannelOpenCost = async (): Promise<void> => {
+			if (amount === 0) {
+				return;
+			}
 			const res = await estimateOrderFee({
 				lspBalanceSat: amount,
 				channelExpiryWeeks: DEFAULT_CHANNEL_DURATION,


### PR DESCRIPTION
### Description

BT only accepts turbo or 0-conf payment channels for orders with 0 client balance. The `min-0conf-tx-fee` is also sometimes excessive. We can use a lower fee for orders with a balance.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
