### PR TITLE
feat(wallet): Add Gap Limit Options

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@synonymdev/web-relay": "1.0.7",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
     "bech32": "2.0.0",
-    "beignet": "0.0.22",
+    "beignet": "0.0.23",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
     "bip39": "3.1.0",

--- a/src/navigation/settings/SettingsNavigator.tsx
+++ b/src/navigation/settings/SettingsNavigator.tsx
@@ -11,6 +11,7 @@ import { TChannel } from '@synonymdev/react-native-ldk';
 import MainSettings from '../../screens/Settings';
 import CurrenciesSettings from '../../screens/Settings/Currencies';
 import ElectrumConfig from '../../screens/Settings/ElectrumConfig';
+import GapLimit from '../../screens/Settings/GapLimit';
 import RGSServer from '../../screens/Settings/RGSServer';
 import CoinSelectPreference from '../../screens/Settings/CoinSelectPreference';
 import PaymentPreference from '../../screens/Settings/PaymentPreference';
@@ -84,6 +85,7 @@ export type SettingsStackParamList = {
 	TransactionSpeedSettings: undefined;
 	CustomFee: undefined;
 	ElectrumConfig: undefined;
+	GapLimit: undefined;
 	RGSServer: undefined;
 	CoinSelectPreference: undefined;
 	PaymentPreference: undefined;
@@ -146,6 +148,7 @@ const SettingsNavigator = (): ReactElement => {
 			/>
 			<Stack.Screen name="CustomFee" component={CustomFee} />
 			<Stack.Screen name="ElectrumConfig" component={ElectrumConfig} />
+			<Stack.Screen name="GapLimit" component={GapLimit} />
 			<Stack.Screen name="RGSServer" component={RGSServer} />
 			<Stack.Screen
 				name="CoinSelectPreference"

--- a/src/screens/Settings/Advanced/index.tsx
+++ b/src/screens/Settings/Advanced/index.tsx
@@ -46,6 +46,13 @@ const AdvancedSettings = ({
 				type: EItemType.button,
 				onPress: (): void => navigation.navigate('PaymentPreference'),
 			},
+			{
+				title: t('adv.gap_limit'),
+				type: EItemType.button,
+				onPress: (): void => navigation.navigate('GapLimit'),
+				testID: 'GapLimit',
+				hide: !enableDevOptions,
+			},
 		];
 
 		const networks: ItemData[] = [

--- a/src/screens/Settings/GapLimit/index.tsx
+++ b/src/screens/Settings/GapLimit/index.tsx
@@ -1,0 +1,171 @@
+import React, { memo, ReactElement, useMemo, useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { useTranslation } from 'react-i18next';
+
+import { View, TextInput, ScrollView } from '../../../styles/components';
+import { Text01S, Caption13Up } from '../../../styles/text';
+import { useAppSelector } from '../../../hooks/redux';
+import { gapLimitOptionsSelector } from '../../../store/reselect/wallet';
+import NavigationHeader from '../../../components/NavigationHeader';
+import SafeAreaInset from '../../../components/SafeAreaInset';
+import Button from '../../../components/Button';
+import type { SettingsScreenProps } from '../../../navigation/types';
+import { getOnChainWallet, refreshWallet } from '../../../utils/wallet';
+import { updateWallet } from '../../../store/actions/wallet';
+import { showToast } from '../../../utils/notifications';
+
+const GapLimit = ({}: SettingsScreenProps<'GapLimit'>): ReactElement => {
+	const { t } = useTranslation('settings');
+	const gapLimitOptions = useAppSelector(gapLimitOptionsSelector);
+	const [loading, setLoading] = useState(false);
+	const [lookBehind, setLookBehind] = useState<string>(
+		String(gapLimitOptions.lookBehind),
+	);
+	const [lookAhead, setLookAhead] = useState<string>(
+		String(gapLimitOptions.lookAhead),
+	);
+
+	const hasEdited = useMemo(() => {
+		return (
+			Number(lookBehind) !== gapLimitOptions.lookBehind ||
+			Number(lookAhead) !== gapLimitOptions.lookAhead
+		);
+	}, [
+		gapLimitOptions.lookAhead,
+		gapLimitOptions.lookBehind,
+		lookAhead,
+		lookBehind,
+	]);
+
+	const areValid = useMemo(() => {
+		return Number(lookBehind) > 0 && Number(lookAhead) > 0;
+	}, [lookAhead, lookBehind]);
+
+	const clearChanges = (): void => {
+		setLookBehind(String(gapLimitOptions.lookBehind));
+		setLookAhead(String(gapLimitOptions.lookAhead));
+	};
+
+	const saveGapLimit = async (): Promise<void> => {
+		setLoading(true);
+		const wallet = getOnChainWallet();
+		const res = wallet.updateGapLimit({
+			lookAhead: Number(lookAhead),
+			lookBehind: Number(lookBehind),
+		});
+		if (res.isOk()) {
+			updateWallet({
+				gapLimitOptions: res.value,
+			});
+			await refreshWallet({
+				lightning: false,
+				onchain: true,
+				scanAllAddresses: true,
+			});
+			showToast({
+				type: 'success',
+				title: t('gap.gap_limit_update_title'),
+				description: t('gap.gap_limit_update_description'),
+			});
+		}
+		setLoading(false);
+	};
+
+	return (
+		<View style={styles.container}>
+			<SafeAreaInset type="top" />
+			<NavigationHeader title={t('adv.gap_limit')} />
+			<ScrollView contentContainerStyle={styles.content} bounces={false}>
+				<Text01S color="gray1">Look Behind</Text01S>
+				<TextInput
+					style={styles.textInput}
+					value={lookBehind}
+					placeholder="20"
+					textAlignVertical="center"
+					underlineColorAndroid="transparent"
+					autoCapitalize="none"
+					autoComplete="off"
+					keyboardType="number-pad"
+					autoCorrect={false}
+					onChangeText={(txt): void => {
+						setLookBehind(txt);
+					}}
+					returnKeyType="done"
+					testID="LookBehind"
+				/>
+
+				<Caption13Up color="gray1" style={styles.label}>
+					{'Look Ahead'}
+				</Caption13Up>
+				<TextInput
+					style={styles.textInput}
+					value={lookAhead}
+					placeholder="20"
+					textAlignVertical="center"
+					underlineColorAndroid="transparent"
+					autoCapitalize="none"
+					autoComplete="off"
+					keyboardType="number-pad"
+					autoCorrect={false}
+					onChangeText={(txt): void => {
+						setLookAhead(txt);
+					}}
+					testID="LookAhead"
+				/>
+
+				<View style={styles.buttons}>
+					<Button
+						style={styles.button}
+						text={t('gap.reset')}
+						variant="secondary"
+						size="large"
+						testID="ResetGapLimit"
+						onPress={clearChanges}
+						disabled={!hasEdited}
+					/>
+					<View style={styles.divider} />
+					<Button
+						style={styles.button}
+						text={t('gap.save')}
+						size="large"
+						testID="SaveGapLimit"
+						loading={loading}
+						disabled={!hasEdited || !areValid}
+						onPress={saveGapLimit}
+					/>
+				</View>
+				<SafeAreaInset type="bottom" minPadding={16} />
+			</ScrollView>
+		</View>
+	);
+};
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+	},
+	content: {
+		flexGrow: 1,
+		paddingHorizontal: 16,
+	},
+	label: {
+		marginTop: 16,
+		marginBottom: 4,
+	},
+	textInput: {
+		minHeight: 52,
+		marginTop: 5,
+	},
+	buttons: {
+		marginTop: 16,
+		flexDirection: 'row',
+	},
+	button: {
+		flex: 1,
+	},
+	divider: {
+		width: 16,
+	},
+});
+
+export default memo(GapLimit);

--- a/src/screens/Wallets/Send/ReviewAndSend.tsx
+++ b/src/screens/Wallets/Send/ReviewAndSend.tsx
@@ -284,7 +284,6 @@ const ReviewAndSend = ({
 		}
 		const response = await broadcastTransaction({
 			rawTx: rawTx.hex,
-			selectedNetwork,
 		});
 		if (response.isErr()) {
 			// Check if it failed to broadcast due to low fee.
@@ -324,7 +323,7 @@ const ReviewAndSend = ({
 		}
 
 		navigation.navigate('Result', { success: true, txId: rawTx.id });
-	}, [rawTx, selectedNetwork, _onError, navigation, transaction, dispatch, t]);
+	}, [rawTx, _onError, navigation, transaction, dispatch, t]);
 
 	useEffect(() => {
 		if (rawTx) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -40,7 +40,7 @@ const persistConfig = {
 	key: 'root',
 	storage: mmkvStorage,
 	// increase version after store shape changes
-	version: 37,
+	version: 38,
 	stateReconciler: autoMergeLevel2,
 	blacklist: ['receive', 'ui'],
 	migrate: createMigrate(migrations, { debug: __ENABLE_MIGRATION_DEBUG__ }),

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -12,6 +12,7 @@ import { defaultBlocktankInfoShape } from '../shapes/blocktank';
 import { initialTodosState } from '../shapes/todos';
 import { defaultViewControllers } from '../shapes/ui';
 import {
+	getDefaultGapLimitOptions,
 	getDefaultWalletStoreShape,
 	getNetworkContent,
 } from '../shapes/wallet';
@@ -508,6 +509,15 @@ const migrations = {
 			};
 		}
 		return newState;
+	},
+	38: (state): PersistedState => {
+		return {
+			...state,
+			wallet: {
+				...state.wallet,
+				gapLimitOptions: getDefaultGapLimitOptions(),
+			},
+		};
 	},
 };
 

--- a/src/store/reselect/wallet.ts
+++ b/src/store/reselect/wallet.ts
@@ -4,6 +4,7 @@ import {
 	IFormattedTransaction,
 	IFormattedTransactions,
 	ISendTransaction,
+	TGapLimitOptions,
 	IUtxo,
 } from 'beignet';
 import { createSelector } from '@reduxjs/toolkit';
@@ -56,6 +57,21 @@ export const currentWalletSelector = createSelector(
 	(wallet, selectedWallet): IWallet => {
 		return wallet.wallets[selectedWallet];
 	},
+);
+
+/**
+ * Returns the saved gap limit options for the wallet.
+ * @param {RootState} state
+ * @returns {TGapLimitOptions}
+ */
+export const gapLimitOptionsSelector = createSelector(
+	[walletState],
+	(wallet): TGapLimitOptions => wallet.gapLimitOptions,
+);
+
+export const addressTypesToMonitorSelector = createSelector(
+	[walletState],
+	(wallet): EAddressType[] => wallet.addressTypesToMonitor,
 );
 
 /**

--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -1,10 +1,9 @@
 import cloneDeep from 'lodash/cloneDeep';
-
 import { __WALLET_DEFAULT_SELECTED_NETWORK__ } from '../../constants/env';
 import { IHeader } from '../../utils/types/electrum';
 import { EAvailableNetwork } from '../../utils/networks';
 import { objectKeys } from '../../utils/objectKeys';
-import { IWalletItem, IWallet, IWalletStore } from '../types/wallet';
+import { IWallet, IWalletItem, IWalletStore } from '../types/wallet';
 import {
 	EAddressType,
 	EBoostType,
@@ -13,6 +12,7 @@ import {
 	IAddresses,
 	ISendTransaction,
 	TAddressTypes,
+	TGapLimitOptions,
 } from 'beignet';
 
 export const addressTypes: Readonly<TAddressTypes> = {
@@ -163,12 +163,22 @@ export const defaultWalletShape: Readonly<IWallet> = {
 	},
 };
 
+const defaultGapLimitOptions = {
+	lookAhead: 1,
+	lookBehind: 5,
+};
+
+export const getDefaultGapLimitOptions = (): TGapLimitOptions => {
+	return cloneDeep(defaultGapLimitOptions);
+};
+
 export const defaultWalletStoreShape: Readonly<IWalletStore> = {
 	walletExists: false,
 	selectedNetwork: __WALLET_DEFAULT_SELECTED_NETWORK__,
 	selectedWallet: 'wallet0',
 	exchangeRates: {},
 	addressTypesToMonitor: [EAddressType.p2wpkh],
+	gapLimitOptions: getDefaultGapLimitOptions(),
 	header: {
 		bitcoin: defaultHeader,
 		bitcoinTestnet: defaultHeader,

--- a/src/store/types/wallet.ts
+++ b/src/store/types/wallet.ts
@@ -9,6 +9,7 @@ import {
 	IBoostedTransactions,
 	IFormattedTransactions,
 	ISendTransaction,
+	TGapLimitOptions,
 	IUtxo,
 	TServer,
 } from 'beignet';
@@ -41,6 +42,7 @@ export interface IWalletStore {
 	exchangeRates: IExchangeRates;
 	header: IWalletItem<IHeader>;
 	addressTypesToMonitor: EAddressType[];
+	gapLimitOptions: TGapLimitOptions;
 	wallets: { [key: TWalletName]: IWallet };
 }
 

--- a/src/store/utils/blocktank.ts
+++ b/src/store/utils/blocktank.ts
@@ -372,7 +372,6 @@ export const confirmChannelPurchase = async ({
 	const broadcastResponse = await broadcastTransaction({
 		rawTx: rawTx.value.hex,
 		subscribeToOutputAddress: false,
-		selectedNetwork,
 	});
 	if (broadcastResponse.isErr()) {
 		showToast({

--- a/src/utils/i18n/locales/en/settings.json
+++ b/src/utils/i18n/locales/en/settings.json
@@ -141,6 +141,10 @@
 		"section_networks": "Networks",
 		"section_other": "Other",
 		"address_type": "Bitcoin Address Type",
+		"monitored_address_types": "Monitored Address Types",
+		"monitored_address_types_update_title": "Monitored Address Types Updated",
+		"monitored_address_types_update_description": "Changes will take full effect after app restarts.",
+		"gap_limit": "Address Gap Limit",
 		"coin_selection": "Coin Selection",
 		"cs_method": "Coin Selection Method",
 		"cs_manual": "Manual",
@@ -234,6 +238,12 @@
 		"protocol": "Protocol",
 		"button_reset": "Reset To Default",
 		"button_connect": "Connect To Host"
+	},
+	"gap": {
+		"save": "Save",
+		"reset": "Reset",
+		"gap_limit_update_title": "Address Gap Limit Updated",
+		"gap_limit_update_description": "Changes will take full effect after app restarts."
 	},
 	"rgs": {
 		"server_url": "Rapid-Gossip-Sync Server URL",

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -5,6 +5,7 @@ import { generateMnemonic, TServer } from 'beignet';
 import {
 	getAddressTypesToMonitor,
 	getBip39Passphrase,
+	getGapLimitOptions,
 	getMnemonicPhrase,
 	getSelectedAddressType,
 	getSelectedNetwork,
@@ -113,10 +114,10 @@ export const startWalletServices = async ({
 			return err(mnemonicResponse.error.message);
 		}
 		const mnemonic = mnemonicResponse.value;
+		const bip39Passphrase = await getBip39Passphrase();
 
 		const walletExists = getWalletStore()?.walletExists;
 		if (!walletExists) {
-			const bip39Passphrase = await getBip39Passphrase();
 			const createRes = await createWallet({ mnemonic, bip39Passphrase });
 			if (createRes.isErr()) {
 				return err(createRes.error.message);
@@ -127,12 +128,14 @@ export const startWalletServices = async ({
 				selectedNetwork,
 			});
 			const addressTypesToMonitor = getAddressTypesToMonitor();
+			const gapLimitOptions = getGapLimitOptions();
 			const onChainSetupRes = await setupOnChainWallet({
 				name: selectedWallet,
 				selectedNetwork,
-				bip39Passphrase: await getBip39Passphrase(),
+				bip39Passphrase,
 				addressType,
 				addressTypesToMonitor,
+				gapLimitOptions,
 			});
 			if (onChainSetupRes.isErr()) {
 				return err(onChainSetupRes.error.message);

--- a/src/utils/wallet/electrum.ts
+++ b/src/utils/wallet/electrum.ts
@@ -40,21 +40,6 @@ export const isConnectedElectrum = async (): Promise<boolean> => {
 };
 
 /**
- * Returns UTXO's for a given wallet and network along with the available balance.
- * @param {TWalletName} [selectedWallet]
- * @param {boolean} [scanAllAddresses]
- * @returns {Promise<Result<IGetUtxosResponse>>}
- */
-export const getUtxos = async ({
-	scanAllAddresses = false,
-}: {
-	scanAllAddresses?: boolean;
-}): Promise<Result<IGetUtxosResponse>> => {
-	const wallet = getOnChainWallet();
-	return await wallet.getUtxos({ scanAllAddresses });
-};
-
-/**
  * Formats a provided array of addresses a returns their UTXO's & balances.
  * @param {IAddress[]} allAddresses
  * @returns {Promise<Result<IGetUtxosResponse>>}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5711,10 +5711,10 @@ bech32@^1.1.2, bech32@^1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-beignet@0.0.22:
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.22.tgz#07fb67299b4c7c99c2537252e9adaa27a51f57c0"
-  integrity sha512-Xb/L7HPUdc0yC/dy2kv1/AoZ6Alej8k8IGQGx2QIuAKTeu9kVVispJFDwe30xcyAuTFMwj2AYM8GJmoAuwkFdA==
+beignet@0.0.23:
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.23.tgz#7c7860a671ad691f7c1fad1598a349085dada8c8"
+  integrity sha512-BD5KnjJrBaLkI/qm5ac9qHckMBbOGcamTFopLdEvcfasB66PPAZSGd60/6zuWFN/ihe81XjwV2EM4kcMoxkx8A==
   dependencies:
     "@bitcoinerlab/secp256k1" "1.0.5"
     bech32 "2.0.0"


### PR DESCRIPTION
### Description
- Upgrades Beignet to `0.0.23`.
- Implements `gapLimitOptions` from upgrade.
    - New wallets default to a `lookBehind` of `5` and a `lookAhead` of `1` to limit queries to Electrum.
    - Restored wallets temporarily use a `lookBehind` of `20` and a `lookAhead` of `20` during the initial scan. Once this scan finishes it reverts back to the default lookBehind-lookAhead of 5-1.
    - If you think the 5-1 defaults are low, we can try something higher like 5-5, but restored wallets may come close to the limits of what a given Electrum server will tolerate for extremely active users or heavy testing sessions.
- Adds two dev-only views.
    - Monitored Address Types: Found in "Settings->Advanced->Bitcoin Address Type" beneath "Monitored Address Types" allowing us to adjust what address types are actively being monitored. An app restart is required for changes to take effect.
    - Gap Limit: Found in "Settings->Advanced->Gap Limit" allowing us to adjust the gap limit in Bitkit as needed for testing/debugging. 
- Updates `broadcastTransaction`, `getReceiveAddress` & `getBalance` methods.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### Tests
- [x] No test

### Screenshot / Video
![Simulator Screenshot - iPhone 14 - 2024-02-19 at 20 54 27](https://github.com/synonymdev/bitkit/assets/8532651/2e3b3886-63d6-4fe2-88c8-fe415f83bc97)
![Simulator Screenshot - iPhone 14 - 2024-02-19 at 20 54 10](https://github.com/synonymdev/bitkit/assets/8532651/606385e4-3f42-4121-a2e5-9fc7dca2c136)


### QA Notes
- Restores should continue to work as expected. Once a restore is successful and the initial scan is complete we should be able to observe that the gap limit lookAhead and lookBehind were reverted to their default of 5-1 in "Settings->Advanced->Gap Limit".