### PR TITLE
chore(wallet): Upgrade react-native-keychain

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -548,7 +548,7 @@ PODS:
   - RNGestureHandler (2.13.4):
     - RCT-Folly (= 2021.07.22.00)
     - React-Core
-  - RNKeychain (8.1.2):
+  - RNKeychain (8.2.0):
     - React-Core
   - RNLocalize (3.0.2):
     - React-Core
@@ -945,7 +945,7 @@ SPEC CHECKSUMS:
   RNExitApp: 00036cabe7bacbb413d276d5520bf74ba39afa6a
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
   RNGestureHandler: 5102af8c91262d5a9b757a56e734b1a02071d83b
-  RNKeychain: a65256b6ca6ba6976132cc4124b238a5b13b3d9c
+  RNKeychain: bfe3d12bf4620fe488771c414530bf16e88f3678
   RNLocalize: dbea38dcb344bf80ff18a1757b1becf11f70cae4
   RNPermissions: 2c0eec471f4de66d04d226c339898d10a6e123c4
   RNQrGenerator: 90461ba3ca88c1d38ef73da50fade35d9648215d

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "react-native-haptic-feedback": "2.2.0",
     "react-native-image-picker": "7.0.2",
     "react-native-keyboard-accessory": "0.1.16",
-    "react-native-keychain": "8.1.2",
+    "react-native-keychain": "git+ssh://git@github.com:synonymdev/react-native-keychain.git#refactor/android-data-store",
     "react-native-localize": "3.0.2",
     "react-native-mmkv": "2.11.0",
     "react-native-modal": "13.0.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "react-native-haptic-feedback": "2.2.0",
     "react-native-image-picker": "7.0.2",
     "react-native-keyboard-accessory": "0.1.16",
-    "react-native-keychain": "git+ssh://git@github.com:synonymdev/react-native-keychain.git#refactor/android-data-store",
+    "react-native-keychain": "github::synonymdev/react-native-keychain.git#refactor/android-data-store",
     "react-native-localize": "3.0.2",
     "react-native-mmkv": "2.11.0",
     "react-native-modal": "13.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12667,9 +12667,9 @@ react-native-keyboard-accessory@0.1.16:
   resolved "https://registry.yarnpkg.com/react-native-keyboard-accessory/-/react-native-keyboard-accessory-0.1.16.tgz#f0babba9e6568c0c2c8f3fd774fcb2b90b8274ba"
   integrity sha512-zpdaduoGjp/spLtM0XxxyxFpCqFQu3fospy/HeYpaIfsXTqGdT1MIajS8tahDxeG6fHLDrWvEIYA6zWM5jni0w==
 
-"react-native-keychain@git+ssh://git@github.com:synonymdev/react-native-keychain.git#refactor/android-data-store":
+"react-native-keychain@github::synonymdev/react-native-keychain.git#refactor/android-data-store":
   version "8.2.0"
-  resolved "git+ssh://git@github.com:synonymdev/react-native-keychain.git#7378c469afe81195487a3163295be425af79fa7a"
+  resolved "https://codeload.github.com/synonymdev/react-native-keychain/tar.gz/7378c469afe81195487a3163295be425af79fa7a"
 
 react-native-localize@3.0.2:
   version "3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12667,10 +12667,9 @@ react-native-keyboard-accessory@0.1.16:
   resolved "https://registry.yarnpkg.com/react-native-keyboard-accessory/-/react-native-keyboard-accessory-0.1.16.tgz#f0babba9e6568c0c2c8f3fd774fcb2b90b8274ba"
   integrity sha512-zpdaduoGjp/spLtM0XxxyxFpCqFQu3fospy/HeYpaIfsXTqGdT1MIajS8tahDxeG6fHLDrWvEIYA6zWM5jni0w==
 
-react-native-keychain@8.1.2:
-  version "8.1.2"
-  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-8.1.2.tgz#34291ae472878e5124d081211af5ede7d810e64f"
-  integrity sha512-bhHEui+yMp3Us41NMoRGtnWEJiBE0g8tw5VFpq4mpmXAx6XJYahuM6K3WN5CsUeUl83hYysSL9oFZNKSTPSvYw==
+"react-native-keychain@git+ssh://git@github.com:synonymdev/react-native-keychain.git#refactor/android-data-store":
+  version "8.2.0"
+  resolved "git+ssh://git@github.com:synonymdev/react-native-keychain.git#7378c469afe81195487a3163295be425af79fa7a"
 
 react-native-localize@3.0.2:
   version "3.0.2"


### PR DESCRIPTION
### Description
- Upgrades to the `refactor/android-data-store` branch of `react-native-keychain`.

### Type of change
- [x] Dependency Upgrade

### Tests
- [x] No test