### PR TITLE
fix(wallet): Refresh Wallet Prior To Boosting

### DIFF
--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -1371,18 +1371,22 @@ const runCoinSelect = async ({
  */
 export const setupBoost = async ({
 	txid,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	txid: string;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<Partial<ISendTransaction>>> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
+	// Ensure all utxos are up-to-date if attempting to boost immediately after a transaction.
+	const refreshResponse = await refreshWallet({
+		onchain: true,
+		lightning: false,
+		selectedWallet,
+		selectedNetwork,
+	});
+	if (refreshResponse.isErr()) {
+		return err(refreshResponse.error.message);
 	}
 	const canBoostResponse = canBoost(txid);
 	if (!canBoostResponse.canBoost) {


### PR DESCRIPTION
### Description
- Adds `refreshWallet` to `setupBoost` method.
- This change helps ensure all utxos are up-to-date if attempting to boost quickly after a transaction.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test
