### PR TITLE
fix(wallet): Level Out Default Limits

### DIFF
--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -164,7 +164,7 @@ export const defaultWalletShape: Readonly<IWallet> = {
 };
 
 const defaultGapLimitOptions = {
-	lookAhead: 1,
+	lookAhead: 5,
 	lookBehind: 5,
 };
 


### PR DESCRIPTION
### Description
- Levels out the `lookAhead` in `defaultGapLimitOptions` to match `lookBehind`.
- Prevents Bitkit from needing to generate an address after every send or receive for immediate use.

### Type of change
- [x] Refactoring (improving code without creating new functionality)

### Tests
- [x] No test
