### PR TITLE
fix(lightning): Add Geo Block Check

### DIFF
--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -71,6 +71,7 @@ import {
 import { TPaidBlocktankOrders } from '../../../store/types/blocktank';
 import { EUnit } from '../../../store/types/wallet';
 import { EChannelStatus, TChannel } from '../../../store/types/lightning';
+import { isGeoBlockedSelector } from '../../../store/reselect/user';
 
 // Workaround for crash on Android
 // https://github.com/software-mansion/react-native-reanimated/issues/4306#issuecomment-1538184321
@@ -238,6 +239,7 @@ const Channels = ({
 	const openChannels = useAppSelector(openChannelsSelector);
 	const pendingChannels = useAppSelector(pendingChannelsSelector);
 	const closedChannels = useAppSelector(closedChannelsSelector);
+	const isGeoBlocked = useAppSelector(isGeoBlockedSelector);
 	const blocktankNodeKey = useAppSelector((state) => {
 		return state.blocktank.info.nodes[0].pubkey;
 	});
@@ -362,7 +364,7 @@ const Channels = ({
 	}, [peer, selectedNetwork, selectedWallet, t]);
 
 	const addConnectionIsDisabled =
-		onchainBalance <= TRANSACTION_DEFAULTS.recommendedBaseFee;
+		onchainBalance <= TRANSACTION_DEFAULTS.recommendedBaseFee || isGeoBlocked;
 
 	return (
 		<ThemedView style={styles.root}>
@@ -370,7 +372,11 @@ const Channels = ({
 			<NavigationHeader
 				title={t('connections')}
 				onActionPress={addConnectionIsDisabled ? undefined : handleAdd}
-				actionIcon={<PlusIcon width={24} height={24} />}
+				actionIcon={
+					addConnectionIsDisabled ? undefined : (
+						<PlusIcon width={24} height={24} />
+					)
+				}
 			/>
 			<ScrollView
 				contentContainerStyle={styles.content}


### PR DESCRIPTION
### Description
- Adds geo-block checks to "Add Connection" buttons in Channels component.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test

### Screenshot / Video
- When geo-blocked the "+" button disappears and the "Add Connection" button is disabled.
![Simulator Screenshot - iPhone 14 - 2024-03-21 at 16 10 26](https://github.com/synonymdev/bitkit/assets/8532651/7901d6c6-cae6-4c10-bf9a-9b0bf3de8b78)
