### PR TITLE
fix: add 10% to the BT info minChannelSizeSat field

### DIFF
--- a/src/screens/Lightning/CustomSetup.tsx
+++ b/src/screens/Lightning/CustomSetup.tsx
@@ -46,7 +46,10 @@ import {
 import { blocktankInfoSelector } from '../../store/reselect/blocktank';
 import NumberPadTextField from '../../components/NumberPadTextField';
 import { getNumberPadText } from '../../utils/numberpad';
-import { MAX_SPENDING_PERCENTAGE } from '../../utils/wallet/constants';
+import {
+	BT_MIN_CHANNEL_SIZE_SAT_MULTIPLIER,
+	MAX_SPENDING_PERCENTAGE,
+} from '../../utils/wallet/constants';
 import { refreshBlocktankInfo } from '../../store/utils/blocktank';
 import { lnSetupSelector } from '../../store/reselect/aggregations';
 import { useDisplayValues } from '../../hooks/displayValues';
@@ -247,6 +250,12 @@ const CustomSetup = ({
 			const medium = receivingPackages.find((p) => p.id === 'medium')!;
 			const big = receivingPackages.find((p) => p.id === 'big')!;
 
+			const minChannelSize = Math.round(
+				blocktankInfo.options.minChannelSizeSat +
+					blocktankInfo.options.minChannelSizeSat *
+						BT_MIN_CHANNEL_SIZE_SAT_MULTIPLIER,
+			);
+
 			// Attempt to suggest a receiving balance 10x greater than current on-chain balance.
 			// May not be able to afford anything much larger.
 			const balanceMultiplied = onchainBalance * 10;
@@ -257,8 +266,8 @@ const CustomSetup = ({
 					? medium.satoshis
 					: balanceMultiplied > small.satoshis
 					? small.satoshis
-					: balanceMultiplied > blocktankInfo.options.minChannelSizeSat
-					? blocktankInfo.options.minChannelSizeSat
+					: balanceMultiplied > minChannelSize
+					? minChannelSize
 					: 0;
 
 			const result = getNumberPadText(amount, denomination, unit);

--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -66,9 +66,19 @@ const QuickSetup = ({
 			const setupTransfer = async (): Promise<void> => {
 				await resetSendTransaction();
 				await setupOnChainTransaction();
-				refreshBlocktankInfo().then();
 			};
 			setupTransfer();
+		}, []),
+	);
+
+	// refresh BT info every 20 seconds, because minChannelSizeSat changes
+	useFocusEffect(
+		useCallback(() => {
+			refreshBlocktankInfo().then();
+			const interval = setInterval(() => {
+				refreshBlocktankInfo().then();
+			}, 20000);
+			return (): void => clearInterval(interval);
 		}, []),
 	);
 

--- a/src/store/reselect/aggregations.ts
+++ b/src/store/reselect/aggregations.ts
@@ -7,6 +7,7 @@ import {
 	LIGHTNING_DIFF,
 	DEFAULT_SPENDING_PERCENTAGE,
 	MAX_SPENDING_PERCENTAGE,
+	BT_MIN_CHANNEL_SIZE_SAT_MULTIPLIER,
 } from '../../utils/wallet/constants';
 
 /**
@@ -66,7 +67,11 @@ export const lnSetupSelector = createSelector(
 		const { totalBalance, onchainBalance, lightningBalance } = balance;
 		const clientBalance = spendingAmount - lightningBalance;
 		const maxTotalChannelSize = blocktankInfo.options.maxChannelSizeSat;
-		const minChannelSize = blocktankInfo.options.minChannelSizeSat;
+		const minChannelSize = Math.round(
+			blocktankInfo.options.minChannelSizeSat +
+				blocktankInfo.options.minChannelSizeSat *
+					BT_MIN_CHANNEL_SIZE_SAT_MULTIPLIER,
+		);
 		const maxChannelSize = Math.max(0, maxTotalChannelSize - channelsSize);
 
 		// LSP balance must be at least 1.5% of the channel size

--- a/src/utils/wallet/constants.ts
+++ b/src/utils/wallet/constants.ts
@@ -26,3 +26,7 @@ export const MAX_SPENDING_PERCENTAGE = 0.8;
 export const LIGHTNING_DIFF = 0.01;
 
 export const DEFAULT_CHANNEL_DURATION = 6;
+
+// Because BT /info minChannelSizeSat constantly changes depending on network fees,
+// we use a multiplier to calculate the minimum channel size.
+export const BT_MIN_CHANNEL_SIZE_SAT_MULTIPLIER = 0.1;


### PR DESCRIPTION
### Description

BT updates `minChannelSizeSat` from info every ~20 seconds. So if the user will stay longer than that on Setup screen he can receive an error when. I'm adding 2 things:
- re-fetch /info every 20 seconds while user is on Setup screen
- add 10% reserve to minChannelSizeSat when do calculations.

### Linked Issues/Tasks

#1685

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video

Insert relevant screenshot / recording

### QA Notes

- open setup screen
- watch for BT /info (https://api.stag.blocktank.to/blocktank/api/v2/info or https://api.blocktank.to/api/v2/info
- when minChannelSizeSat spikes, try to create a channel