### PR TITLE
fix(lightning): Fix All-Caps Lightning Invoice Payments

### DIFF
--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -512,7 +512,7 @@ export const decodeQRData = async (
 		if (decodedInvoice.isOk()) {
 			foundNetworksInQR.push({
 				qrDataType: EQRDataType.lightningPaymentRequest,
-				lightningPaymentRequest: data,
+				lightningPaymentRequest: lightningInvoice,
 				network: selectedNetwork,
 				sats: decodedInvoice.value.amount_satoshis ?? 0,
 				message: decodedInvoice.value.description ?? '',


### PR DESCRIPTION
### Description
- Previously, all caps lightning invoices would fail when scanned. This PR should resolve that issue.
- Swaps `data` with `lightningInvoice` in `decodeQRData`.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test
