### PR TITLE
feat(lightning): show sheet for counterparty force-close

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -392,7 +392,7 @@ PODS:
     - React-Core
   - react-native-keep-awake (1.2.2):
     - React-Core
-  - react-native-ldk (0.0.129):
+  - react-native-ldk (0.0.132):
     - React
   - react-native-mmkv (2.11.0):
     - MMKV (>= 1.2.13)
@@ -911,7 +911,7 @@ SPEC CHECKSUMS:
   react-native-flipper: 9c1957af24b76493ba74f46d000a5c1d485e7731
   react-native-image-picker: 2e2e82aba9b6a91a7c78f7d9afde341a2659c7b8
   react-native-keep-awake: ad1d67f617756b139536977a0bf06b27cec0714a
-  react-native-ldk: 30a80ced71007307cfceb8a79e4996788ab413ea
+  react-native-ldk: 4bb809be74082223644931a3239323af56c7ee8f
   react-native-mmkv: e97c0c79403fb94577e5d902ab1ebd42b0715b43
   react-native-netinfo: 5ddbf20865bcffab6b43d0e4e1fd8b3896beb898
   react-native-quick-base64: a5dbe4528f1453e662fcf7351029500b8b63e7bb
@@ -965,4 +965,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: b01d3271ab99feb247ef10569ea8ace3cf7254ec
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/ios/bitkit.xcodeproj/project.pbxproj
+++ b/ios/bitkit.xcodeproj/project.pbxproj
@@ -8,16 +8,16 @@
 
 /* Begin PBXBuildFile section */
 		00E356F31AD99517003FC87E /* bitkitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 00E356F21AD99517003FC87E /* bitkitTests.m */; };
-		12DDECE6DB6F04C489311159 /* libPods-bitkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E82FA9E64FA69625137C3E /* libPods-bitkit.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		567C8B7A7734CB223E1D3C42 /* libPods-bitkit-bitkitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 375987267538AB596CB234D8 /* libPods-bitkit-bitkitTests.a */; };
+		6BE67F74D82906844066A77F /* libPods-bitkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 16CFF02DE133FBCF02F77129 /* libPods-bitkit.a */; };
 		777F5BE129EDEB75005E0E4B /* InterTight-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 777F5BDD29EDEB75005E0E4B /* InterTight-Bold.ttf */; };
 		777F5BE229EDEB75005E0E4B /* InterTight-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 777F5BDE29EDEB75005E0E4B /* InterTight-Regular.ttf */; };
 		777F5BE329EDEB75005E0E4B /* InterTight-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 777F5BDF29EDEB75005E0E4B /* InterTight-SemiBold.ttf */; };
 		777F5BE429EDEB75005E0E4B /* InterTight-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 777F5BE029EDEB75005E0E4B /* InterTight-Medium.ttf */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		C7280BD3D4B06ACF2492C2F3 /* libPods-bitkit-bitkitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A56F0C4BCA4E3F79EBF3F7C4 /* libPods-bitkit-bitkitTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -34,23 +34,23 @@
 		00E356EE1AD99517003FC87E /* bitkitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = bitkitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* bitkitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bitkitTests.m; sourceTree = "<group>"; };
-		0D53BC92A62A7EE80BB4DBC9 /* Pods-bitkit-bitkitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.debug.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		04F1381DC8396EE1A0FBB0AA /* Pods-bitkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.release.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* bitkit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = bitkit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = bitkit/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = bitkit/AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = bitkit/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = bitkit/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = bitkit/main.m; sourceTree = "<group>"; };
-		354C379BD300695F3EE7A40E /* Pods-bitkit-bitkitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.release.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.release.xcconfig"; sourceTree = "<group>"; };
-		375987267538AB596CB234D8 /* libPods-bitkit-bitkitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit-bitkitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		16CFF02DE133FBCF02F77129 /* libPods-bitkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		584C0F67B2AC615A76BABDF5 /* Pods-bitkit-bitkitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.release.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.release.xcconfig"; sourceTree = "<group>"; };
 		777F5BDD29EDEB75005E0E4B /* InterTight-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "InterTight-Bold.ttf"; sourceTree = "<group>"; };
 		777F5BDE29EDEB75005E0E4B /* InterTight-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "InterTight-Regular.ttf"; sourceTree = "<group>"; };
 		777F5BDF29EDEB75005E0E4B /* InterTight-SemiBold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "InterTight-SemiBold.ttf"; sourceTree = "<group>"; };
 		777F5BE029EDEB75005E0E4B /* InterTight-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "InterTight-Medium.ttf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = bitkit/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		9B2123A1E473C9CBAFE25212 /* Pods-bitkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.debug.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.debug.xcconfig"; sourceTree = "<group>"; };
-		C1E82FA9E64FA69625137C3E /* libPods-bitkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		C377ED0D202043E3FF7A0C4E /* Pods-bitkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.release.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.release.xcconfig"; sourceTree = "<group>"; };
+		A56F0C4BCA4E3F79EBF3F7C4 /* libPods-bitkit-bitkitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit-bitkitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A6721A37EE46BDF7836A4507 /* Pods-bitkit-bitkitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.debug.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C72C5306B469DA8D51596C71 /* Pods-bitkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.debug.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.debug.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -59,7 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				567C8B7A7734CB223E1D3C42 /* libPods-bitkit-bitkitTests.a in Frameworks */,
+				C7280BD3D4B06ACF2492C2F3 /* libPods-bitkit-bitkitTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -67,7 +67,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				12DDECE6DB6F04C489311159 /* libPods-bitkit.a in Frameworks */,
+				6BE67F74D82906844066A77F /* libPods-bitkit.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -108,8 +108,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				C1E82FA9E64FA69625137C3E /* libPods-bitkit.a */,
-				375987267538AB596CB234D8 /* libPods-bitkit-bitkitTests.a */,
+				16CFF02DE133FBCF02F77129 /* libPods-bitkit.a */,
+				A56F0C4BCA4E3F79EBF3F7C4 /* libPods-bitkit-bitkitTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -161,10 +161,10 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				9B2123A1E473C9CBAFE25212 /* Pods-bitkit.debug.xcconfig */,
-				C377ED0D202043E3FF7A0C4E /* Pods-bitkit.release.xcconfig */,
-				0D53BC92A62A7EE80BB4DBC9 /* Pods-bitkit-bitkitTests.debug.xcconfig */,
-				354C379BD300695F3EE7A40E /* Pods-bitkit-bitkitTests.release.xcconfig */,
+				C72C5306B469DA8D51596C71 /* Pods-bitkit.debug.xcconfig */,
+				04F1381DC8396EE1A0FBB0AA /* Pods-bitkit.release.xcconfig */,
+				A6721A37EE46BDF7836A4507 /* Pods-bitkit-bitkitTests.debug.xcconfig */,
+				584C0F67B2AC615A76BABDF5 /* Pods-bitkit-bitkitTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -176,12 +176,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "bitkitTests" */;
 			buildPhases = (
-				D0B2D6AAF02D3E8F8F31443B /* [CP] Check Pods Manifest.lock */,
+				1CB708DF22CD2150837D2F63 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				A742D333941DC1C722CF692D /* [CP] Embed Pods Frameworks */,
-				6F6FB320C9A4CA35B7A16EC1 /* [CP] Copy Pods Resources */,
+				6C843FF2FB6FFF6D51478993 /* [CP] Embed Pods Frameworks */,
+				B6FFC96BAE420153D40A3FDD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -197,18 +197,18 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "bitkit" */;
 			buildPhases = (
-				2B35F90A69012C67CDE681FE /* [CP] Check Pods Manifest.lock */,
+				67624593C833B1A269033D68 /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				0FBF2245AF91AC7E48263E57 /* [CP] Embed Pods Frameworks */,
-				09E298217A4D7521AF54D065 /* [CP] Copy Pods Resources */,
-				B7D3385FA9C9AE91C340765C /* [CP-User] [NODEJS MOBILE] Copy Node.js Project files */,
-				71D57A8D9ADC35D76226E259 /* [CP-User] [NODEJS MOBILE] Build Native Modules */,
-				766E60A6079B97D1B23E5D4C /* [CP-User] [NODEJS MOBILE] Sign Native Modules */,
-				61F0354FF2020C4ECB9B98EC /* [CP-User] [NODEJS MOBILE] Remove Simulator Strip */,
+				DDBE43F14182446D2E5D5E6A /* [CP] Embed Pods Frameworks */,
+				EF4D029D410447A670630793 /* [CP] Copy Pods Resources */,
+				88EE80BBA68E161286ABEAA0 /* [CP-User] [NODEJS MOBILE] Copy Node.js Project files */,
+				4C1DF5DFB51763BAFC336F16 /* [CP-User] [NODEJS MOBILE] Build Native Modules */,
+				8D564450C4A0ADF82C03894B /* [CP-User] [NODEJS MOBILE] Sign Native Modules */,
+				797723223DEE4A9F423039E5 /* [CP-User] [NODEJS MOBILE] Remove Simulator Strip */,
 			);
 			buildRules = (
 			);
@@ -295,41 +295,39 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		09E298217A4D7521AF54D065 /* [CP] Copy Pods Resources */ = {
+		1CB708DF22CD2150837D2F63 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Copy Pods Resources";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-bitkit-bitkitTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		0FBF2245AF91AC7E48263E57 /* [CP] Embed Pods Frameworks */ = {
+		4C1DF5DFB51763BAFC336F16 /* [CP-User] [NODEJS MOBILE] Build Native Modules */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
+			name = "[CP-User] [NODEJS MOBILE] Build Native Modules";
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
+			shellScript = "#!/bin/sh\nset -e\n\nif [ -f ./.xcode.env ]; then\n  source \"./.xcode.env\";\nfi\nif [ -f ./.xcode.env.local ]; then\n  source \"./.xcode.env.local\";\nfi\n\nDESIRED_NODE_VERSION=\"18\"\nCURRENT_NODE_VERSION=\"$(node -p \"process.versions.node.split('.')[0]\")\"\nif [ \"$CURRENT_NODE_VERSION\" -ne \"$DESIRED_NODE_VERSION\" ]; then\n  echo \"nodejs-mobile-react-native requires Node.js version \\\n$DESIRED_NODE_VERSION accessible from Xcode, but found \\\n$(node -p 'process.versions.node')\"\n  exit 1\nfi\n\n# This is our nodejs-project folder that was copied to the Xcode build folder\nNODEPROJ=\"$CODESIGNING_FOLDER_PATH/nodejs-project\"\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, look for it in the project's\n#nodejs-assets/BUILD_NATIVE_MODULES.txt file.\nNODEJS_ASSETS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../nodejs-assets/ && pwd )\"\nPREFERENCE_FILE_PATH=\"$NODEJS_ASSETS_DIR/BUILD_NATIVE_MODULES.txt\"\n  if [ -f \"$PREFERENCE_FILE_PATH\" ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=\"$(cat $PREFERENCE_FILE_PATH | xargs)\"\n  fi\nfi\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, try to find .gyp files\n#to turn it on.\n  gypfiles=($(find \"$NODEPROJ\" -type f -name \"*.gyp\"))\n  if [ ${#gypfiles[@]} -gt 0 ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=1\n  else\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=0\n  fi\nfi\n\nif [ \"1\" != \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then exit 0; fi\n\n# Delete object files that may already come from within the npm package.\nfind \"$NODEPROJ\" -name \"*.o\" -type f -delete\nfind \"$NODEPROJ\" -name \"*.a\" -type f -delete\n\n# Function to skip compilation of a prebuilt module\npreparePrebuiltModule()\n{\n  local DOT_NODE_PATH=\"$1\"\n  local DOT_NODE_FULL=\"$(cd \"$(dirname -- \"$DOT_NODE_PATH\")\" >/dev/null; pwd -P)/$(basename -- \"$DOT_NODE_PATH\")\"\n  local MODULE_ROOT=\"$(cd $DOT_NODE_PATH && cd .. && cd .. && cd .. && pwd)\"\n  local MODULE_NAME=\"$(basename $MODULE_ROOT)\"\n  echo \"Preparing to use the prebuild in $MODULE_NAME\"\n  # Move the prebuild to the correct folder:\n  rm -rf $MODULE_ROOT/build\n  mkdir -p $MODULE_ROOT/build/Release\n  mv $DOT_NODE_FULL $MODULE_ROOT/build/Release/\n  # Hack the npm package to forcefully disable compile-on-install:\n  rm -rf $MODULE_ROOT/binding.gyp\n  sed -i.bak 's/\"install\"/\"dontinstall\"/g; s/\"rebuild\"/\"dontrebuild\"/g; s/\"gypfile\"/\"dontgypfile\"/g' $MODULE_ROOT/package.json\n}\n\n# Delete bundle contents that may be there from previous builds.\n# Handle the special case where the module has a prebuild that we want to use\nif [ \"$PLATFORM_PREFERRED_ARCH\" == \"arm64\" ]; then\n  PREBUILD_ARCH=\"arm64\"\nelse\n  PREBUILD_ARCH=\"x64\"\nfi\nif [ \"$PLATFORM_NAME\" == \"iphonesimulator\" ] && [ \"$NATIVE_ARCH\" == \"arm64\" ]; then\n  SUFFIX=\"-simulator\"\n  PREBUILD_ARCH=\"arm64\"\nelse\n  SUFFIX=\"\"\nfi\nfind -E \"$NODEPROJ\" \\\n    ! -regex \".*/prebuilds/ios-$PREBUILD_ARCH$SUFFIX\" \\\n    -regex '.*/prebuilds/[^/]*$' -type d \\\n    -prune -exec rm -rf \"{}\" \\;\nfind -E \"$NODEPROJ\" \\\n    ! -regex \".*/prebuilds/ios-$PREBUILD_ARCH$SUFFIX/.*\\.node$\" \\\n    -name '*.node' -type f \\\n    -exec rm \"{}\" \\;\nfind \"$NODEPROJ\" \\\n    -name \"*.framework\" -type d \\\n    -prune -exec rm -rf \"{}\" \\;\nfor DOT_NODE in `find -E \"$NODEPROJ\" -regex \".*/prebuilds/ios-$PREBUILD_ARCH$SUFFIX/.*\\.node$\"`; do\n  preparePrebuiltModule \"$DOT_NODE\"\ndone\n\n# Apply patches to the modules package.json\nif [ -d \"$NODEPROJ\"/node_modules/ ]; then\n  PATCH_SCRIPT_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/scripts/ && pwd )\"\n  NODEJS_PROJECT_MODULES_DIR=\"$( cd \"$NODEPROJ\" && cd node_modules && pwd )\"\n  node \"$PATCH_SCRIPT_DIR\"/patch-package.js $NODEJS_PROJECT_MODULES_DIR\nfi\n\n# Get the nodejs-mobile-gyp location\nNODEJS_MOBILE_GYP_BIN_FILE=\"$( cd \"$PROJECT_DIR\" && cd .. && node -p 'require.resolve(`nodejs-mobile-gyp/bin/node-gyp.js`)' )\"\n\n# Support building neon-bindings (Rust) native modules\nif [ -f ~/.cargo/env ]; then\n  source ~/.cargo/env;\nfi\n\n# Rebuild modules with right environment\nNODEJS_HEADERS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/ios/libnode/ && pwd )\"\npushd $NODEPROJ\nif [ \"$PLATFORM_NAME\" == \"iphoneos\" ]; then\n  GYP_DEFINES=\"OS=ios\" \\\n  CARGO_BUILD_TARGET=\"aarch64-apple-ios iossim=false\" \\\n  NODEJS_MOBILE_GYP=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_node_gyp=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_nodedir=\"$NODEJS_HEADERS_DIR\" \\\n  npm_config_platform=\"ios\" \\\n  npm_config_format=\"make-ios\" \\\n  npm_config_arch=\"arm64\" \\\n  npm --verbose --foreground-scripts rebuild --build-from-source\nelif [ \"$NATIVE_ARCH\" == \"arm64\" ]; then\n  GYP_DEFINES=\"OS=ios target_arch=arm64 iossim=true\" \\\n  CARGO_BUILD_TARGET=\"aarch64-apple-ios-sim\" \\\n  NODEJS_MOBILE_GYP=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_node_gyp=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_nodedir=\"$NODEJS_HEADERS_DIR\" \\\n  npm_config_platform=\"ios\" \\\n  npm_config_format=\"make-ios\" \\\n  npm_config_arch=\"arm64\" \\\n  npm --verbose --foreground-scripts rebuild --build-from-source\nelse\n  GYP_DEFINES=\"OS=ios target_arch=x64 iossim=true\" \\\n  CARGO_BUILD_TARGET=\"x86_64-apple-ios\" \\\n  NODEJS_MOBILE_GYP=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_node_gyp=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_nodedir=\"$NODEJS_HEADERS_DIR\" \\\n  npm_config_platform=\"ios\" \\\n  npm_config_format=\"make-ios\" \\\n  npm_config_arch=\"x64\" \\\n  npm --verbose --foreground-scripts rebuild --build-from-source\nfi\npopd\n";
 		};
-		2B35F90A69012C67CDE681FE /* [CP] Check Pods Manifest.lock */ = {
+		67624593C833B1A269033D68 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -351,54 +349,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		61F0354FF2020C4ECB9B98EC /* [CP-User] [NODEJS MOBILE] Remove Simulator Strip */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			name = "[CP-User] [NODEJS MOBILE] Remove Simulator Strip";
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\nset -e\n\nFRAMEWORK_BINARY_PATH=\"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/NodeMobile.framework/NodeMobile\"\nFRAMEWORK_STRIPPED_PATH=\"$FRAMEWORK_BINARY_PATH-strip\"\n\nif [ \"$PLATFORM_NAME\" != \"iphonesimulator\" ]; then\n  if $(lipo \"$FRAMEWORK_BINARY_PATH\" -verify_arch \"x86_64\") ; then\n    lipo -output \"$FRAMEWORK_STRIPPED_PATH\" -remove \"x86_64\" \"$FRAMEWORK_BINARY_PATH\"\n    rm \"$FRAMEWORK_BINARY_PATH\"\n    mv \"$FRAMEWORK_STRIPPED_PATH\" \"$FRAMEWORK_BINARY_PATH\"\n    echo \"Removed simulator strip from NodeMobile.framework\"\n  fi\nfi\n";
-		};
-		6F6FB320C9A4CA35B7A16EC1 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		71D57A8D9ADC35D76226E259 /* [CP-User] [NODEJS MOBILE] Build Native Modules */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			name = "[CP-User] [NODEJS MOBILE] Build Native Modules";
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\nset -e\n\nif [ -f ./.xcode.env ]; then\n  source \"./.xcode.env\";\nfi\nif [ -f ./.xcode.env.local ]; then\n  source \"./.xcode.env.local\";\nfi\n\nDESIRED_NODE_VERSION=\"18\"\nCURRENT_NODE_VERSION=\"$(node -p \"process.versions.node.split('.')[0]\")\"\nif [ \"$CURRENT_NODE_VERSION\" -ne \"$DESIRED_NODE_VERSION\" ]; then\n  echo \"nodejs-mobile-react-native requires Node.js version \\\n$DESIRED_NODE_VERSION accessible from Xcode, but found \\\n$(node -p 'process.versions.node')\"\n  exit 1\nfi\n\n# This is our nodejs-project folder that was copied to the Xcode build folder\nNODEPROJ=\"$CODESIGNING_FOLDER_PATH/nodejs-project\"\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, look for it in the project's\n#nodejs-assets/BUILD_NATIVE_MODULES.txt file.\nNODEJS_ASSETS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../nodejs-assets/ && pwd )\"\nPREFERENCE_FILE_PATH=\"$NODEJS_ASSETS_DIR/BUILD_NATIVE_MODULES.txt\"\n  if [ -f \"$PREFERENCE_FILE_PATH\" ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=\"$(cat $PREFERENCE_FILE_PATH | xargs)\"\n  fi\nfi\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, try to find .gyp files\n#to turn it on.\n  gypfiles=($(find \"$NODEPROJ\" -type f -name \"*.gyp\"))\n  if [ ${#gypfiles[@]} -gt 0 ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=1\n  else\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=0\n  fi\nfi\n\nif [ \"1\" != \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then exit 0; fi\n\n# Delete object files that may already come from within the npm package.\nfind \"$NODEPROJ\" -name \"*.o\" -type f -delete\nfind \"$NODEPROJ\" -name \"*.a\" -type f -delete\n\n# Function to skip compilation of a prebuilt module\npreparePrebuiltModule()\n{\n  local DOT_NODE_PATH=\"$1\"\n  local DOT_NODE_FULL=\"$(cd \"$(dirname -- \"$DOT_NODE_PATH\")\" >/dev/null; pwd -P)/$(basename -- \"$DOT_NODE_PATH\")\"\n  local MODULE_ROOT=\"$(cd $DOT_NODE_PATH && cd .. && cd .. && cd .. && pwd)\"\n  local MODULE_NAME=\"$(basename $MODULE_ROOT)\"\n  echo \"Preparing to use the prebuild in $MODULE_NAME\"\n  # Move the prebuild to the correct folder:\n  rm -rf $MODULE_ROOT/build\n  mkdir -p $MODULE_ROOT/build/Release\n  mv $DOT_NODE_FULL $MODULE_ROOT/build/Release/\n  # Hack the npm package to forcefully disable compile-on-install:\n  rm -rf $MODULE_ROOT/binding.gyp\n  sed -i.bak 's/\"install\"/\"dontinstall\"/g; s/\"rebuild\"/\"dontrebuild\"/g; s/\"gypfile\"/\"dontgypfile\"/g' $MODULE_ROOT/package.json\n}\n\n# Delete bundle contents that may be there from previous builds.\n# Handle the special case where the module has a prebuild that we want to use\nif [ \"$PLATFORM_PREFERRED_ARCH\" == \"arm64\" ]; then\n  PREBUILD_ARCH=\"arm64\"\nelse\n  PREBUILD_ARCH=\"x64\"\nfi\nif [ \"$PLATFORM_NAME\" == \"iphonesimulator\" ] && [ \"$NATIVE_ARCH\" == \"arm64\" ]; then\n  SUFFIX=\"-simulator\"\n  PREBUILD_ARCH=\"arm64\"\nelse\n  SUFFIX=\"\"\nfi\nfind -E \"$NODEPROJ\" \\\n    ! -regex \".*/prebuilds/ios-$PREBUILD_ARCH$SUFFIX\" \\\n    -regex '.*/prebuilds/[^/]*$' -type d \\\n    -prune -exec rm -rf \"{}\" \\;\nfind -E \"$NODEPROJ\" \\\n    ! -regex \".*/prebuilds/ios-$PREBUILD_ARCH$SUFFIX/.*\\.node$\" \\\n    -name '*.node' -type f \\\n    -exec rm \"{}\" \\;\nfind \"$NODEPROJ\" \\\n    -name \"*.framework\" -type d \\\n    -prune -exec rm -rf \"{}\" \\;\nfor DOT_NODE in `find -E \"$NODEPROJ\" -regex \".*/prebuilds/ios-$PREBUILD_ARCH$SUFFIX/.*\\.node$\"`; do\n  preparePrebuiltModule \"$DOT_NODE\"\ndone\n\n# Apply patches to the modules package.json\nif [ -d \"$NODEPROJ\"/node_modules/ ]; then\n  PATCH_SCRIPT_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/scripts/ && pwd )\"\n  NODEJS_PROJECT_MODULES_DIR=\"$( cd \"$NODEPROJ\" && cd node_modules && pwd )\"\n  node \"$PATCH_SCRIPT_DIR\"/patch-package.js $NODEJS_PROJECT_MODULES_DIR\nfi\n\n# Get the nodejs-mobile-gyp location\nNODEJS_MOBILE_GYP_BIN_FILE=\"$( cd \"$PROJECT_DIR\" && cd .. && node -p 'require.resolve(`nodejs-mobile-gyp/bin/node-gyp.js`)' )\"\n\n# Support building neon-bindings (Rust) native modules\nif [ -f ~/.cargo/env ]; then\n  source ~/.cargo/env;\nfi\n\n# Rebuild modules with right environment\nNODEJS_HEADERS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/ios/libnode/ && pwd )\"\npushd $NODEPROJ\nif [ \"$PLATFORM_NAME\" == \"iphoneos\" ]; then\n  GYP_DEFINES=\"OS=ios\" \\\n  CARGO_BUILD_TARGET=\"aarch64-apple-ios iossim=false\" \\\n  NODEJS_MOBILE_GYP=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_node_gyp=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_nodedir=\"$NODEJS_HEADERS_DIR\" \\\n  npm_config_platform=\"ios\" \\\n  npm_config_format=\"make-ios\" \\\n  npm_config_arch=\"arm64\" \\\n  npm --verbose --foreground-scripts rebuild --build-from-source\nelif [ \"$NATIVE_ARCH\" == \"arm64\" ]; then\n  GYP_DEFINES=\"OS=ios target_arch=arm64 iossim=true\" \\\n  CARGO_BUILD_TARGET=\"aarch64-apple-ios-sim\" \\\n  NODEJS_MOBILE_GYP=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_node_gyp=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_nodedir=\"$NODEJS_HEADERS_DIR\" \\\n  npm_config_platform=\"ios\" \\\n  npm_config_format=\"make-ios\" \\\n  npm_config_arch=\"arm64\" \\\n  npm --verbose --foreground-scripts rebuild --build-from-source\nelse\n  GYP_DEFINES=\"OS=ios target_arch=x64 iossim=true\" \\\n  CARGO_BUILD_TARGET=\"x86_64-apple-ios\" \\\n  NODEJS_MOBILE_GYP=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_node_gyp=\"$NODEJS_MOBILE_GYP_BIN_FILE\" \\\n  npm_config_nodedir=\"$NODEJS_HEADERS_DIR\" \\\n  npm_config_platform=\"ios\" \\\n  npm_config_format=\"make-ios\" \\\n  npm_config_arch=\"x64\" \\\n  npm --verbose --foreground-scripts rebuild --build-from-source\nfi\npopd\n";
-		};
-		766E60A6079B97D1B23E5D4C /* [CP-User] [NODEJS MOBILE] Sign Native Modules */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			name = "[CP-User] [NODEJS MOBILE] Sign Native Modules";
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "#!/bin/sh\nset -e\n\nif [ -f ./.xcode.env ]; then\n  source \"./.xcode.env\";\nfi\nif [ -f ./.xcode.env.local ]; then\n  source \"./.xcode.env.local\";\nfi\n\nDESIRED_NODE_VERSION=\"18\"\nCURRENT_NODE_VERSION=\"$(node -p \"process.versions.node.split('.')[0]\")\"\nif [ \"$CURRENT_NODE_VERSION\" -ne \"$DESIRED_NODE_VERSION\" ]; then\n  echo \"nodejs-mobile-react-native's ios-build-native-modules script requires \\\nNode.js version $DESIRED_NODE_VERSION, but found \\\n$(node -p 'process.versions.node')\"\n  exit 1\nfi\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, look for it in the project's\n#nodejs-assets/BUILD_NATIVE_MODULES.txt file.\nNODEJS_ASSETS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../nodejs-assets/ && pwd )\"\nPREFERENCE_FILE_PATH=\"$NODEJS_ASSETS_DIR/BUILD_NATIVE_MODULES.txt\"\n  if [ -f \"$PREFERENCE_FILE_PATH\" ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=\"$(cat $PREFERENCE_FILE_PATH | xargs)\"\n  fi\nfi\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, try to find .gyp files\n#to turn it on.\n  gypfiles=($(find \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -type f -name \"*.gyp\"))\n  if [ ${#gypfiles[@]} -gt 0 ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=1\n  else\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=0\n  fi\nfi\n\nif [ \"1\" != \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then exit 0; fi\n\n# Delete object files\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.o\" -type f -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.a\" -type f -delete\n\n# Create Info.plist for each framework built and loader override.\nPATCH_SCRIPT_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/scripts/ && pwd )\"\nNODEJS_PROJECT_DIR=\"$( cd \"$CODESIGNING_FOLDER_PATH\" && cd nodejs-project/ && pwd )\"\nnode \"$PATCH_SCRIPT_DIR\"/ios-create-plists-and-dlopen-override.js $NODEJS_PROJECT_DIR\n\n# Embed every resulting .framework in the application and delete them afterwards.\nembed_framework()\n{\n  FRAMEWORK_NAME=\"$(basename \"$1\")\"\n  cp -r \"$1\" \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/\"\n  /usr/bin/codesign --force --sign $EXPANDED_CODE_SIGN_IDENTITY --preserve-metadata=identifier,entitlements,flags --timestamp=none \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$FRAMEWORK_NAME\"\n}\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.framework\" -type d | while read frmwrk_path; do embed_framework \"$frmwrk_path\"; done\n\n#Delete gyp temporary .deps dependency folders from the project structure.\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -path \"*/.deps/*\" -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \".deps\" -type d -delete\n\n#Delete frameworks from their build paths\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -path \"*/*.framework/*\" -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.framework\" -type d -delete\n";
-		};
-		A742D333941DC1C722CF692D /* [CP] Embed Pods Frameworks */ = {
+		6C843FF2FB6FFF6D51478993 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -415,7 +366,17 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		B7D3385FA9C9AE91C340765C /* [CP-User] [NODEJS MOBILE] Copy Node.js Project files */ = {
+		797723223DEE4A9F423039E5 /* [CP-User] [NODEJS MOBILE] Remove Simulator Strip */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			name = "[CP-User] [NODEJS MOBILE] Remove Simulator Strip";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/sh\nset -e\n\nFRAMEWORK_BINARY_PATH=\"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/NodeMobile.framework/NodeMobile\"\nFRAMEWORK_STRIPPED_PATH=\"$FRAMEWORK_BINARY_PATH-strip\"\n\nif [ \"$PLATFORM_NAME\" != \"iphonesimulator\" ]; then\n  if $(lipo \"$FRAMEWORK_BINARY_PATH\" -verify_arch \"x86_64\") ; then\n    lipo -output \"$FRAMEWORK_STRIPPED_PATH\" -remove \"x86_64\" \"$FRAMEWORK_BINARY_PATH\"\n    rm \"$FRAMEWORK_BINARY_PATH\"\n    mv \"$FRAMEWORK_STRIPPED_PATH\" \"$FRAMEWORK_BINARY_PATH\"\n    echo \"Removed simulator strip from NodeMobile.framework\"\n  fi\nfi\n";
+		};
+		88EE80BBA68E161286ABEAA0 /* [CP-User] [NODEJS MOBILE] Copy Node.js Project files */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -425,26 +386,65 @@
 			shellPath = /bin/sh;
 			shellScript = "#!/bin/sh\nset -e\n\nNODEJS_ASSETS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../nodejs-assets/ && pwd )\"\nNODEJS_BUILT_IN_MODULES_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/install/resources/nodejs-modules/ && pwd )\"\n\nif [ -d \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" ]; then\n  rm -rf \"$CODESIGNING_FOLDER_PATH/nodejs-project/\"\nfi\n\nif [ -d \"$CODESIGNING_FOLDER_PATH/builtin_modules/\" ]; then\n  rm -rf \"$CODESIGNING_FOLDER_PATH/builtin_modules/\"\nfi\n\nrsync --archive --delete \"$NODEJS_ASSETS_DIR/nodejs-project\" \"$CODESIGNING_FOLDER_PATH\"\nrsync --archive --delete \"$NODEJS_BUILT_IN_MODULES_DIR/builtin_modules\" \"$CODESIGNING_FOLDER_PATH\"\n";
 		};
-		D0B2D6AAF02D3E8F8F31443B /* [CP] Check Pods Manifest.lock */ = {
+		8D564450C4A0ADF82C03894B /* [CP-User] [NODEJS MOBILE] Sign Native Modules */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			name = "[CP-User] [NODEJS MOBILE] Sign Native Modules";
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#!/bin/sh\nset -e\n\nif [ -f ./.xcode.env ]; then\n  source \"./.xcode.env\";\nfi\nif [ -f ./.xcode.env.local ]; then\n  source \"./.xcode.env.local\";\nfi\n\nDESIRED_NODE_VERSION=\"18\"\nCURRENT_NODE_VERSION=\"$(node -p \"process.versions.node.split('.')[0]\")\"\nif [ \"$CURRENT_NODE_VERSION\" -ne \"$DESIRED_NODE_VERSION\" ]; then\n  echo \"nodejs-mobile-react-native's ios-build-native-modules script requires \\\nNode.js version $DESIRED_NODE_VERSION, but found \\\n$(node -p 'process.versions.node')\"\n  exit 1\nfi\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, look for it in the project's\n#nodejs-assets/BUILD_NATIVE_MODULES.txt file.\nNODEJS_ASSETS_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../nodejs-assets/ && pwd )\"\nPREFERENCE_FILE_PATH=\"$NODEJS_ASSETS_DIR/BUILD_NATIVE_MODULES.txt\"\n  if [ -f \"$PREFERENCE_FILE_PATH\" ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=\"$(cat $PREFERENCE_FILE_PATH | xargs)\"\n  fi\nfi\n\nif [ -z \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then\n# If build native modules preference is not set, try to find .gyp files\n#to turn it on.\n  gypfiles=($(find \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -type f -name \"*.gyp\"))\n  if [ ${#gypfiles[@]} -gt 0 ]; then\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=1\n  else\n    NODEJS_MOBILE_BUILD_NATIVE_MODULES=0\n  fi\nfi\n\nif [ \"1\" != \"$NODEJS_MOBILE_BUILD_NATIVE_MODULES\" ]; then exit 0; fi\n\n# Delete object files\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.o\" -type f -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.a\" -type f -delete\n\n# Create Info.plist for each framework built and loader override.\nPATCH_SCRIPT_DIR=\"$( cd \"$PROJECT_DIR\" && cd ../node_modules/nodejs-mobile-react-native/scripts/ && pwd )\"\nNODEJS_PROJECT_DIR=\"$( cd \"$CODESIGNING_FOLDER_PATH\" && cd nodejs-project/ && pwd )\"\nnode \"$PATCH_SCRIPT_DIR\"/ios-create-plists-and-dlopen-override.js $NODEJS_PROJECT_DIR\n\n# Embed every resulting .framework in the application and delete them afterwards.\nembed_framework()\n{\n  FRAMEWORK_NAME=\"$(basename \"$1\")\"\n  cp -r \"$1\" \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/\"\n  /usr/bin/codesign --force --sign $EXPANDED_CODE_SIGN_IDENTITY --preserve-metadata=identifier,entitlements,flags --timestamp=none \"$TARGET_BUILD_DIR/$FRAMEWORKS_FOLDER_PATH/$FRAMEWORK_NAME\"\n}\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.framework\" -type d | while read frmwrk_path; do embed_framework \"$frmwrk_path\"; done\n\n#Delete gyp temporary .deps dependency folders from the project structure.\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -path \"*/.deps/*\" -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \".deps\" -type d -delete\n\n#Delete frameworks from their build paths\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -path \"*/*.framework/*\" -delete\nfind \"$CODESIGNING_FOLDER_PATH/nodejs-project/\" -name \"*.framework\" -type d -delete\n";
+		};
+		B6FFC96BAE420153D40A3FDD /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
+			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-bitkit-bitkitTests-checkManifestLockResult.txt",
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DDBE43F14182446D2E5D5E6A /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EF4D029D410447A670630793 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
@@ -499,7 +499,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0D53BC92A62A7EE80BB4DBC9 /* Pods-bitkit-bitkitTests.debug.xcconfig */;
+			baseConfigurationReference = A6721A37EE46BDF7836A4507 /* Pods-bitkit-bitkitTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -527,7 +527,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 354C379BD300695F3EE7A40E /* Pods-bitkit-bitkitTests.release.xcconfig */;
+			baseConfigurationReference = 584C0F67B2AC615A76BABDF5 /* Pods-bitkit-bitkitTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -552,7 +552,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9B2123A1E473C9CBAFE25212 /* Pods-bitkit.debug.xcconfig */;
+			baseConfigurationReference = C72C5306B469DA8D51596C71 /* Pods-bitkit.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -583,7 +583,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C377ED0D202043E3FF7A0C4E /* Pods-bitkit.release.xcconfig */;
+			baseConfigurationReference = 04F1381DC8396EE1A0FBB0AA /* Pods-bitkit.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@synonymdev/blocktank-client": "0.0.50",
     "@synonymdev/blocktank-lsp-http-client": "0.13.1",
     "@synonymdev/feeds": "2.1.1",
-    "@synonymdev/react-native-ldk": "0.0.129",
+    "@synonymdev/react-native-ldk": "0.0.132",
     "@synonymdev/react-native-lnurl": "0.0.7",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "1.0.0-alpha.6",

--- a/src/components/Percentage.tsx
+++ b/src/components/Percentage.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { Platform, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 import { Headline, Text01S } from '../styles/text';
-import { CoinsIcon, SavingsIcon } from '../styles/icons';
+import { LightningHollow, SavingsIcon } from '../styles/icons';
 
 type PercentageProps = {
 	value: number;
@@ -12,7 +12,7 @@ type PercentageProps = {
 const Percentage = ({ value, type, style }: PercentageProps): ReactElement => (
 	<View style={[styles.root, style]}>
 		{type === 'spending' ? (
-			<CoinsIcon color="purple" height={26} width={26} />
+			<LightningHollow color="purple" height={32} width={32} />
 		) : (
 			<SavingsIcon color="orange" height={32} width={32} />
 		)}

--- a/src/navigation/bottom-sheet/ConnectionClosed.tsx
+++ b/src/navigation/bottom-sheet/ConnectionClosed.tsx
@@ -1,5 +1,6 @@
 import React, { memo, ReactElement } from 'react';
 import { StyleSheet, View } from 'react-native';
+import { useTranslation } from 'react-i18next';
 
 import { Text01S } from '../../styles/text';
 import BottomSheetWrapper from '../../components/BottomSheetWrapper';
@@ -16,35 +17,33 @@ import {
 
 const imageSrc = require('../../assets/illustrations/switch.png');
 
-const CloseChannelSuccess = (): ReactElement => {
+const ConnectionClosed = (): ReactElement => {
+	const { t } = useTranslation('lightning');
 	const dispatch = useAppDispatch();
 	const snapPoints = useSnapPoints('medium');
 
 	useBottomSheetBackPress('backupPrompt');
 
 	const onContinue = (): void => {
-		dispatch(closeSheet('closeChannelSuccess'));
+		dispatch(closeSheet('connectionClosed'));
 	};
 
 	return (
 		<BottomSheetWrapper
-			view="closeChannelSuccess"
+			view="connectionClosed"
 			snapPoints={snapPoints}
 			backdrop={true}>
 			<View style={styles.container}>
 				<BottomSheetNavigationHeader
-					title="Connection closed"
+					title={t('connection_closed.title')}
 					displayBackButton={false}
 				/>
-				<Text01S color="white50">
-					Part of your instant balance has been moved to your savings because a
-					Lightning connection has closed.
-				</Text01S>
+				<Text01S color="white50">{t('connection_closed.description')}</Text01S>
 				<GlowImage image={imageSrc} imageSize={170} glowColor="red" />
 				<View style={styles.buttonContainer}>
 					<Button
 						style={styles.button}
-						text="OK"
+						text={t('ok')}
 						size="large"
 						onPress={onContinue}
 					/>
@@ -70,4 +69,4 @@ const styles = StyleSheet.create({
 	},
 });
 
-export default memo(CloseChannelSuccess);
+export default memo(ConnectionClosed);

--- a/src/navigation/root/RootNavigator.tsx
+++ b/src/navigation/root/RootNavigator.tsx
@@ -56,7 +56,7 @@ import ReceiveNavigation from '../bottom-sheet/ReceiveNavigation';
 import BackupNavigation from '../bottom-sheet/BackupNavigation';
 import PINNavigation from '../bottom-sheet/PINNavigation';
 import ForceTransfer from '../bottom-sheet/ForceTransfer';
-import CloseChannelSuccess from '../bottom-sheet/CloseChannelSuccess';
+import ConnectionClosed from '../bottom-sheet/ConnectionClosed';
 import LNURLWithdrawNavigation from '../bottom-sheet/LNURLWithdrawNavigation';
 import LNURLPayNavigation from '../bottom-sheet/LNURLPayNavigation';
 import TreasureHuntNavigation from '../bottom-sheet/TreasureHuntNavigation';
@@ -240,7 +240,7 @@ const RootNavigator = (): ReactElement => {
 			<NewTxPrompt />
 			<SlashAuthModal />
 			<ForceTransfer />
-			<CloseChannelSuccess />
+			<ConnectionClosed />
 			<BackupSubscriber />
 			<LNURLWithdrawNavigation />
 			<LNURLPayNavigation />

--- a/src/screens/Settings/Lightning/CloseConnection.tsx
+++ b/src/screens/Settings/Lightning/CloseConnection.tsx
@@ -55,7 +55,6 @@ const CloseConnection = ({
 			return;
 		}
 
-		// TODO: remove and use CloseChannelSuccess bottom-sheet instead
 		showToast({
 			type: 'success',
 			title: t('close_success_title'),

--- a/src/store/shapes/ui.ts
+++ b/src/store/shapes/ui.ts
@@ -11,7 +11,7 @@ export const defaultViewControllers: TUiState['viewControllers'] = {
 	backupNavigation: defaultViewController,
 	backupPrompt: defaultViewController,
 	boostPrompt: defaultViewController,
-	closeChannelSuccess: defaultViewController,
+	connectionClosed: defaultViewController,
 	forceTransfer: defaultViewController,
 	forgotPIN: defaultViewController,
 	highBalance: defaultViewController,

--- a/src/store/types/ui.ts
+++ b/src/store/types/ui.ts
@@ -9,7 +9,7 @@ export type ViewControllerParamList = {
 	backupNavigation: undefined;
 	backupPrompt: undefined;
 	boostPrompt: { onchainActivityItem: TOnchainActivityItem };
-	closeChannelSuccess: undefined;
+	connectionClosed: undefined;
 	forceTransfer: undefined;
 	forgotPIN: undefined;
 	highBalance: undefined;

--- a/src/utils/i18n/locales/en/lightning.json
+++ b/src/utils/i18n/locales/en/lightning.json
@@ -105,11 +105,15 @@
 	"is_usable": "Is Usable?",
 	"is_ready": "Is Ready?",
 	"support": "Support",
+	"connection_closed": {
+		"title": "Connection Closed",
+		"description": "A Lightning Connection has closed. The funds will move back to your savings."
+	},
 	"close_conn": "Close Connection",
 	"close_error": "Transfer Failed",
 	"close_success_title": "Transfer Successful",
 	"close_success_msg": "Your funds have been moved back to your savings.",
-	"close_text": "There is a small cost to close this Lightning Connection and transfer your full spending balance back to your savings. The exact fee depends on network conditions.\n\nTransferring funds to savings usually takes ±1 hour, but settlement may take <white>14 days</white> under certain network conditions.",
+	"close_text": "There is a small cost to close this Lightning Connection and transfer your full spending balance back to your savings. The exact fee depends on network conditions.\n\nTransferring funds to savings usually takes <white>±1 hour</white>, but settlement may take <white>14 days</white> under certain network conditions.",
 	"close_button": "Close",
 	"force_title": "Force Transfer",
 	"force_text": "Could not initiate transfer. Do you want to force this transfer? You won’t be able to use these funds for ±14 days (!)",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4375,10 +4375,10 @@
   dependencies:
     b4a "^1.5.3"
 
-"@synonymdev/react-native-ldk@0.0.129":
-  version "0.0.129"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.129.tgz#77b30fbf268afe01e753ba8ff54ef3966ac96365"
-  integrity sha512-xpAHIBiphmbe8niuIcRCZ+XVrdV/leBJOmpN9W5eHNMIbT9SYEHS7Tgyzh+vzQ+xM9/AEfKmSWEgA+MkVFqpNg==
+"@synonymdev/react-native-ldk@0.0.132":
+  version "0.0.132"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.132.tgz#82e1aa7721fd4e5e42ee54bb331840e877945f51"
+  integrity sha512-dNWT3LJ6EZ36K1vTAGpyw0TWITWmGMQAqHwF9gA8p+MrQaOuHRrrqqTA/+cuSuyhA3D1GSmV8iko39kkXdBqUw==
   dependencies:
     bech32 "^2.0.0"
     bitcoinjs-lib "^6.0.2"


### PR DESCRIPTION
### Description

- updates `react-native-ldk` to `v0.0.132`
- Shows a bottom-sheet in the event our channel counterparty force-closes on us. Right now this only works for force-closes, not coop closes initiated by the counterparty.
- Updates an icon according to design.

### Linked Issues/Tasks

https://app.asana.com/0/0/1205862969450140/f

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

![Simulator Screenshot - iPhone 14 - 2024-02-22 at 18 03 51](https://github.com/synonymdev/bitkit/assets/8538369/dfbf1080-b42d-4e88-9e5c-4226f91239f6)
