### PR TITLE
chore(lightning): Upgrade react-native-ldk

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -392,7 +392,7 @@ PODS:
     - React-Core
   - react-native-keep-awake (1.2.2):
     - React-Core
-  - react-native-ldk (0.0.132):
+  - react-native-ldk (0.0.134):
     - React
   - react-native-mmkv (2.11.0):
     - MMKV (>= 1.2.13)
@@ -911,7 +911,7 @@ SPEC CHECKSUMS:
   react-native-flipper: 9c1957af24b76493ba74f46d000a5c1d485e7731
   react-native-image-picker: 2e2e82aba9b6a91a7c78f7d9afde341a2659c7b8
   react-native-keep-awake: ad1d67f617756b139536977a0bf06b27cec0714a
-  react-native-ldk: 4bb809be74082223644931a3239323af56c7ee8f
+  react-native-ldk: e4971770e3773415fff4e5aa04df83f9d5485744
   react-native-mmkv: e97c0c79403fb94577e5d902ab1ebd42b0715b43
   react-native-netinfo: 5ddbf20865bcffab6b43d0e4e1fd8b3896beb898
   react-native-quick-base64: a5dbe4528f1453e662fcf7351029500b8b63e7bb

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@synonymdev/blocktank-client": "0.0.50",
     "@synonymdev/blocktank-lsp-http-client": "0.13.1",
     "@synonymdev/feeds": "2.1.1",
-    "@synonymdev/react-native-ldk": "0.0.132",
+    "@synonymdev/react-native-ldk": "0.0.134",
     "@synonymdev/react-native-lnurl": "0.0.7",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-auth": "1.0.0-alpha.6",

--- a/src/screens/Wallets/index.tsx
+++ b/src/screens/Wallets/index.tsx
@@ -92,7 +92,7 @@ const Wallets = ({ navigation, onFocus }: Props): ReactElement => {
 
 	const onRefresh = async (): Promise<void> => {
 		setRefreshing(true);
-		await refreshWallet({ scanAllAddresses: true });
+		await refreshWallet();
 		setRefreshing(false);
 	};
 

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -212,5 +212,6 @@
 	"refresh_error_title": "Refresh Failed",
 	"refresh_error_description": "Bitkit was unable to refresh your wallet.",
 	"refresh_error_throttle_title": "Connection Throttled",
-	"refresh_error_throttle_description": "Electrum server connection is throttled. Please wait several minutes before trying again."
+	"refresh_error_throttle_description": "Electrum server connection is throttled. Please wait several minutes before trying again.",
+	"ldk_sync_error_title": "Lightning Sync Error"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4375,10 +4375,10 @@
   dependencies:
     b4a "^1.5.3"
 
-"@synonymdev/react-native-ldk@0.0.132":
-  version "0.0.132"
-  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.132.tgz#82e1aa7721fd4e5e42ee54bb331840e877945f51"
-  integrity sha512-dNWT3LJ6EZ36K1vTAGpyw0TWITWmGMQAqHwF9gA8p+MrQaOuHRrrqqTA/+cuSuyhA3D1GSmV8iko39kkXdBqUw==
+"@synonymdev/react-native-ldk@0.0.134":
+  version "0.0.134"
+  resolved "https://registry.yarnpkg.com/@synonymdev/react-native-ldk/-/react-native-ldk-0.0.134.tgz#36870d17128ca76bf08aea6ba6909187fe7fbdd7"
+  integrity sha512-Peb6VQ/HLe9Tv+MsjnU2pQR7Yi/oU6GtryUwBbfytvbxdsq0luFkAEKHxzQ/wNjO7z1QYLmMhK6IVqJC3zaT8Q==
   dependencies:
     bech32 "^2.0.0"
     bitcoinjs-lib "^6.0.2"


### PR DESCRIPTION
### Description
- Upgrades `react-native-ldk` to `0.0.134`.
- Updates `syncLdk` method to return any error.
- Removes `scanAllAddresses` on pull-to-refresh to prevent users from overloading/timing-out the server.
- Shows toast when `syncLdk` returns an error.

### Linked Issues/Tasks
- Closes #1594.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (improving code without creating new functionality)

### Tests
- [x] No test
