### PR TITLE
chore(wallet): Upgrade Beignet

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@synonymdev/web-relay": "1.0.7",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
     "bech32": "2.0.0",
-    "beignet": "0.0.25",
+    "beignet": "0.0.26",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
     "bip39": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5712,10 +5712,10 @@ bech32@^1.1.2, bech32@^1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-beignet@0.0.25:
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.25.tgz#7b6beec58ecae3c176f2315245b741876de1991a"
-  integrity sha512-TEpTczUVQwl/yh8db9C+8eLMaDRRC5OpWIQTPBNhWK9HphAJMzcr9zWjknKw4dFJpfds5Zq2z6jqR2bGKwDnMQ==
+beignet@0.0.26:
+  version "0.0.26"
+  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.26.tgz#f1138e9c97ec67b4748b272996b6aee02eea3e64"
+  integrity sha512-OvouVDlQfrP69EkwJThwTyRKtj7wVcrMBaKIkNiy4+IcMTghPKk+DoC+oe73cnO10Utw98xG6ulWtOFT+o96nw==
   dependencies:
     "@bitcoinerlab/secp256k1" "1.0.5"
     bech32 "2.0.0"


### PR DESCRIPTION
### Description
- Upgrades `beignet` to `0.0.26`.

### Type of change
- [x] Dependency Upgrade

### Tests
- [x] No test

### QA Notes
- Rescanning addresses in Settings->Advanced->Rescan Addresses should continue to work as expected.
