### PR TITLE
chore(wallet): Upgrade Beignet

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@synonymdev/web-relay": "1.0.7",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
     "bech32": "2.0.0",
-    "beignet": "0.0.34",
+    "beignet": "0.0.35",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
     "bip39": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@synonymdev/web-relay": "1.0.7",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
     "bech32": "2.0.0",
-    "beignet": "0.0.30",
+    "beignet": "0.0.34",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
     "bip39": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5886,10 +5886,10 @@ bech32@^1.1.2, bech32@^1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-beignet@0.0.30:
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.30.tgz#5b98568af4eedb6cc415a9df3c7f4dc4d9001bf3"
-  integrity sha512-DbAR59dbd7BSPpYIgsVXCOTXg1g5HTzH0ozzTLNajysKokkZbp0vAjZjpRSnRmd0P+r4YjXMdpUZtL9hXRiFBA==
+beignet@0.0.34:
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.34.tgz#536d544364674fbc5b2378de28f3445bab405395"
+  integrity sha512-j4rTA0kdhlZzCYVwquu/miTak/gag8flU8/SE0JWDg/smYfIc0KBBLMbK3sZyun+yw8IsB5vj40uJPLPWKcBJg==
   dependencies:
     "@bitcoinerlab/secp256k1" "1.0.5"
     bech32 "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5886,10 +5886,10 @@ bech32@^1.1.2, bech32@^1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-beignet@0.0.34:
-  version "0.0.34"
-  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.34.tgz#536d544364674fbc5b2378de28f3445bab405395"
-  integrity sha512-j4rTA0kdhlZzCYVwquu/miTak/gag8flU8/SE0JWDg/smYfIc0KBBLMbK3sZyun+yw8IsB5vj40uJPLPWKcBJg==
+beignet@0.0.35:
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.35.tgz#b3255587d51fc16cdd95e2fdd5e9231b1cff4c48"
+  integrity sha512-hOT26TzgX4L9ALOh9vWz3Vfs3RKQhrtFNIL2ZjxIAjnmPRlSmxaqkO4REqtHSQ4CHi1hsnBZ9rrvqzeb7Al5QQ==
   dependencies:
     "@bitcoinerlab/secp256k1" "1.0.5"
     bech32 "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15069,3 +15069,4 @@ z32@^1.0.0:
   integrity sha512-p3DhBJckAZj5XwYMJYeLlkgJJ+aEyCoOjTpK17I/MofVs70eR+WQPXQpk1LEmMweB2JbUx0naFXPPI2EGaVX6w==
   dependencies:
     b4a "^1.5.3"
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -15069,4 +15069,3 @@ z32@^1.0.0:
   integrity sha512-p3DhBJckAZj5XwYMJYeLlkgJJ+aEyCoOjTpK17I/MofVs70eR+WQPXQpk1LEmMweB2JbUx0naFXPPI2EGaVX6w==
   dependencies:
     b4a "^1.5.3"
-


### PR DESCRIPTION
### Description
- Upgrades Beignet for the:
    - Fee estimate fallback.
        - We now fallback to using blocktank for fee estimates in the event mempool.space is down or the user if blacklisted.
     - Dust transaction fixes.

### Type of change
- [x] Dependency Upgrade

### Linked Issue
- [#1698](https://github.com/synonymdev/bitkit/issues/1698)

### Tests
- [x] No test
