### PR TITLE
fix(wallet): Reset & Setup Tx On-Scan

### DIFF
--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -25,7 +25,11 @@ import {
 } from './wallet/transactions';
 import { dispatch, getLightningStore } from '../store/helpers';
 import { showToast, ToastOptions } from './notifications';
-import { updateSendTransaction } from '../store/actions/wallet';
+import {
+	resetSendTransaction,
+	setupOnChainTransaction,
+	updateSendTransaction,
+} from '../store/actions/wallet';
 import { getBalance, getSelectedNetwork, getSelectedWallet } from './wallet';
 import { closeSheet } from '../store/slices/ui';
 import { showBottomSheet } from '../store/utils/ui';
@@ -602,6 +606,10 @@ export const processBitcoinTransactionData = async ({
 	selectedWallet?: TWalletName;
 }): Promise<Result<QRData>> => {
 	try {
+		// Reset existing transaction state and prepare for a new one.
+		await resetSendTransaction();
+		await setupOnChainTransaction({});
+
 		let response;
 		let error: ToastOptions | undefined; //Information that will be passed as a notification.
 		let requestedAmount = 0; //Amount requested in sats by the provided invoice.


### PR DESCRIPTION

### Description
- Adds `resetSendTransaction` & `setupOnChainTransaction` to `processBitcoinTransactionData` in `scanner.ts`.

### Linked Issues/Tasks
-  Addresses #1601

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test

### QA Notes
Previously, scanning a qr-code with an on-chain Bitcoin address would navigate the user to the send screen and after the user typed in their amount and pressed "Continue" they would receive the "Send amount too small" error no matter the amount. This PR should prevent that issue from occurring. 
