### PR TITLE
chore(wallet): Beignet Upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@synonymdev/web-relay": "1.0.7",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
     "bech32": "2.0.0",
-    "beignet": "0.0.26",
+    "beignet": "0.0.27",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
     "bip39": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5712,10 +5712,10 @@ bech32@^1.1.2, bech32@^1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-beignet@0.0.26:
-  version "0.0.26"
-  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.26.tgz#f1138e9c97ec67b4748b272996b6aee02eea3e64"
-  integrity sha512-OvouVDlQfrP69EkwJThwTyRKtj7wVcrMBaKIkNiy4+IcMTghPKk+DoC+oe73cnO10Utw98xG6ulWtOFT+o96nw==
+beignet@0.0.27:
+  version "0.0.27"
+  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.27.tgz#a6ddb3d238b37a2ae074aecdad036a89b771de38"
+  integrity sha512-gwZgWV93Y6x8bj3PXeDTeHrBCiWk3nHRa2Jn4SnUsa5RqIMbg2e6WW8NBmZXPD6ER+hokiQL23GKU2TrVl6HbA==
   dependencies:
     "@bitcoinerlab/secp256k1" "1.0.5"
     bech32 "2.0.0"


### PR DESCRIPTION
### Description
- Upgrades beignet to `0.0.27`.
- Disables Bitkit's on-chain refresh when sats are received.
    - Beignet now handles this.
- Adds check to prevent duplicate receive notifications.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (improving code without creating new functionality)

### Tests
- [x] No test