### PR TITLE
fix(wallet): Consider tx_hash when combining utxos

### DIFF
--- a/src/screens/Wallets/Send/CoinSelection.tsx
+++ b/src/screens/Wallets/Send/CoinSelection.tsx
@@ -99,7 +99,8 @@ const CoinSelection = ({
 				(item) =>
 					item.index === current.index &&
 					item.tx_pos === current.tx_pos &&
-					item.value === current.value,
+					item.value === current.value &&
+					item.tx_hash === current.tx_hash,
 			);
 			if (!x) {
 				return acc.concat([current]);


### PR DESCRIPTION
### Description
- Considers `tx_hash` when combining UTXO's in the `CoinSelection` view.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test
