### PR TITLE
fix: channel UI fixes

### DIFF
--- a/src/screens/Lightning/CustomConfirm.tsx
+++ b/src/screens/Lightning/CustomConfirm.tsx
@@ -74,12 +74,12 @@ const CustomConfirm = ({
 	};
 
 	const updateOrderExpiration = async (): Promise<void> => {
-		const max0ConfBalance = blocktankInfo.options.max0ConfClientBalanceSat;
+		const { max0ConfClientBalanceSat, minExpiryWeeks } = blocktankInfo.options;
 		const purchaseResponse = await startChannelPurchase({
 			remoteBalance: order.clientBalanceSat,
 			localBalance: order.lspBalanceSat,
-			channelExpiry: Math.max(weeks, 1),
-			zeroConfPayment: order.clientBalanceSat <= max0ConfBalance,
+			channelExpiry: Math.max(weeks, minExpiryWeeks),
+			zeroConfPayment: order.clientBalanceSat <= max0ConfClientBalanceSat,
 			selectedWallet,
 			selectedNetwork,
 		});
@@ -99,9 +99,7 @@ const CustomConfirm = ({
 			<SafeAreaInset type="top" />
 			<NavigationHeader
 				title={t('add_instant_payments')}
-				onClosePress={(): void => {
-					navigation.navigate('Wallet');
-				}}
+				onClosePress={(): void => navigation.navigate('Wallet')}
 			/>
 			<View style={styles.root} testID="CustomConfirm">
 				{!showNumberPad && (
@@ -179,11 +177,7 @@ const CustomConfirm = ({
 				)}
 
 				{showNumberPad && (
-					<AnimatedView
-						style={styles.weeks}
-						color="transparent"
-						entering={FadeIn}
-						exiting={FadeOut}>
+					<AnimatedView color="transparent" entering={FadeIn} exiting={FadeOut}>
 						<Caption13Up style={styles.text} color="purple">
 							{t('duration_week', { count: weeks })}
 						</Caption13Up>
@@ -226,10 +220,6 @@ const styles = StyleSheet.create({
 	},
 	block: {
 		marginBottom: 32,
-	},
-	weeks: {
-		alignSelf: 'flex-start',
-		alignItems: 'center',
 	},
 	buttonContainer: {
 		marginTop: 'auto',

--- a/src/screens/Lightning/CustomConfirm.tsx
+++ b/src/screens/Lightning/CustomConfirm.tsx
@@ -28,7 +28,6 @@ import { showToast } from '../../utils/notifications';
 import { DEFAULT_CHANNEL_DURATION } from '../../utils/wallet/constants';
 import {
 	selectedNetworkSelector,
-	selectedWalletSelector,
 	transactionFeeSelector,
 } from '../../store/reselect/wallet';
 
@@ -43,7 +42,6 @@ const CustomConfirm = ({
 	const [orderId, setOrderId] = useState(route.params.orderId);
 	const [showNumberPad, setShowNumberPad] = useState(false);
 	const transactionFee = useAppSelector(transactionFeeSelector);
-	const selectedWallet = useAppSelector(selectedWalletSelector);
 	const selectedNetwork = useAppSelector(selectedNetworkSelector);
 	const blocktankInfo = useAppSelector(blocktankInfoSelector);
 	const order = useAppSelector((state) => {
@@ -76,12 +74,10 @@ const CustomConfirm = ({
 	const updateOrderExpiration = async (): Promise<void> => {
 		const { max0ConfClientBalanceSat, minExpiryWeeks } = blocktankInfo.options;
 		const purchaseResponse = await startChannelPurchase({
-			remoteBalance: order.clientBalanceSat,
-			localBalance: order.lspBalanceSat,
-			channelExpiry: Math.max(weeks, minExpiryWeeks),
+			clientBalance: order.clientBalanceSat,
+			lspBalance: order.lspBalanceSat,
+			channelExpiryWeeks: Math.max(weeks, minExpiryWeeks),
 			zeroConfPayment: order.clientBalanceSat <= max0ConfClientBalanceSat,
-			selectedWallet,
-			selectedNetwork,
 		});
 		if (purchaseResponse.isErr()) {
 			showToast({
@@ -91,7 +87,7 @@ const CustomConfirm = ({
 			});
 			return;
 		}
-		setOrderId(purchaseResponse.value.order.id);
+		setOrderId(purchaseResponse.value.id);
 	};
 
 	return (

--- a/src/screens/Lightning/NumberPadWeeks.tsx
+++ b/src/screens/Lightning/NumberPadWeeks.tsx
@@ -5,8 +5,8 @@ import NumberPad from '../../components/NumberPad';
 import NumberPadButtons from '../Wallets/NumberPadButtons';
 import { vibrate } from '../../utils/helpers';
 import { handleNumberPadPress } from '../../utils/numberpad';
-
-const MAX_WEEKS = 12;
+import { useAppSelector } from '../../hooks/redux';
+import { blocktankInfoSelector } from '../../store/reselect/blocktank';
 
 const NumberPadWeeks = ({
 	weeks,
@@ -19,13 +19,16 @@ const NumberPadWeeks = ({
 	onDone: () => void;
 	style?: StyleProp<ViewStyle>;
 }): ReactElement => {
+	const blocktankInfo = useAppSelector(blocktankInfoSelector);
 	const [errorKey, setErrorKey] = useState<string>();
+
+	const { minExpiryWeeks, maxExpiryWeeks } = blocktankInfo.options;
 
 	const onPress = (key: string): void => {
 		const current = weeks.toString();
 		const newAmount = handleNumberPadPress(key, current, { maxLength: 2 });
 
-		if (Number(newAmount) > MAX_WEEKS) {
+		if (Number(newAmount) > maxExpiryWeeks) {
 			vibrate({ type: 'notificationWarning' });
 			setErrorKey(key);
 			setTimeout(() => setErrorKey(undefined), 500);
@@ -36,7 +39,7 @@ const NumberPadWeeks = ({
 	};
 
 	const handleDone = (): void => {
-		onChange(Math.max(weeks, 1));
+		onChange(Math.max(weeks, minExpiryWeeks));
 		onDone();
 	};
 
@@ -48,7 +51,7 @@ const NumberPadWeeks = ({
 			onPress={onPress}>
 			<NumberPadButtons
 				color="white"
-				onMax={(): void => onChange(MAX_WEEKS)}
+				onMax={(): void => onChange(maxExpiryWeeks)}
 				onDone={handleDone}
 			/>
 		</NumberPad>

--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -126,9 +126,10 @@ const getPendingBlocktankChannels = (
 			createdAt: new Date().getTime(),
 		};
 
-		if (order.state2 === BtOrderState2.CREATED) {
+		if ([BtOrderState2.CREATED, BtOrderState2.PAID].includes(order.state2)) {
 			pendingOrders.push(fakeChannel);
 		}
+
 		if (order.state2 === BtOrderState2.EXPIRED) {
 			failedOrders.push(fakeChannel);
 		}

--- a/src/screens/Wallets/Receive/ReceiveConnect.tsx
+++ b/src/screens/Wallets/Receive/ReceiveConnect.tsx
@@ -43,7 +43,7 @@ const ReceiveConnect = ({
 
 	useEffect(() => {
 		const getFeeEstimation = async (): Promise<void> => {
-			const estimate = await estimateOrderFee({ lspBalanceSat: amount });
+			const estimate = await estimateOrderFee({ lspBalance: amount });
 			if (estimate.isOk()) {
 				setFeeEstimate(estimate.value);
 			}

--- a/src/store/reselect/lightning.ts
+++ b/src/store/reselect/lightning.ts
@@ -121,6 +121,28 @@ export const closedChannelsSelector = createSelector(
 );
 
 /**
+ * Returns the summed up size of all open and pending channels.
+ * @param {RootState} state
+ * @returns {number}
+ */
+export const channelsSizeSelector = createSelector(
+	[openChannelsSelector, pendingChannelsSelector],
+	(openChannels, pendingChannels) => {
+		const openResult = reduceValue(openChannels, 'channel_value_satoshis');
+		const pendingResult = reduceValue(
+			pendingChannels,
+			'channel_value_satoshis',
+		);
+
+		const openChannelsSize = openResult.isOk() ? openResult.value : 0;
+		const pendingChannelsSize = pendingResult.isOk() ? pendingResult.value : 0;
+		const channelSize = openChannelsSize + pendingChannelsSize;
+
+		return channelSize;
+	},
+);
+
+/**
  * Returns claimable balances.
  * @param {RootState} state
  * @returns {number}

--- a/src/store/types/blocktank.ts
+++ b/src/store/types/blocktank.ts
@@ -19,7 +19,7 @@ export type TPaidBlocktankOrders = {
 export type TGeoBlockResponse = { error?: 'GEO_BLOCKED'; accept?: boolean };
 
 export interface ICreateOrderRequest {
-	lspBalanceSat: number;
+	lspBalance: number;
 	channelExpiryWeeks?: number;
 	options?: Partial<ICreateOrderOptions>;
 }

--- a/src/utils/blocktank/index.ts
+++ b/src/utils/blocktank/index.ts
@@ -81,7 +81,7 @@ export const getBlocktankInfo = async (
  * @returns {Promise<Result<IBtOrder>>}
  */
 export const createOrder = async ({
-	lspBalanceSat,
+	lspBalance,
 	channelExpiryWeeks = DEFAULT_CHANNEL_DURATION,
 	options,
 }: ICreateOrderRequest): Promise<Result<IBtOrder>> => {
@@ -91,7 +91,7 @@ export const createOrder = async ({
 		if (addPeersRes.isErr()) {
 			return err('Unable to add Blocktank node as a peer at this time.');
 		}
-		const buyRes = await bt.createOrder(lspBalanceSat, channelExpiryWeeks, {
+		const buyRes = await bt.createOrder(lspBalance, channelExpiryWeeks, {
 			...options,
 			couponCode: options?.couponCode ?? 'bitkit',
 			zeroReserve: true,
@@ -111,13 +111,13 @@ export const createOrder = async ({
  * @returns {Promise<Result<number>>}
  */
 export const estimateOrderFee = async ({
-	lspBalanceSat,
+	lspBalance,
 	channelExpiryWeeks = DEFAULT_CHANNEL_DURATION,
 	options,
 }: ICreateOrderRequest): Promise<Result<number>> => {
 	try {
 		const estimateRes = await bt.estimateOrderFee(
-			lspBalanceSat,
+			lspBalance,
 			channelExpiryWeeks,
 			{
 				...options,

--- a/src/utils/wallet/constants.ts
+++ b/src/utils/wallet/constants.ts
@@ -11,16 +11,18 @@ export const GAP_LIMIT = 20;
 // TODO: remove chunk logic and move it to rn-electrum library
 export const CHUNK_LIMIT = 15;
 
-//How much of the users funds we allow to be used for Lightning.
-export const SPENDING_LIMIT_RATIO = 0.8;
-
-export const LIGHTNING_DIFF = 0.01;
-
-export const LIGHTNING_DEFAULT_SLIDER = 0.2;
-
-export const DEFAULT_CHANNEL_DURATION = 6;
-
 export const TRANSACTION_DEFAULTS = {
 	recommendedBaseFee: 256, // Total recommended tx base fee in sats
 	dustLimit: 546, // Minimum value in sats for an output. Outputs below the dust limit may not be processed because the fees required to include them in a block would be greater than the value of the transaction itself.
 };
+
+// Default spending percentage for the transfer slider (of onchain balance)
+export const DEFAULT_SPENDING_PERCENTAGE = 0.2;
+
+// How much of the users funds we allow to be used for Lightning (of onchain balance)
+export const MAX_SPENDING_PERCENTAGE = 0.8;
+
+// Used to make sure LSP balance is bigger than client balance
+export const LIGHTNING_DIFF = 0.01;
+
+export const DEFAULT_CHANNEL_DURATION = 6;


### PR DESCRIPTION
### Description

- QuickSetup/Transfer: prevent buying channel when node capacity is reached
- ChannelList: show stuck pending channels
- CustomSetup: use maximum channel duration from LSP api
- CustomSetup: Remove 'Custom Amount' button for receiving capacity screen
- some renaming for clarity

### Linked Issues/Tasks

Closes #1563 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/8538369/7974d2ef-9825-4718-b144-7e5c9592547f

### QA Notes

1. Buy a CJIT channel to get maximum inbound capacity
2. Try to buy another channel via transfer flow
3. The UI should prevent you from buying the channel
