### PR TITLE
fix(receive): lower cjit LSP balance

### DIFF
--- a/src/screens/Wallets/Receive/ReceiveConnect.tsx
+++ b/src/screens/Wallets/Receive/ReceiveConnect.tsx
@@ -37,25 +37,28 @@ const ReceiveConnect = ({
 	const blocktank = useAppSelector(blocktankInfoSelector);
 	const { amount, message } = useAppSelector(receiveSelector);
 
-	const { maxChannelSizeSat } = blocktank.options;
+	const { minChannelSizeSat, maxChannelSizeSat } = blocktank.options;
+	const minChannelSize = Math.max(minChannelSizeSat, 2.5 * amount);
+	const channelSize = Math.min(minChannelSize, maxChannelSizeSat);
+	const lspBalance = channelSize - amount;
 	const payAmount = amount - feeEstimate;
 	const displayFee = useDisplayValues(feeEstimate);
 
 	useEffect(() => {
 		const getFeeEstimation = async (): Promise<void> => {
-			const estimate = await estimateOrderFee({ lspBalance: amount });
+			const estimate = await estimateOrderFee({ lspBalance });
 			if (estimate.isOk()) {
 				setFeeEstimate(estimate.value);
 			}
 		};
 
 		getFeeEstimation();
-	}, [amount]);
+	}, [lspBalance]);
 
 	const onContinue = async (): Promise<void> => {
 		setIsLoading(true);
 		const cJitEntryResponse = await createCJitEntry({
-			channelSizeSat: maxChannelSizeSat,
+			channelSizeSat: channelSize,
 			invoiceSat: amount,
 			invoiceDescription: message,
 		});

--- a/src/screens/Wallets/Receive/ReceiveDetails.tsx
+++ b/src/screens/Wallets/Receive/ReceiveDetails.tsx
@@ -68,7 +68,9 @@ const ReceiveDetails = ({
 	const isGeoBlocked = useAppSelector(isGeoBlockedSelector);
 	const accountVersion = useAppSelector(accountVersionSelector);
 
-	const { maxChannelSizeSat } = blocktank.options;
+	const { minChannelSizeSat, maxChannelSizeSat } = blocktank.options;
+	const minChannelSize = Math.max(minChannelSizeSat, 2.5 * invoice.amount);
+	const channelSize = Math.min(minChannelSize, maxChannelSizeSat);
 
 	const onChangeUnit = (): void => {
 		const result = getNumberPadText(invoice.amount, denomination, nextUnit);
@@ -94,7 +96,7 @@ const ReceiveDetails = ({
 		// Ensure the CJIT entry is within an acceptable range.
 		if (invoice.amount >= MINIMUM_AMOUNT && invoice.amount <= maxAmount) {
 			const cJitEntryResponse = await createCJitEntry({
-				channelSizeSat: maxChannelSizeSat,
+				channelSizeSat: channelSize,
 				invoiceSat: invoice.amount,
 				invoiceDescription: invoice.message,
 			});
@@ -107,6 +109,7 @@ const ReceiveDetails = ({
 			navigation.navigate('ReceiveConnect');
 		}
 	}, [
+		channelSize,
 		maxChannelSizeSat,
 		enableInstant,
 		invoice.amount,


### PR DESCRIPTION
### Description

- lower CJIT LSP balance to be 2,5 x invoice amount
- fixes CJIT fee estimation

### Linked Issues/Tasks

Closes #1703  #1644

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

Get a CJIT channel, check the "You will receive" amount matches the actual amount received, check that the receive capacity is not at the maximum
