### PR TITLE
refactor(wallet): Update Fee Estimates

### DIFF
--- a/src/screens/Settings/Fee/index.tsx
+++ b/src/screens/Settings/Fee/index.tsx
@@ -16,8 +16,7 @@ import {
 	updateOnchainFees,
 	updateOverrideFees,
 } from '../../../store/slices/fees';
-import { updateOnchainFeeEstimates } from '../../../store/utils/fees';
-import { selectedNetworkSelector } from '../../../store/reselect/wallet';
+import { refreshOnchainFeeEstimates } from '../../../store/utils/fees';
 import { EItemType, IListData } from '../../../components/List';
 import Button from '../../../components/Button';
 import SafeAreaInset from '../../../components/SafeAreaInset';
@@ -78,7 +77,6 @@ const FeeSettings = ({}: SettingsScreenProps<'FeeSettings'>): ReactElement => {
 	const dispatch = useAppDispatch();
 	const fees = useAppSelector(onChainFeesSelector);
 	const override = useAppSelector(overrideFeeSelector);
-	const selectedNetwork = useAppSelector(selectedNetworkSelector);
 	const [loading, setLoading] = useState(false);
 
 	const handleMinus = (title: string): void => {
@@ -140,7 +138,7 @@ const FeeSettings = ({}: SettingsScreenProps<'FeeSettings'>): ReactElement => {
 						value: updated,
 						type: EItemType.textButton,
 						onPress: (): void => {
-							updateOnchainFeeEstimates({ selectedNetwork, forceUpdate: true });
+							refreshOnchainFeeEstimates({ forceUpdate: true });
 						},
 					},
 					{
@@ -154,7 +152,7 @@ const FeeSettings = ({}: SettingsScreenProps<'FeeSettings'>): ReactElement => {
 				],
 			},
 		];
-	}, [override, fees, tTime, selectedNetwork, dispatch]);
+	}, [override, fees, tTime, dispatch]);
 
 	return (
 		<ThemedView style={styles.container}>

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -91,7 +91,7 @@ import {
 	TLightningNodeVersion,
 } from '../../store/types/lightning';
 import { getBlocktankInfo, isGeoBlocked } from '../blocktank';
-import { updateOnchainFeeEstimates } from '../../store/utils/fees';
+import { refreshOnchainFeeEstimates } from '../../store/utils/fees';
 import { reportLdkChannelMigrations } from '../checks';
 import {
 	__BACKUPS_SERVER_HOST__,
@@ -1524,8 +1524,8 @@ export const closeAllChannels = async ({
 			return err(refreshRes.error.message);
 		}
 
-		// Update fees before closing channels
-		await updateOnchainFeeEstimates({ selectedNetwork, forceUpdate: true });
+		// Force update fees before closing channels
+		await refreshOnchainFeeEstimates({ forceUpdate: true });
 
 		const channelsUnableToCoopClose: TChannel[] = [];
 		await Promise.all(


### PR DESCRIPTION
### Description
- This prevents Beignet's fee estimate interval from interfering with Bitkit's internal check, preventing updates.
- Adds `refreshOnchainFeeEstimates` method.
- Moves refresh interval check in `updateOnchainFeeEstimates` method.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (improving code without creating new functionality)

### Tests
- [x] No test
