### PR TITLE
fix(scan): remove prefix from Bitkit specific deep links

### DIFF
--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -203,6 +203,12 @@ export const processInputData = async ({
 	showErrors?: boolean;
 }): Promise<Result<TProcessedData>> => {
 	data = data.trim();
+
+	// Remove prefix from Bitkit specific deep links
+	if (data.startsWith('bitkit://')) {
+		data = data.replace('bitkit://', '');
+	}
+
 	try {
 		const decodeRes = await decodeQRData(data, selectedNetwork);
 		if (decodeRes.isErr()) {


### PR DESCRIPTION
### Description

This allows the scanner to parse any deeplinks that use the `bitkit://` scheme.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

For example:

```
npx uri-scheme open "bitkit://LNURL1DP68GURN8GHJ7CTSDYH8XARPVUHXYMR0VD4HGCTWDVH8GME0VFKX7CMTW3SKU6E0V9CXJTMKXGHKCTMZXQ6K2EPKX33Z6VECXENZ6DP3XGMJ6WRYV43Z6CENX5URSV3KXCMNSEF5P53WRA" --ios
```