### PR TITLE
Fix Max Fee Checks

### DIFF
--- a/src/screens/Wallets/Send/FeeCustom.tsx
+++ b/src/screens/Wallets/Send/FeeCustom.tsx
@@ -55,12 +55,12 @@ const FeeCustom = ({
 
 	const onPress = (key: string): void => {
 		const current = feeRate.toString();
-		const newAmount = handleNumberPadPress(key, current, { maxLength: 4 });
+		const newAmount = handleNumberPadPress(key, current, { maxLength: 3 });
 		if (Number(newAmount) > maxFee) {
 			showToast({
 				type: 'info',
-				title: 'Max possible fee rate',
-				description: `${maxFee} sats/vbyte`,
+				title: t('max_possible_fee_rate'),
+				description: `${maxFee} ${t('sats_per_vbyte')}`,
 			});
 			return;
 		}

--- a/src/screens/Wallets/Send/FeeRate.tsx
+++ b/src/screens/Wallets/Send/FeeRate.tsx
@@ -45,11 +45,13 @@ const FeeRate = ({ navigation }: SendScreenProps<'FeeRate'>): ReactElement => {
 	const satsPerByte = transaction.satsPerByte;
 
 	useEffect(() => {
-		const feeInfo = getFeeInfo({ satsPerByte, transaction });
+		const feeInfo = getFeeInfo({
+			satsPerByte: transaction.satsPerByte,
+			transaction,
+		});
 		if (feeInfo.isOk()) {
 			setMaxFee(feeInfo.value.maxSatPerByte);
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [transaction]);
 
 	const transactionTotal = useCallback(() => {

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -58,6 +58,8 @@
 	"send_fee_and_speed": "Speed and fee",
 	"send_fee_speed": "Speed",
 	"send_fee_error": "Fee Invalid",
+	"max_possible_fee_rate": "Max possible fee rate",
+	"sats_per_vbyte": "sats/vbyte",
 	"send_output_to_small_title": "Send Amount Too Small",
 	"send_output_to_small_description": "Please increase your send amount to proceed.",
 	"send_coin_selection_output_to_small_description": "Please remove UTXO's or increase your send amount to proceed.",

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -90,6 +90,7 @@ import { updateUi } from '../../store/slices/ui';
 import { resetActivityState } from '../../store/slices/activity';
 import BitcoinActions from '../bitcoin-actions';
 import { bitkitLedger, syncLedger } from '../ledger';
+import { TGetTotalFeeObj } from 'beignet/dist/types/types';
 
 bitcoin.initEccLib(ecc);
 const bip32 = BIP32Factory(ecc);
@@ -1608,4 +1609,31 @@ export const switchNetwork = async (
 	wallet = response.value;
 	setTimeout(updateActivityList, 500);
 	return ok(true);
+};
+
+/**
+ * Returns a fee object for the current/provided transaction.
+ * @param {number} [satsPerByte]
+ * @param {string} [message]
+ * @param {Partial<ISendTransaction>} [transaction]
+ * @param {boolean} [fundingLightning]
+ * @returns {Result<TGetTotalFeeObj>}
+ */
+export const getFeeInfo = ({
+	satsPerByte,
+	transaction,
+	message,
+	fundingLightning,
+}: {
+	satsPerByte: number;
+	message?: string;
+	transaction?: Partial<ISendTransaction>;
+	fundingLightning?: boolean;
+}): Result<TGetTotalFeeObj> => {
+	return wallet.getFeeInfo({
+		satsPerByte,
+		transaction,
+		message,
+		fundingLightning,
+	});
 };


### PR DESCRIPTION
### Description
- Adds max fee checks to the `FeeRate` & `FeeCustom` views to prevent users from selecting or setting a fee-rate above what the max is.
- Adds `getFeeInfo` method.
- Resolves UI bug in #1619

### Linked Issues/Tasks
- #1619

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test

### QA Notes
When setting fees during the send flow, the max fee checks should be in place and prevent you from setting a value above the `maxFee` provided by Beignet's `getFeeInfo` method.
