### PR TITLE
chore(wallet): Upgrade Beignet

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@synonymdev/web-relay": "1.0.7",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
     "bech32": "2.0.0",
-    "beignet": "0.0.28",
+    "beignet": "0.0.30",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
     "bip39": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5712,10 +5712,10 @@ bech32@^1.1.2, bech32@^1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-beignet@0.0.28:
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.28.tgz#9112d8270ff8d7d63f152af6cd8b1adac1697d64"
-  integrity sha512-/nmrOCfisRAj3ieUHwvez/qHQM4zhs92kfQM8ToAjJrONy+RiQOn+XfMtkpZUxx7HlMQrkW4HVeczpTAKNbd7A==
+beignet@0.0.30:
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.30.tgz#5b98568af4eedb6cc415a9df3c7f4dc4d9001bf3"
+  integrity sha512-DbAR59dbd7BSPpYIgsVXCOTXg1g5HTzH0ozzTLNajysKokkZbp0vAjZjpRSnRmd0P+r4YjXMdpUZtL9hXRiFBA==
   dependencies:
     "@bitcoinerlab/secp256k1" "1.0.5"
     bech32 "2.0.0"


### PR DESCRIPTION
### Description
- Upgrades Beignet to version `0.0.30`.
- Contains a `batchLimit` fix for `listUnspentAddressScriptHashes` [here](https://github.com/synonymdev/beignet/pull/52).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Dependency Upgrade

### Tests
- [x] No test

### QA Notes
The specified `batchLimit` is now properly applied in the `listUnspentAddressScriptHashes` method in `beignet`.