### PR TITLE
refactor: get selected wallet and network by default

### DIFF
--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -202,8 +202,8 @@ export const updateWalletBalance = ({
  * @returns {Result<string>}
  */
 export const addUnconfirmedTransactions = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	transactions,
 }: {
 	selectedWallet?: TWalletName;
@@ -211,13 +211,6 @@ export const addUnconfirmedTransactions = ({
 	transactions: IFormattedTransactions;
 }): Result<string> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-
 		let unconfirmedTransactions: IFormattedTransactions = {};
 		Object.keys(transactions).forEach((key) => {
 			const confirmations = blockHeightToConfirmations({
@@ -261,8 +254,8 @@ export const addUnconfirmedTransactions = ({
 export const injectFakeTransaction = ({
 	id = 'fake-transaction',
 	fakeTx,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	id?: string;
 	fakeTx?: IFormattedTransactions;
@@ -270,13 +263,6 @@ export const injectFakeTransaction = ({
 	selectedNetwork?: EAvailableNetwork;
 }): Result<string> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-
 		const fakeTransaction = fakeTx ?? getFakeTransaction(id);
 
 		const payload = {
@@ -440,13 +426,10 @@ export const addBoostedTransaction = async ({
  * This resets a given wallet to defaultWalletShape
  */
 export const resetSelectedWallet = async ({
-	selectedWallet,
+	selectedWallet = getSelectedWallet(),
 }: {
 	selectedWallet?: TWalletName;
 }): Promise<void> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
 	dispatch({
 		type: actions.RESET_SELECTED_WALLET,
 		payload: { selectedWallet },
@@ -687,14 +670,11 @@ const txSpeedToFeeId = (txSpeed: ETransactionSpeed): EFeeId => {
  */
 export const updateHeader = ({
 	header,
-	selectedNetwork,
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	header: IHeader;
 	selectedNetwork?: EAvailableNetwork;
 }): void => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	const payload = {
 		header,
 		selectedNetwork,
@@ -724,8 +704,8 @@ export const resetExchangeRates = (): Result<string> => {
  * @returns {Promise<Result<string>>}
  */
 export const replaceImpactedAddresses = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	impactedAddresses,
 }: {
 	selectedWallet?: TWalletName;
@@ -733,13 +713,6 @@ export const replaceImpactedAddresses = async ({
 	impactedAddresses: TGetImpactedAddressesRes; // Retrieved from getImpactedAddresses
 }): Promise<Result<string>> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-
 		const { currentWallet } = getCurrentWallet({
 			selectedWallet,
 			selectedNetwork,
@@ -757,9 +730,6 @@ export const replaceImpactedAddresses = async ({
 			impactedAddresses.impactedChangeAddresses;
 
 		allImpactedAddresses.map(({ addressType, addresses }) => {
-			if (!selectedNetwork) {
-				selectedNetwork = getSelectedNetwork();
-			}
 			addresses.map((impactedAddress) => {
 				const invalidScriptHash = impactedAddress.storedAddress.scriptHash;
 				const validScriptHash = impactedAddress.generatedAddress.scriptHash;
@@ -780,9 +750,6 @@ export const replaceImpactedAddresses = async ({
 		});
 
 		allImpactedChangeAddresses.map(({ addressType, addresses }) => {
-			if (!selectedNetwork) {
-				selectedNetwork = getSelectedNetwork();
-			}
 			addresses.map((impactedAddress) => {
 				const invalidScriptHash = impactedAddress.storedAddress.scriptHash;
 				const validScriptHash = impactedAddress.generatedAddress.scriptHash;

--- a/src/store/utils/backup.ts
+++ b/src/store/utils/backup.ts
@@ -66,15 +66,11 @@ export enum EBackupCategories {
 
 export const performLdkRestore = async ({
 	backupServerDetails,
-	selectedNetwork,
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	backupServerDetails: TBackupServerDetails;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<{ backupExists: boolean }>> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	const storageRes = await setLdkStoragePath();
 	if (storageRes.isErr()) {
 		return err(storageRes.error);
@@ -140,15 +136,12 @@ export const performLdkRestore = async ({
 
 export const performLdkRestoreDeprecated = async ({
 	slashtag,
-	selectedNetwork,
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	slashtag: Slashtag;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<{ backupExists: boolean }>> => {
 	console.warn(`Restoring ${selectedNetwork} from deprecated backup server.`);
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	const res = await listBackups(
 		slashtag,
 		EBackupCategoriesOld.ldkComplete,

--- a/src/store/utils/blocktank.ts
+++ b/src/store/utils/blocktank.ts
@@ -232,8 +232,8 @@ export const startChannelPurchase = async ({
 	couponCode,
 	turboChannel = true,
 	zeroConfPayment = false,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	remoteBalance: number;
 	localBalance: number;
@@ -252,13 +252,6 @@ export const startChannelPurchase = async ({
 		transactionFeeEstimate: number;
 	}>
 > => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-
 	const buyChannelResponse = await createOrder({
 		lspBalanceSat: localBalance,
 		channelExpiryWeeks: channelExpiry,
@@ -355,20 +348,13 @@ export const startChannelPurchase = async ({
  */
 export const confirmChannelPurchase = async ({
 	order,
-	selectedNetwork,
-	selectedWallet,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	order: IBtOrder;
 	selectedNetwork?: EAvailableNetwork;
 	selectedWallet?: TWalletName;
 }): Promise<Result<{ txid: string; useUnconfirmedInputs: boolean }>> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-
 	const rawTx = await createTransaction();
 	if (rawTx.isErr()) {
 		showToast({

--- a/src/store/utils/lightning.ts
+++ b/src/store/utils/lightning.ts
@@ -91,18 +91,12 @@ export const updateLightningNodeVersionThunk = async (): Promise<
  * @param {EAvailableNetwork} [selectedNetwork]
  */
 export const updateLightningChannelsThunk = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<string>> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
 	const lightningChannelsRes = await getLightningChannels();
 	if (lightningChannelsRes.isErr()) {
 		return err(lightningChannelsRes.error.message);
@@ -194,15 +188,9 @@ export const createLightningInvoice = async ({
 	amountSats,
 	description,
 	expiryDeltaSeconds,
-	selectedNetwork,
-	selectedWallet,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: TCreateLightningInvoice): Promise<Result<TInvoice>> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
 	const invoice = await createPaymentRequest({
 		amountSats,
 		description,
@@ -224,21 +212,14 @@ export const createLightningInvoice = async ({
  * @param {string} peer
  */
 export const savePeer = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	peer,
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 	peer: string;
 }): Result<string> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	if (!peer) {
 		return err('The peer data appears to be invalid.');
 	}
@@ -272,20 +253,14 @@ export const savePeer = ({
  * @returns {Result<string>}
  */
 export const removePeer = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	peer,
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 	peer: string;
 }): Result<string> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	if (!peer) {
 		return err('The peer data appears to be invalid.');
 	}

--- a/src/store/utils/settings.ts
+++ b/src/store/utils/settings.ts
@@ -21,7 +21,7 @@ import { TWalletName } from '../types/wallet';
  * @return {Promise<Result<string>>}
  */
 export const wipeApp = async ({
-	selectedWallet,
+	selectedWallet = getSelectedWallet(),
 	showNotification = true,
 	restartApp = true,
 }: {
@@ -30,10 +30,6 @@ export const wipeApp = async ({
 	restartApp?: boolean;
 } = {}): Promise<Result<string>> => {
 	try {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-
 		// Reset Redux stores & persisted storage
 		dispatch({ type: actions.WIPE_APP });
 

--- a/src/utils/boost.ts
+++ b/src/utils/boost.ts
@@ -15,18 +15,12 @@ import {
  * @returns {IBoostedTransactions}
  */
 export const getBoostedTransactions = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): IBoostedTransactions => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	return getWalletStore().wallets[selectedWallet]?.boostedTransactions[
 		selectedNetwork
 	];
@@ -43,8 +37,8 @@ export const getBoostedTransactions = ({
 export const getBoostedTransactionParents = ({
 	txid,
 	boostedTransactions,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	txid: string;
 	boostedTransactions?: IBoostedTransactions;
@@ -52,12 +46,6 @@ export const getBoostedTransactionParents = ({
 	selectedNetwork?: EAvailableNetwork;
 }): string[] => {
 	if (!boostedTransactions) {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		boostedTransactions = getBoostedTransactions({
 			selectedWallet,
 			selectedNetwork,
@@ -82,8 +70,8 @@ export const getBoostedTransactionParents = ({
 export const isTransactionBoosted = ({
 	txid,
 	boostedTransactions,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	txid: string;
 	boostedTransactions?: IBoostedTransactions;
@@ -91,12 +79,6 @@ export const isTransactionBoosted = ({
 	selectedNetwork?: EAvailableNetwork;
 }): boolean => {
 	if (!boostedTransactions) {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		boostedTransactions = getBoostedTransactions({
 			selectedWallet,
 			selectedNetwork,
@@ -116,8 +98,8 @@ export const isTransactionBoosted = ({
 export const hasBoostedParents = ({
 	txid,
 	boostedTransactions,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	txid: string;
 	boostedTransactions?: IBoostedTransactions;
@@ -125,12 +107,6 @@ export const hasBoostedParents = ({
 	selectedNetwork?: EAvailableNetwork;
 }): boolean => {
 	if (!boostedTransactions) {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		boostedTransactions = getBoostedTransactions({
 			selectedWallet,
 			selectedNetwork,
@@ -156,8 +132,8 @@ export const getRootParentActivity = ({
 	txid,
 	items,
 	boostedTransactions,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	txid: string;
 	items: TOnchainActivityItem[];
@@ -166,12 +142,6 @@ export const getRootParentActivity = ({
 	selectedNetwork?: EAvailableNetwork;
 }): TOnchainActivityItem | undefined => {
 	if (!boostedTransactions) {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		boostedTransactions = getBoostedTransactions({
 			selectedWallet,
 			selectedNetwork,

--- a/src/utils/checks.ts
+++ b/src/utils/checks.ts
@@ -22,16 +22,12 @@ import { v4 as uuidv4 } from 'uuid';
  * @returns {Promise<Result<number>>}
  */
 export const reportImpactedAddressBalance = async ({
-	selectedNetwork,
+	selectedNetwork = getSelectedNetwork(),
 	impactedAddressRes,
 }: {
 	selectedNetwork: EAvailableNetwork;
 	impactedAddressRes: TGetImpactedAddressesRes;
 }): Promise<Result<number>> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	const addresses = impactedAddressRes.impactedAddresses;
 	const changeAddresses = impactedAddressRes.impactedChangeAddresses;
 
@@ -88,16 +84,13 @@ export const reportImpactedAddressBalance = async ({
 };
 
 export const reportLdkChannelMigrations = async ({
-	selectedNetwork,
+	selectedNetwork = getSelectedNetwork(),
 	channels,
 }: {
 	selectedNetwork: EAvailableNetwork;
 	channels: TChannel[];
 }): Promise<Result<string>> => {
 	const selectedWallet = getSelectedWallet();
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	const warnings = getWarnings({ selectedNetwork });
 	const ldkMigrationWarnings = warnings.filter(
 		(w) => w.warningId === EWarningIds.ldkMigration,
@@ -159,20 +152,12 @@ export const reportLdkChannelMigrations = async ({
  * @returns {Promise<number>}
  */
 export const reportUnreportedWarnings = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<number> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	const warnings = getWarnings({ selectedWallet, selectedNetwork });
 
 	const unreportedWarnings = warnings.filter(
@@ -183,12 +168,6 @@ export const reportUnreportedWarnings = async ({
 
 	await Promise.all(
 		unreportedWarnings.map(async (warning: TStorageWarning) => {
-			if (!selectedWallet) {
-				selectedWallet = getSelectedWallet();
-			}
-			if (!selectedNetwork) {
-				selectedNetwork = getSelectedNetwork();
-			}
 			const reportRes = await reportImpactedAddressBalance({
 				selectedNetwork,
 				impactedAddressRes: warning.data as TGetImpactedAddressesRes,
@@ -220,17 +199,11 @@ export const reportUnreportedWarnings = async ({
  * @returns {TStorageWarning[]}
  */
 export const getWarnings = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): TStorageWarning[] => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	return getChecksStore()[selectedWallet].warnings[selectedNetwork];
 };

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -126,19 +126,12 @@ let onBackupStateUpdate: EmitterSubscription | undefined;
  * @returns {Promise<Result<string>>}
  */
 export const wipeLdkStorage = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<string>> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	await ldk.stop();
 	const path = `${RNFS.DocumentDirectoryPath}/ldk/${lm.account.name}`;
 
@@ -388,19 +381,13 @@ export const getPendingInvoice = (
 
 export const handleLightningPaymentSubscription = async ({
 	payment,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	payment: TChannelManagerClaim;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<void> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	const invoice = await getPendingInvoice(payment.payment_hash);
 
 	let message = '';
@@ -446,8 +433,8 @@ export const handleLightningPaymentSubscription = async ({
  * @param {EAvailableNetwork} [selectedNetwork]
  */
 export const subscribeToLightningPayments = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
@@ -456,13 +443,6 @@ export const subscribeToLightningPayments = ({
 		paymentSubscription = ldk.onEvent(
 			EEventTypes.channel_manager_payment_claimed,
 			(res: TChannelManagerClaim) => {
-				if (!selectedWallet) {
-					selectedWallet = getSelectedWallet();
-				}
-				if (!selectedNetwork) {
-					selectedNetwork = getSelectedNetwork();
-				}
-
 				handleLightningPaymentSubscription({
 					payment: res,
 					selectedNetwork,
@@ -476,13 +456,6 @@ export const subscribeToLightningPayments = ({
 			EEventTypes.new_channel,
 			async (_res: TChannelUpdate) => {
 				// New Channel will open in 1 block confirmation
-
-				if (!selectedWallet) {
-					selectedWallet = getSelectedWallet();
-				}
-				if (!selectedNetwork) {
-					selectedNetwork = getSelectedNetwork();
-				}
 
 				await refreshLdk({ selectedWallet, selectedNetwork });
 
@@ -501,13 +474,6 @@ export const subscribeToLightningPayments = ({
 		onBackupStateUpdate = ldk.onEvent(
 			EEventTypes.backup_state_update,
 			(res: TBackupStateUpdate) => {
-				if (!selectedWallet) {
-					selectedWallet = getSelectedWallet();
-				}
-				if (!selectedNetwork) {
-					selectedNetwork = getSelectedNetwork();
-				}
-
 				dispatch(
 					updateBackupState({
 						backup: res,
@@ -554,8 +520,8 @@ const handleRefreshError = (errorMessage: string): Result<string> => {
  * @returns {Promise<Result<string>>}
  */
 export const refreshLdk = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	clearPendingRefreshPromises = false,
 }: {
 	selectedWallet?: TWalletName;
@@ -578,13 +544,6 @@ export const refreshLdk = async ({
 		await new Promise((resolve) => {
 			InteractionManager.runAfterInteractions(() => resolve(null));
 		});
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-
 		const isRunning = await isLdkRunning();
 		if (!isRunning) {
 			dispatch(updateUi({ isLDKReady: false }));
@@ -708,21 +667,14 @@ export const checkAccountVersion = async (
 export const getLdkAccount = async ({
 	version = 2,
 	shouldCreateAccount = true,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	version?: TLdkAccountVersion;
 	shouldCreateAccount?: boolean;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 } = {}): Promise<Result<TAccount>> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	const existingAccountRes = await getExistingLdkAccount({
 		version,
 		selectedWallet,
@@ -804,8 +756,8 @@ const getExistingLdkAccount = async ({
  */
 const handleAccountMigrations = async ({
 	accountVersion,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	accountVersion: TLdkAccountVersion;
 	selectedWallet: TWalletName;
@@ -831,8 +783,8 @@ const handleAccountMigrations = async ({
  * @returns {Promise<Result<string>>}
  */
 const closeLdkV1Account = async (
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 ): Promise<Result<string>> => {
 	const openChannelsRes = await getOpenChannels({
 		fromStorage: false,
@@ -1037,11 +989,8 @@ export const getSha256 = (str: string): string => {
  * @returns {Promise<THeader>}
  */
 export const getBestBlock = async (
-	selectedNetwork?: EAvailableNetwork,
+	selectedNetwork: EAvailableNetwork = getSelectedNetwork(),
 ): Promise<THeader> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	try {
 		const beignetHeader = getOnChainWalletData().header;
 		const storageHeader = getWalletStore().header[selectedNetwork];
@@ -1248,18 +1197,12 @@ export const addPeer = async ({
  * @param {EAvailableNetwork} [selectedNetwork]
  */
 export const getCustomLightningPeers = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): string[] => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	const peers = getLightningStore().nodes[selectedWallet]?.peers;
 	if (peers && selectedNetwork in peers) {
 		return peers[selectedNetwork];
@@ -1272,19 +1215,13 @@ export const getCustomLightningPeers = ({
  * @returns {Promise<Result<string[]>>}
  */
 export const addPeers = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 } = {}): Promise<Result<string[]>> => {
 	try {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		const geoBlocked = await isGeoBlocked(true);
 
 		let blocktankNodeUris: string[] = [];
@@ -1330,19 +1267,13 @@ export const addPeers = async ({
 };
 
 export const getLightningNodePeers = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 } = {}): Promise<string[]> => {
 	try {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		const geoBlocked = await isGeoBlocked(true);
 
 		let blocktankNodeUris: string[] = [];
@@ -1391,8 +1322,8 @@ export const getLightningChannels = (): Promise<Result<TChannel[]>> => {
  */
 export const getPendingChannels = async ({
 	fromStorage = false,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	fromStorage?: boolean;
 	selectedWallet?: TWalletName;
@@ -1400,12 +1331,6 @@ export const getPendingChannels = async ({
 }): Promise<Result<TChannel[]>> => {
 	let channels: TChannel[];
 	if (fromStorage) {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		const channelsStore =
 			getLightningStore().nodes[selectedWallet].channels[selectedNetwork];
 		channels = Object.values(channelsStore);
@@ -1428,20 +1353,13 @@ export const getPendingChannels = async ({
  */
 export const getOpenChannels = async ({
 	fromStorage = false,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	fromStorage?: boolean;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 } = {}): Promise<Result<TChannel[]>> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	let channels: TChannel[];
 	const node = getLightningStore().nodes[selectedWallet];
 
@@ -1505,8 +1423,8 @@ export const closeChannel = async ({
 export const closeAllChannels = async ({
 	channels,
 	force = false,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	channels?: TChannel[];
 	force?: boolean; // It will always try to coop close first and only force close if set to true.
@@ -1514,12 +1432,6 @@ export const closeAllChannels = async ({
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<TChannel[]>> => {
 	try {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		if (!channels) {
 			const openChannelsRes = await getOpenChannels({
 				fromStorage: true,
@@ -1677,8 +1589,8 @@ export const decodeLightningInvoice = ({
  */
 export const keepLdkSynced = async ({
 	frequency = 120000,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	frequency?: number;
 	selectedWallet?: TWalletName;
@@ -1688,12 +1600,6 @@ export const keepLdkSynced = async ({
 		return;
 	} else {
 		LDKIsStayingSynced = true;
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
 	}
 
 	let error: string = '';
@@ -1715,18 +1621,12 @@ export const keepLdkSynced = async ({
  * @returns {boolean}
  */
 export const hasOpenLightningChannels = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): boolean => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	const availableChannels =
 		getLightningStore().nodes[selectedWallet].openChannelIds[selectedNetwork];
 	return availableChannels.length > 0;
@@ -1747,18 +1647,12 @@ export const recoverOutputs = async (): Promise<Result<string>> => {
  * @returns {Promise<number>}
  */
 export const getLightningReserveBalance = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): number => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	const node = getLightningStore().nodes[selectedWallet];
 	const openChannelIds = node.openChannelIds[selectedNetwork];
 	const channels = node.channels[selectedNetwork];
@@ -1792,18 +1686,12 @@ export const getClaimableBalances = async ({
  * @param {EAvailableNetwork} [selectedNetwork]
  */
 export const getPeersFromStorage = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): string[] => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	return getLightningStore().nodes[selectedWallet].peers[selectedNetwork];
 };
 
@@ -1816,19 +1704,12 @@ export const getPeersFromStorage = ({
  * @returns {Promise<Result<string>>}
  */
 export const removeUnusedPeers = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<string>> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	const getChannelsResponse = await getLightningChannels();
 	if (getChannelsResponse.isErr()) {
 		return err(getChannelsResponse.error.message);
@@ -1871,8 +1752,8 @@ export const removeUnusedPeers = async ({
  * @returns {{ localBalance: number; remoteBalance: number; }}
  */
 export const getLightningBalance = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	includeReserveBalance = true,
 }: {
 	selectedWallet?: TWalletName;
@@ -1882,13 +1763,6 @@ export const getLightningBalance = ({
 	localBalance: number;
 	remoteBalance: number;
 } => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	const node = getLightningStore().nodes[selectedWallet];
 	const openChannelIds = node.openChannelIds[selectedNetwork];
 	const channels = node.channels[selectedNetwork];

--- a/src/utils/lnurl.ts
+++ b/src/utils/lnurl.ts
@@ -124,20 +124,13 @@ export const handleLnurlPay = async ({
  */
 export const handleLnurlChannel = async ({
 	params,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	params: LNURLChannelParams;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<TProcessedData>> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	const peer = params.uri;
 	if (peer.includes('onion')) {
 		const message = i18n.t('lightning:error_add_tor');
@@ -243,20 +236,13 @@ export const handleLnurlChannel = async ({
  */
 export const handleLnurlAuth = async ({
 	params,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	params: LNURLAuthParams;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<TProcessedData>> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	const getMnemonicPhraseResponse = await getMnemonicPhrase(selectedWallet);
 	if (getMnemonicPhraseResponse.isErr()) {
 		return err(getMnemonicPhraseResponse.error.message);
@@ -299,21 +285,14 @@ export const handleLnurlAuth = async ({
 export const handleLnurlWithdraw = async ({
 	amount,
 	params,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	amount: number;
 	params: LNURLWithdrawParams;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<TProcessedData>> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	const invoice = await createLightningInvoice({
 		expiryDeltaSeconds: 3600,
 		amountSats: amount,

--- a/src/utils/nodejs-mobile/index.ts
+++ b/src/utils/nodejs-mobile/index.ts
@@ -97,20 +97,14 @@ export const invokeNodeJsMethod = async <T = string>(
  * @returns {Promise<{Result<{string}>}>}
  */
 export const setupNodejsMobile = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	mnemonic,
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 	mnemonic?: string;
 } = {}): Promise<Result<string>> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	if (!mnemonic) {
 		const mnemonicResponse = await getMnemonicPhrase(selectedWallet);
 		if (mnemonicResponse.isErr()) {

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -184,8 +184,8 @@ export const processInputData = async ({
 	data,
 	source = 'mainScanner',
 	sdk,
-	selectedNetwork,
-	selectedWallet,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	skip = [],
 	showErrors = true,
 }: {
@@ -199,13 +199,6 @@ export const processInputData = async ({
 }): Promise<Result<TProcessedData>> => {
 	data = data.trim();
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-
 		const decodeRes = await decodeQRData(data, selectedNetwork);
 		if (decodeRes.isErr()) {
 			const errorMessage = i18n.t('other:scan_err_interpret_msg');
@@ -333,7 +326,7 @@ export const processInputData = async ({
  */
 export const decodeQRData = async (
 	data: string,
-	selectedNetwork?: EAvailableNetwork,
+	selectedNetwork: EAvailableNetwork = getSelectedNetwork(),
 ): Promise<Result<QRData[]>> => {
 	if (!data) {
 		return err('No data provided.');
@@ -372,10 +365,6 @@ export const decodeQRData = async (
 		return ok([{ qrDataType: EQRDataType.slashtagURL, url: data }]);
 	} else if (data.startsWith('slashfeed:')) {
 		return ok([{ qrDataType: EQRDataType.slashFeedURL, url: data }]);
-	}
-
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
 	}
 
 	let foundNetworksInQR: (
@@ -603,8 +592,8 @@ export const processBitcoinTransactionData = async ({
 	data = [],
 	preferredPaymentMethod,
 	showErrors = true,
-	selectedNetwork,
-	selectedWallet,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	data: QRData[];
 	preferredPaymentMethod?: EQRDataType;
@@ -613,13 +602,6 @@ export const processBitcoinTransactionData = async ({
 	selectedWallet?: TWalletName;
 }): Promise<Result<QRData>> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-
 		let response;
 		let error: ToastOptions | undefined; //Information that will be passed as a notification.
 		let requestedAmount = 0; //Amount requested in sats by the provided invoice.
@@ -770,8 +752,8 @@ export const processBitcoinTransactionData = async ({
  */
 export const handleData = async ({
 	data,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	data: QRData;
 	selectedWallet?: TWalletName;
@@ -784,13 +766,6 @@ export const handleData = async ({
 			description: i18n.t('other:qr_error_no_data_text'),
 		});
 		return err('Unable to read or interpret the provided data.');
-	}
-
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
 	}
 
 	const qrDataType = data.qrDataType;
@@ -1057,8 +1032,8 @@ export const validateInputData = async ({
 	source = 'mainScanner',
 	sdk,
 	showErrors,
-	selectedNetwork,
-	selectedWallet,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	data: string;
 	source?: 'mainScanner' | 'send';
@@ -1069,13 +1044,6 @@ export const validateInputData = async ({
 }): Promise<Result<QRData>> => {
 	if (!data) {
 		return err('No data provided.');
-	}
-
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
 	}
 
 	try {

--- a/src/utils/slashtags/index.ts
+++ b/src/utils/slashtags/index.ts
@@ -185,8 +185,8 @@ export const updateSlashPayConfig = debounce(
 	async ({
 		forceUpdate = false,
 		sdk,
-		selectedWallet,
-		selectedNetwork,
+		selectedWallet = getSelectedWallet(),
+		selectedNetwork = getSelectedNetwork(),
 	}: {
 		forceUpdate?: boolean;
 		sdk?: SDK;
@@ -196,12 +196,6 @@ export const updateSlashPayConfig = debounce(
 		if (!sdk) {
 			// sdk is not ready yet
 			return;
-		}
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
 		}
 		const slashtag = getSelectedSlashtag(sdk);
 		const drive = slashtag.drivestore.get();

--- a/src/utils/slashtags2/index.ts
+++ b/src/utils/slashtags2/index.ts
@@ -61,8 +61,8 @@ export const getNewProfileUrl = (url: string, webRelayUrl: string): string => {
 export const updateSlashPayConfig2 = debounce(
 	async ({
 		forceUpdate = false,
-		selectedWallet,
-		selectedNetwork,
+		selectedWallet = getSelectedWallet(),
+		selectedNetwork = getSelectedNetwork(),
 	}: {
 		forceUpdate?: boolean;
 		selectedWallet?: TWalletName;
@@ -71,12 +71,6 @@ export const updateSlashPayConfig2 = debounce(
 		if (!webRelayClient) {
 			console.debug('webRelayClient not ready yet');
 			return;
-		}
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
 		}
 		const slashpay = new SlashpayConfig(webRelayClient);
 		const url = await slashpay.createURL();

--- a/src/utils/wallet/checks.ts
+++ b/src/utils/wallet/checks.ts
@@ -43,18 +43,12 @@ import { dispatch } from '../../store/helpers';
 import { EAddressType } from 'beignet';
 
 export const runChecks = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet: TWalletName;
 	selectedNetwork: EAvailableNetwork;
 }): Promise<Result<{ ranStorageCheck: boolean }>> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	const storageCheckRes = await runStorageCheck({
 		selectedWallet,
 		selectedNetwork,
@@ -77,20 +71,14 @@ export const runChecks = async ({
  * @returns {Promise<Result<string>>}
  */
 export const runStorageCheck = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	allAddressTypes = false,
 }: {
 	selectedWallet: TWalletName;
 	selectedNetwork: EAvailableNetwork;
 	allAddressTypes?: boolean;
 }): Promise<Result<string>> => {
-	if (!selectedWallet) {
-		getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		getSelectedNetwork();
-	}
 	const selectedAddressType = getSelectedAddressType({
 		selectedWallet,
 		selectedNetwork,
@@ -180,20 +168,14 @@ export const runStorageCheck = async ({
  * @returns {Promise<Result<TAddressStorageCheckRes>>}
  */
 export const addressStorageCheck = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	addressTypesToCheck,
 }: {
 	selectedNetwork?: EAvailableNetwork;
 	selectedWallet?: TWalletName;
 	addressTypesToCheck?: IAddressTypeData[];
 }): Promise<Result<TAddressStorageCheckRes>> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
 	const { currentWallet } = getCurrentWallet({
 		selectedWallet,
 		selectedNetwork,
@@ -368,20 +350,14 @@ const _createMinMaxData = async ({
  * @returns {TGetImpactedAddressesRes}
  */
 export const getImpactedAddresses = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	storageCheckData,
 }: {
 	selectedWallet: TWalletName;
 	selectedNetwork: EAvailableNetwork;
 	storageCheckData: TMinMaxData[]; // Retrieved by calling addressStorageCheck
 }): Promise<Result<TGetImpactedAddressesRes>> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
 	const { currentWallet } = getCurrentWallet({
 		selectedWallet,
 		selectedNetwork,
@@ -395,9 +371,6 @@ export const getImpactedAddresses = async ({
 		changeAddress,
 		addressType,
 	} of storageCheckData) {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		const keyDerivationPathResponse = getKeyDerivationPathObject({
 			selectedNetwork,
 			path: addressTypes[addressType].path,

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -107,8 +107,8 @@ export const refreshWallet = async ({
 	lightning = true,
 	scanAllAddresses = false, // If set to false, on-chain scanning will adhere to the gap limit (20).
 	showNotification = true, // Whether to show newTxPrompt on new incoming transactions.
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	onchain?: boolean;
 	lightning?: boolean;
@@ -123,12 +123,6 @@ export const refreshWallet = async ({
 		await new Promise((resolve) => {
 			InteractionManager.runAfterInteractions(() => resolve(null));
 		});
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 
 		let notificationTxid: string | undefined;
 
@@ -197,7 +191,7 @@ export const generateAddresses = async ({
  */
 export const getPrivateKey = async ({
 	addressData,
-	selectedNetwork,
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	addressData: IAddress;
 	selectedNetwork?: EAvailableNetwork;
@@ -205,9 +199,6 @@ export const getPrivateKey = async ({
 	try {
 		if (!addressData) {
 			return err('No addressContent specified.');
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
 		}
 
 		const getPrivateKeyShapeShape = DefaultNodeJsMethodsShape.getPrivateKey();
@@ -287,7 +278,7 @@ export const getKeyDerivationAccount = (
 export const formatKeyDerivationPath = ({
 	path,
 	purpose,
-	selectedNetwork,
+	selectedNetwork = getSelectedNetwork(),
 	accountType = 'onchain',
 	changeAddress = false,
 	addressIndex = '0',
@@ -300,10 +291,6 @@ export const formatKeyDerivationPath = ({
 	addressIndex?: string;
 }): Result<IKeyDerivationPathData> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-
 		if (typeof path === 'string') {
 			const derivationPathResponse = getKeyDerivationPathObject({
 				path,
@@ -346,15 +333,12 @@ export const formatKeyDerivationPath = ({
  */
 export const getKeyDerivationPath = ({
 	addressType,
-	selectedNetwork,
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	addressType: EAddressType;
 	selectedNetwork?: EAvailableNetwork;
 }): Result<IKeyDerivationPath> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		const keyDerivationPathResponse = getKeyDerivationPathObject({
 			selectedNetwork,
 			path: addressTypes[addressType].path,
@@ -375,12 +359,9 @@ export const getKeyDerivationPath = ({
  * @return {Promise<Result<string>>}
  */
 export const getMnemonicPhrase = async (
-	selectedWallet?: TWalletName,
+	selectedWallet: TWalletName = getSelectedWallet(),
 ): Promise<Result<string>> => {
 	try {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
 		const response = await getKeychainValue({ key: selectedWallet });
 		if (response.error) {
 			return err(response.data);
@@ -398,12 +379,9 @@ export const getMnemonicPhrase = async (
  * @return {Promise<string>}
  */
 export const getBip39Passphrase = async (
-	selectedWallet?: TWalletName,
+	selectedWallet: TWalletName = getSelectedWallet(),
 ): Promise<string> => {
 	try {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
 		const key = `${selectedWallet}passphrase`;
 		const bip39PassphraseResult = await getKeychainValue({ key });
 		if (!bip39PassphraseResult.error && bip39PassphraseResult.data) {
@@ -438,14 +416,11 @@ export const getSeed = async (
  */
 export const getScriptHash = async (
 	address: string,
-	selectedNetwork?: EAvailableNetwork,
+	selectedNetwork: EAvailableNetwork = getSelectedNetwork(),
 ): Promise<string> => {
 	try {
 		if (!address) {
 			return '';
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
 		}
 		const data = DefaultNodeJsMethodsShape.getScriptHash();
 		data.data.address = address;
@@ -509,14 +484,11 @@ export const electrumNetworkToBitkitNetwork = (
  */
 export const getAddress = async ({
 	path,
-	selectedNetwork,
+	selectedNetwork = getSelectedNetwork(),
 	type,
 }: IGetAddress): Promise<Result<IGetAddressResponse>> => {
 	if (!path) {
 		return err('No path specified');
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
 	}
 	try {
 		const data = DefaultNodeJsMethodsShape.getAddress();
@@ -603,18 +575,12 @@ export const validateMnemonic = (mnemonic: string): boolean => {
  * @return number - Will always return balance in sats.
  */
 export const getOnChainBalance = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 } = {}): number => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	return getWalletStore().wallets[selectedWallet]?.balance[selectedNetwork];
 };
 
@@ -648,8 +614,8 @@ export const getAssetTicker = (asset = 'bitcoin'): string => {
 export const removeDuplicateAddresses = async ({
 	addresses = {},
 	changeAddresses = {},
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	addresses?: IAddresses;
 	changeAddresses?: IAddresses;
@@ -657,12 +623,6 @@ export const removeDuplicateAddresses = async ({
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<IGenerateAddressesResponse>> => {
 	try {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		const { currentWallet } = getCurrentWallet({
 			selectedWallet,
 			selectedNetwork,
@@ -861,18 +821,12 @@ export const getCurrentWallet = ({
 };
 
 export const getOnChainTransactions = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet: TWalletName;
 	selectedNetwork: EAvailableNetwork;
 }): IFormattedTransactions => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	return (
 		getWalletStore().wallets[selectedWallet]?.transactions[selectedNetwork] ??
 		{}
@@ -887,19 +841,13 @@ export const getOnChainTransactions = ({
  */
 export const getTransactionById = ({
 	txid,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	txid: string;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Result<IFormattedTransaction> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	const transactions = getOnChainTransactions({
 		selectedNetwork,
 		selectedWallet,
@@ -947,15 +895,11 @@ type InputData = {
 
 export const getInputData = async ({
 	inputs,
-	selectedNetwork,
 }: {
 	inputs: { tx_hash: string; vout: number }[];
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<InputData>> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		const inputData: InputData = {};
 
 		for (let i = 0; i < inputs.length; i += CHUNK_LIMIT) {
@@ -987,8 +931,8 @@ export const getInputData = async ({
 
 export const formatTransactions = async ({
 	transactions,
-	selectedNetwork,
-	selectedWallet,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	transactions: ITransaction<IUtxo>[];
 	selectedNetwork?: EAvailableNetwork;
@@ -996,12 +940,6 @@ export const formatTransactions = async ({
 }): Promise<Result<IFormattedTransactions>> => {
 	if (transactions.length < 1) {
 		return ok({});
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
 	}
 	const { currentWallet } = getCurrentWallet({
 		selectedNetwork,
@@ -1871,8 +1809,8 @@ export const getKeyDerivationPathObject = ({
  */
 export const getAddressTypePath = ({
 	addressType,
-	selectedNetwork,
-	selectedWallet,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	changeAddress,
 }: {
 	addressType?: EAddressType;
@@ -1881,12 +1819,6 @@ export const getAddressTypePath = ({
 	changeAddress?: boolean;
 }): Result<IKeyDerivationPathData> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
 		if (!addressType) {
 			addressType = getSelectedAddressType({ selectedNetwork, selectedWallet });
 		}
@@ -1984,8 +1916,8 @@ export const getCurrentAddressIndex = async ({
  * @param {EAvailableNetwork} [selectedNetwork]
  */
 export const getBalance = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
@@ -1998,12 +1930,6 @@ export const getBalance = ({
 	spendableBalance: number; // Total spendable funds (onchain + spendable lightning)
 	totalBalance: number; // Total funds (all of the above)
 } => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	const { currentWallet, currentLightningNode: node } = getCurrentWallet({
 		selectedWallet,
 		selectedNetwork,
@@ -2056,8 +1982,8 @@ export const getBalance = ({
  * @returns {Result<{ addressDelta: number; changeAddressDelta: number }>}
  */
 export const getGapLimit = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	addressType,
 }: {
 	selectedWallet?: TWalletName;
@@ -2065,12 +1991,6 @@ export const getGapLimit = ({
 	addressType?: EAddressType;
 }): Result<{ addressDelta: number; changeAddressDelta: number }> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
 		if (!addressType) {
 			addressType = getSelectedAddressType({ selectedNetwork, selectedWallet });
 		}
@@ -2110,11 +2030,8 @@ export const getGapLimit = ({
  */
 export const getAddressFromScriptPubKey = (
 	scriptPubKey: string,
-	selectedNetwork?: EAvailableNetwork,
+	selectedNetwork: EAvailableNetwork = getSelectedNetwork(),
 ): string => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	const network = networks[selectedNetwork];
 	return bitcoin.address.fromOutputScript(
 		Buffer.from(scriptPubKey, 'hex'),
@@ -2129,20 +2046,14 @@ export const getAddressFromScriptPubKey = (
  * @param {EAddressType} [addressType]
  */
 export const getAddressIndexInfo = ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	addressType,
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 	addressType?: EAddressType;
 }): TAddressIndexInfo => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
 	if (!addressType) {
 		addressType = getSelectedAddressType({ selectedNetwork, selectedWallet });
 	}
@@ -2193,19 +2104,12 @@ export const rescanAddresses = async ({
  * @returns {Promise<Result<IFormattedTransactions>>}
  */
 export const getUnconfirmedTransactions = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<IFormattedTransactions>> => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	const { currentWallet } = getCurrentWallet({
 		selectedWallet,
 		selectedNetwork,

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -493,12 +493,9 @@ export const addInput = async ({
 	psbt,
 	keyPair,
 	input,
-	selectedNetwork,
+	selectedNetwork = getSelectedNetwork(),
 }: IAddInput): Promise<Result<string>> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		const network = networks[selectedNetwork];
 		const { type } = getAddressInfo(input.address);
 
@@ -570,17 +567,13 @@ export const addInput = async ({
 
 export const broadcastTransaction = async ({
 	rawTx,
-	selectedNetwork,
+	selectedNetwork = getSelectedNetwork(),
 	subscribeToOutputAddress = true,
 }: {
 	rawTx: string;
 	selectedNetwork?: EAvailableNetwork;
 	subscribeToOutputAddress?: boolean;
 }): Promise<Result<string>> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-
 	/**
 	 * Subscribe to the output address and refresh the wallet when the Electrum server detects it.
 	 * This prevents updating the wallet prior to the Electrum server detecting the new tx in the mempool.
@@ -701,12 +694,9 @@ export const updateFee = ({
 export const getBlockExplorerLink = (
 	id: string,
 	type: 'tx' | 'address' = 'tx',
-	selectedNetwork?: EAvailableNetwork,
+	selectedNetwork: EAvailableNetwork = getSelectedNetwork(),
 	service: 'blockstream' | 'mempool' = 'mempool',
 ): string => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
 	switch (service) {
 		case 'blockstream':
 			if (selectedNetwork === 'bitcoinTestnet') {
@@ -939,8 +929,8 @@ export const canBoost = (txid: string): ICanBoostResponse => {
  */
 export const getMaxSendAmount = ({
 	transaction,
-	selectedNetwork,
-	selectedWallet,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	transaction?: ISendTransaction;
 	selectedNetwork?: EAvailableNetwork;
@@ -956,12 +946,6 @@ export const getMaxSendAmount = ({
 		}
 
 		if (transaction.lightningInvoice) {
-			if (!selectedWallet) {
-				selectedWallet = getSelectedWallet();
-			}
-			if (!selectedNetwork) {
-				selectedNetwork = getSelectedNetwork();
-			}
 			// lightning transaction
 			const { spendingBalance } = getBalance({
 				selectedWallet,
@@ -1135,20 +1119,14 @@ export const adjustFee = ({
 export const updateSendAmount = ({
 	amount,
 	transaction,
-	selectedNetwork,
-	selectedWallet,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	amount: number;
 	transaction?: ISendTransaction;
 	selectedNetwork?: EAvailableNetwork;
 	selectedWallet?: TWalletName;
 }): Result<string> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
 	if (!transaction) {
 		const transactionDataResponse = getOnchainTransactionData();
 		if (transactionDataResponse.isErr()) {
@@ -1228,21 +1206,11 @@ export const updateMessage = async ({
 	message,
 	transaction,
 	index = 0,
-	selectedWallet,
-	selectedNetwork,
 }: {
 	message: string;
 	transaction?: ISendTransaction;
 	index?: number;
-	selectedWallet?: TWalletName;
-	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<string>> => {
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
 	if (!transaction) {
 		const transactionDataResponse = getOnchainTransactionData();
 		if (transactionDataResponse.isErr()) {
@@ -1297,20 +1265,14 @@ export const updateMessage = async ({
 /*
 const runCoinSelect = async ({
 	transaction,
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 }: {
 	transaction?: ISendTransaction;
 	selectedNetwork?: EAvailableNetwork;
 	selectedWallet?: TWalletName;
 }): Promise<Result<string>> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
 		if (!transaction) {
 			const transactionDataResponse = getOnchainTransactionData({
 				selectedWallet,
@@ -1502,8 +1464,8 @@ export const setupRbf = async ({
  * @param {string} oldTxId
  */
 export const broadcastBoost = async ({
-	selectedWallet,
-	selectedNetwork,
+	selectedWallet = getSelectedWallet(),
+	selectedNetwork = getSelectedNetwork(),
 	oldTxId,
 	oldFee,
 }: {
@@ -1513,12 +1475,6 @@ export const broadcastBoost = async ({
 	oldFee: number;
 }): Promise<Result<Partial<TOnchainActivityItem>>> => {
 	try {
-		if (!selectedWallet) {
-			selectedWallet = getSelectedWallet();
-		}
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
 		const transactionDataResponse = getOnchainTransactionData();
 		if (transactionDataResponse.isErr()) {
 			return err(transactionDataResponse.error.message);
@@ -1584,13 +1540,9 @@ export interface IGetFeeEstimatesResponse {
  * @returns {Promise<IOnchainFees>}
  */
 export const getFeeEstimates = async (
-	selectedNetwork?: EAvailableNetwork,
+	selectedNetwork: EAvailableNetwork = getSelectedNetwork(),
 ): Promise<Result<IOnchainFees>> => {
 	try {
-		if (!selectedNetwork) {
-			selectedNetwork = getSelectedNetwork();
-		}
-
 		if (__E2E__) {
 			return ok({
 				...initialFeesState.onchain,
@@ -1620,19 +1572,7 @@ export const getFeeEstimates = async (
  * Returns the currently selected on-chain fee id (Ex: 'normal').
  * @returns {EFeeId}
  */
-export const getSelectedFeeId = ({
-	selectedWallet,
-	selectedNetwork,
-}: {
-	selectedWallet?: TWalletName;
-	selectedNetwork?: EAvailableNetwork;
-}): EFeeId => {
-	if (!selectedWallet) {
-		selectedWallet = getSelectedWallet();
-	}
-	if (!selectedNetwork) {
-		selectedNetwork = getSelectedNetwork();
-	}
+export const getSelectedFeeId = (): EFeeId => {
 	const transaction = getOnchainTransactionData();
 	if (transaction.isErr()) {
 		return EFeeId.none;


### PR DESCRIPTION
### Description

Refactors the code to replace occurrences of
```js
if (!selectedNetwork) {
  selectedNetwork = getSelectedNetwork();
}
```
and / or :
```js
if (!selectedWallet) {
  selectedWallet = getSelectedWallet();
}
```

with default parameter values, ie.
```ts
selectedWallet = getSelectedWallet(),
selectedNetwork = getSelectedNetwork(),
```

### Type of change

- [x] Refactoring (improving code without creating new functionality)

### Tests

- [x] No test
