### PR TITLE
fix: reselect test

### DIFF
--- a/__tests__/r2.ts
+++ b/__tests__/r2.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert';
+import cloneDeep from 'lodash/cloneDeep';
+
+import '../src/utils/i18n';
+import store, { RootState } from '../src/store';
+import { createNewWallet } from '../src/utils/startup';
+import { updateWallet } from '../src/store/actions/wallet';
+import { EAvailableNetwork } from '../src/utils/networks';
+import {
+	balanceSelector,
+	lnSetupSelector,
+} from '../src/store/reselect/aggregations';
+import { TChannel, EChannelStatus } from '../src/store/types/lightning';
+import { channelsSizeSelector, pendingChannelsSelector } from '../src/store/reselect/lightning';
+
+describe('Reselect', () => {
+	let s: RootState;
+
+	beforeAll(async () => {
+		let res = await createNewWallet();
+		if (res.isErr()) {
+			throw res.error;
+		}
+		updateWallet({ selectedNetwork: EAvailableNetwork.bitcoinRegtest, selectedWallet: 'wallet0' });
+		s = store.getState();
+	});
+
+	describe('lnChannelsSelector', () => {
+		it('should return empty array by default', () => {
+			const state = cloneDeep(s);
+
+			// expect(pendingChannelsSelector(state)).toEqual([]);
+			expect(channelsSizeSelector(state)).toEqual(0);
+		})
+	})
+});

--- a/src/store/reselect/lightning.ts
+++ b/src/store/reselect/lightning.ts
@@ -97,9 +97,16 @@ export const pendingChannelsSelector = createSelector(
 		const node = lightning.nodes[selectedWallet];
 		const channels = node.channels[selectedNetwork];
 
-		return Object.values(channels).filter((channel) => {
+		console.info('node', node);
+		console.info('channels', channels);
+
+		const z = Object.values(channels).filter((channel) => {
 			return channel.status === EChannelStatus.pending;
 		});
+
+		console.info('pendingChannelsSelector return value', z);
+
+		return z;
 	},
 );
 
@@ -128,6 +135,8 @@ export const closedChannelsSelector = createSelector(
 export const channelsSizeSelector = createSelector(
 	[openChannelsSelector, pendingChannelsSelector],
 	(openChannels, pendingChannels) => {
+		console.info('kekeke openChannels', openChannels);
+		console.info('kekeke pendingChannels', pendingChannels);
 		const openResult = reduceValue(openChannels, 'channel_value_satoshis');
 		const pendingResult = reduceValue(
 			pendingChannels,


### PR DESCRIPTION
```

  console.info
    node {
      nodeId: { bitcoin: '', bitcoinTestnet: '', bitcoinRegtest: '' },
      info: { bitcoin: {}, bitcoinTestnet: {}, bitcoinRegtest: {} },
      channels: { bitcoin: {}, bitcoinTestnet: {}, bitcoinRegtest: {} },
      peers: { bitcoin: [], bitcoinTestnet: [], bitcoinRegtest: [] },
      claimableBalances: { bitcoin: [], bitcoinTestnet: [], bitcoinRegtest: [] },
      backup: { bitcoin: {}, bitcoinTestnet: {}, bitcoinRegtest: {} }
    }

      at info (src/store/reselect/lightning.ts:100:11)

  console.info
    channels {}

      at info (src/store/reselect/lightning.ts:101:11)

  console.info
    pendingChannelsSelector return value []

      at info (src/store/reselect/lightning.ts:107:11)

  console.info
    kekeke openChannels {}

      at info (src/store/reselect/lightning.ts:138:11)

  console.info
    kekeke pendingChannels undefined

      at info (src/store/reselect/lightning.ts:139:11)

  console.info
    kekeke openChannels []

      at info (src/store/reselect/lightning.ts:138:11)

  console.info
    kekeke pendingChannels []

      at info (src/store/reselect/lightning.ts:139:11)
```