### PR TITLE
fix: use BT state2 field, change pending orders logic

### DIFF
--- a/__tests__/todos.ts
+++ b/__tests__/todos.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import cloneDeep from 'lodash/cloneDeep';
 import { IBtOrder } from '@synonymdev/blocktank-lsp-http-client';
+import { BtOrderState2 } from '@synonymdev/blocktank-lsp-http-client/dist/shared/BtOrderState2';
 
 import '../src/utils/i18n';
 import { todosFullSelector } from '../src/store/reselect/todos';
@@ -83,16 +84,16 @@ describe('Todos selector', () => {
 	it('should not return hidden todos', () => {
 		const state = cloneDeep(s);
 
-		const order = {
+		const order: Partial<IBtOrder> = {
 			id: 'order1',
-			state: 'expired',
+			state2: BtOrderState2.EXPIRED,
 			// expired 10 days ago
 			orderExpiresAt: new Date(
 				new Date().getTime() - 10 * 24 * 60 * 60 * 1000,
 			).toISOString(),
-		} as IBtOrder;
+		};
 		state.blocktank.paidOrders = { order1: 'txid' };
-		state.blocktank.orders = [order];
+		state.blocktank.orders = [order as IBtOrder];
 
 		state.todos.hide = {
 			backupSeedPhrase: +new Date(),
@@ -125,12 +126,14 @@ describe('Todos selector', () => {
 	it('should return transferClosingChannel if there are gracefully closing channels', () => {
 		const state = cloneDeep(s);
 
-		const channel1 = {
+		const channel1: Partial<TChannel> = {
 			channel_id: 'channel1',
 			status: EChannelStatus.open,
 			is_channel_ready: true,
-		} as TChannel;
-		state.lightning.nodes.wallet0.channels.bitcoinRegtest = { channel1 };
+		};
+		state.lightning.nodes.wallet0.channels.bitcoinRegtest = {
+			channel1: channel1 as TChannel,
+		};
 		state.user.startCoopCloseTimestamp = 123;
 
 		expect(todosFullSelector(state)).toEqual(
@@ -140,12 +143,14 @@ describe('Todos selector', () => {
 
 	it('should return lightningSettingUpTodo for addtional pending transfers to spending', () => {
 		const state = cloneDeep(s);
-		const channel1 = {
+		const channel1: Partial<TChannel> = {
 			channel_id: 'channel1',
 			status: EChannelStatus.open,
 			is_channel_ready: true,
-		} as TChannel;
-		state.lightning.nodes.wallet0.channels.bitcoinRegtest = { channel1 };
+		};
+		state.lightning.nodes.wallet0.channels.bitcoinRegtest = {
+			channel1: channel1 as TChannel,
+		};
 		state.wallet.wallets.wallet0.transfers.bitcoinRegtest.push({
 			txId: 'txid',
 			type: ETransferType.open,
@@ -175,14 +180,16 @@ describe('Todos selector', () => {
 	it('should return lightningReadyTodo if there is a new open channel', () => {
 		const state = cloneDeep(s);
 
-		const channel1 = {
+		const channel1: Partial<TChannel> = {
 			channel_id: 'channel1',
 			status: EChannelStatus.open,
 			is_channel_ready: true,
 			confirmations: 1,
 			confirmations_required: 1,
-		} as TChannel;
-		state.lightning.nodes.wallet0.channels.bitcoinRegtest = { channel1 };
+		};
+		state.lightning.nodes.wallet0.channels.bitcoinRegtest = {
+			channel1: channel1 as TChannel,
+		};
 
 		expect(todosFullSelector(state)).toEqual(
 			expect.arrayContaining([lightningReadyTodo]),
@@ -192,14 +199,16 @@ describe('Todos selector', () => {
 	it('should return not lightningReadyTodo if notification has already been shown', () => {
 		const state = cloneDeep(s);
 
-		const channel1 = {
+		const channel1: Partial<TChannel> = {
 			channel_id: 'channel1',
 			status: EChannelStatus.open,
 			is_channel_ready: true,
 			confirmations: 1,
 			confirmations_required: 1,
-		} as TChannel;
-		state.lightning.nodes.wallet0.channels.bitcoinRegtest = { channel1 };
+		};
+		state.lightning.nodes.wallet0.channels.bitcoinRegtest = {
+			channel1: channel1 as TChannel,
+		};
 		state.todos.newChannelsNotifications = { channel1: +new Date() };
 
 		expect(todosFullSelector(state)).not.toEqual(
@@ -210,13 +219,13 @@ describe('Todos selector', () => {
 	it('should return btFailedTodo if there is a failed BT order', () => {
 		const state = cloneDeep(s);
 
-		const order = {
+		const order: Partial<IBtOrder> = {
 			id: 'order1',
-			state: 'expired',
+			state2: BtOrderState2.EXPIRED,
 			orderExpiresAt: new Date().toISOString(),
-		} as IBtOrder;
+		};
 		state.blocktank.paidOrders = { order1: 'txid' };
-		state.blocktank.orders = [order];
+		state.blocktank.orders = [order as IBtOrder];
 
 		expect(todosFullSelector(state)).toEqual(
 			expect.arrayContaining([btFailedTodo]),
@@ -226,13 +235,13 @@ describe('Todos selector', () => {
 	it('should return btFailedTodo if there is a failed BT order and the previous one was hidden', () => {
 		const state = cloneDeep(s);
 
-		const order = {
+		const order: Partial<IBtOrder> = {
 			id: 'order1',
-			state: 'expired',
+			state2: BtOrderState2.EXPIRED,
 			orderExpiresAt: new Date().toISOString(),
-		} as IBtOrder;
+		};
 		state.blocktank.paidOrders = { order1: 'txid' };
-		state.blocktank.orders = [order];
+		state.blocktank.orders = [order as IBtOrder];
 
 		// mark btFinishedTodo as hidden
 		state.todos.hide.btFailed = +new Date() - 60 * 1000;

--- a/src/screens/Activity/ActivityList.tsx
+++ b/src/screens/Activity/ActivityList.tsx
@@ -1,39 +1,39 @@
+import { useNavigation } from '@react-navigation/native';
 import React, {
-	memo,
-	ReactElement,
-	useCallback,
-	useState,
-	useMemo,
 	MutableRefObject,
+	ReactElement,
+	memo,
+	useCallback,
+	useMemo,
+	useState,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
 	NativeScrollEvent,
 	NativeSyntheticEvent,
+	RefreshControl,
 	StyleProp,
 	StyleSheet,
 	View,
 	ViewStyle,
-	RefreshControl,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
 import { FlatList, GestureType } from 'react-native-gesture-handler';
-import { useTranslation } from 'react-i18next';
 
-import { Caption13Up, BodyM, BodySSB } from '../../styles/text';
 import Button from '../../components/Button';
-import ListItem from './ListItem';
 import useColors from '../../hooks/colors';
 import { useAppSelector } from '../../hooks/redux';
-import { refreshWallet } from '../../utils/wallet';
-import {
-	groupActivityItems,
-	filterActivityItems,
-	TActivityFilter,
-} from '../../utils/activity';
 import { RootNavigationProp } from '../../navigation/types';
 import { activityItemsSelector } from '../../store/reselect/activity';
 import { tagsSelector } from '../../store/reselect/metadata';
 import { IActivityItem } from '../../store/types/activity';
+import { BodyM, BodySSB, Caption13Up } from '../../styles/text';
+import {
+	TActivityFilter,
+	filterActivityItems,
+	groupActivityItems,
+} from '../../utils/activity';
+import { refreshWallet } from '../../utils/wallet';
+import ListItem from './ListItem';
 
 const ListFooter = ({ showButton }: { showButton?: boolean }): ReactElement => {
 	const { t } = useTranslation('wallet');
@@ -81,6 +81,7 @@ const ActivityList = ({
 }): ReactElement => {
 	const colors = useColors();
 	const { t } = useTranslation('wallet');
+	const colors = useColors();
 	const navigation = useNavigation<RootNavigationProp>();
 	const items = useAppSelector(activityItemsSelector);
 	const tags = useAppSelector(tagsSelector);

--- a/src/screens/Activity/ActivityList.tsx
+++ b/src/screens/Activity/ActivityList.tsx
@@ -81,7 +81,6 @@ const ActivityList = ({
 }): ReactElement => {
 	const colors = useColors();
 	const { t } = useTranslation('wallet');
-	const colors = useColors();
 	const navigation = useNavigation<RootNavigationProp>();
 	const items = useAppSelector(activityItemsSelector);
 	const tags = useAppSelector(tagsSelector);

--- a/src/store/reselect/blocktank.ts
+++ b/src/store/reselect/blocktank.ts
@@ -1,11 +1,8 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { RootState } from '..';
 import { IBlocktank, TPaidBlocktankOrders } from '../types/blocktank';
-import {
-	BtOrderState,
-	IBtInfo,
-	IBtOrder,
-} from '@synonymdev/blocktank-lsp-http-client';
+import { IBtInfo, IBtOrder } from '@synonymdev/blocktank-lsp-http-client';
+import { BtOrderState2 } from '@synonymdev/blocktank-lsp-http-client/dist/shared/BtOrderState2';
 
 const blocktankState = (state: RootState): IBlocktank => state.blocktank;
 
@@ -41,13 +38,13 @@ export const blocktankPaidOrdersFullSelector = createSelector(
 	): {
 		created: IBtOrder[];
 		expired: IBtOrder[];
-		open: IBtOrder[];
-		closed: IBtOrder[];
+		executed: IBtOrder[];
+		paid: IBtOrder[];
 	} => {
 		const created: IBtOrder[] = [];
 		const expired: IBtOrder[] = [];
-		const open: IBtOrder[] = [];
-		const closed: IBtOrder[] = [];
+		const executed: IBtOrder[] = [];
+		const paid: IBtOrder[] = [];
 
 		Object.keys(blocktank.paidOrders).forEach((orderId) => {
 			const order = blocktank.orders.find(
@@ -60,23 +57,23 @@ export const blocktankPaidOrdersFullSelector = createSelector(
 				return;
 			}
 
-			switch (order.state) {
-				case BtOrderState.CREATED:
+			switch (order.state2) {
+				case BtOrderState2.CREATED:
 					created.push(order);
 					break;
-				case BtOrderState.EXPIRED:
+				case BtOrderState2.EXPIRED:
 					expired.push(order);
 					break;
-				case BtOrderState.OPEN:
-					open.push(order);
+				case BtOrderState2.EXECUTED:
+					executed.push(order);
 					break;
-				case BtOrderState.CLOSED:
-					closed.push(order);
+				case BtOrderState2.PAID:
+					paid.push(order);
 					break;
 			}
 		});
 
-		return { created, expired, open, closed };
+		return { created, expired, executed, paid };
 	},
 );
 /**

--- a/src/store/shapes/blocktank.ts
+++ b/src/store/shapes/blocktank.ts
@@ -1,10 +1,5 @@
 import { IBlocktank } from '../types/blocktank';
-import {
-	BtOrderState,
-	BtPaymentState,
-	IBtOrder,
-	IBtInfo,
-} from '@synonymdev/blocktank-lsp-http-client';
+import { IBtInfo } from '@synonymdev/blocktank-lsp-http-client';
 
 export const defaultBlocktankInfoShape: IBtInfo = {
 	version: 2,
@@ -47,49 +42,4 @@ export const initialBlocktankState: IBlocktank = {
 	paidOrders: {},
 	info: defaultBlocktankInfoShape,
 	cJitEntries: [],
-};
-
-export const defaultOrderResponse: IBtOrder = {
-	id: '',
-	state: BtOrderState.CREATED,
-	feeSat: 0,
-	lspBalanceSat: 0,
-	clientBalanceSat: 0,
-	zeroConf: false,
-	channelExpiryWeeks: 0,
-	// @ts-ignore
-	channelExpiresAt: new Date().getTime(),
-	// @ts-ignore
-	orderExpiresAt: new Date().getTime(),
-	channel: undefined,
-	lspNode: {
-		alias: '',
-		pubkey: '',
-		connectionStrings: [],
-	},
-	payment: {
-		state: BtPaymentState.CREATED,
-		paidSat: 0,
-		bolt11Invoice: {
-			request: '',
-			// @ts-ignore
-			state: null,
-			// @ts-ignore
-			expiresAt: new Date().getTime(),
-			// @ts-ignore
-			updatedAt: new Date().getTime(),
-		},
-		onchain: {
-			address: '',
-			confirmedSat: 0,
-			transactions: [],
-			requiredConfirmations: 0,
-		},
-	},
-	couponCode: '',
-	discountPercent: 0,
-	// @ts-ignore
-	updatedAt: new Date().getTime(),
-	// @ts-ignore
-	createdAt: new Date().getTime(),
 };

--- a/src/store/utils/blocktank.ts
+++ b/src/store/utils/blocktank.ts
@@ -1,11 +1,8 @@
 import { err, ok, Result } from '@synonymdev/result';
 import { CJitStateEnum } from '@synonymdev/blocktank-lsp-http-client/dist/shared/CJitStateEnum';
-import {
-	BtOrderState,
-	BtPaymentState,
-	IBtOrder,
-	ICJitEntry,
-} from '@synonymdev/blocktank-lsp-http-client';
+import { IBtOrder, ICJitEntry } from '@synonymdev/blocktank-lsp-http-client';
+import { BtOrderState2 } from '@synonymdev/blocktank-lsp-http-client/dist/shared/BtOrderState2';
+import { BtPaymentState2 } from '@synonymdev/blocktank-lsp-http-client/dist/shared/BtPaymentState2';
 
 import {
 	addTransfer,
@@ -132,8 +129,8 @@ export const refreshOrder = async (
 
 		// Attempt to finalize the channel open.
 		if (
-			order.state === BtOrderState.CREATED &&
-			order.payment.state === BtPaymentState.PAID
+			order.state2 === BtOrderState2.PAID &&
+			order.payment.state2 === BtPaymentState2.PAID
 		) {
 			dispatch(setLightningSetupStep(1));
 			const finalizeRes = await openChannel(orderId);
@@ -409,7 +406,7 @@ const handleOrderStateChange = (order: IBtOrder): void => {
 	}
 
 	// order expired
-	if (order.state === BtOrderState.EXPIRED) {
+	if (order.state2 === BtOrderState2.EXPIRED) {
 		showToast({
 			type: 'warning',
 			title: i18n.t('lightning:order_expired_title'),
@@ -419,7 +416,7 @@ const handleOrderStateChange = (order: IBtOrder): void => {
 	}
 
 	// new channel open
-	if (order.state === BtOrderState.OPEN) {
+	if (order.state2 === BtOrderState2.EXECUTED) {
 		// refresh LDK after channel open
 		refreshLdk();
 	}

--- a/src/store/utils/blocktank.ts
+++ b/src/store/utils/blocktank.ts
@@ -1,6 +1,11 @@
 import { err, ok, Result } from '@synonymdev/result';
 import { CJitStateEnum } from '@synonymdev/blocktank-lsp-http-client/dist/shared/CJitStateEnum';
-import { IBtOrder, ICJitEntry } from '@synonymdev/blocktank-lsp-http-client';
+import {
+	BtBolt11PaymentState,
+	BtOpenChannelState,
+	IBtOrder,
+	ICJitEntry,
+} from '@synonymdev/blocktank-lsp-http-client';
 import { BtOrderState2 } from '@synonymdev/blocktank-lsp-http-client/dist/shared/BtOrderState2';
 import { BtPaymentState2 } from '@synonymdev/blocktank-lsp-http-client/dist/shared/BtPaymentState2';
 
@@ -146,8 +151,8 @@ export const refreshOrder = async (
 
 		// Order state has not changed
 		if (
-			currentOrder?.state === order.state &&
-			currentOrder?.payment.state === order.payment.state &&
+			currentOrder?.state2 === order.state2 &&
+			currentOrder?.payment.state2 === order.payment.state2 &&
 			currentOrder?.channel?.state === order.channel?.state
 		) {
 			return ok(order);
@@ -160,8 +165,8 @@ export const refreshOrder = async (
 		if (
 			currentOrder &&
 			isPaidOrder &&
-			(currentOrder.state !== order.state ||
-				currentOrder.payment.state !== order.payment.state)
+			(currentOrder.state2 !== order.state2 ||
+				currentOrder.payment.state2 !== order.payment.state2)
 		) {
 			handleOrderStateChange(order);
 		}
@@ -391,12 +396,12 @@ const handleOrderStateChange = (order: IBtOrder): void => {
 	}
 
 	// opening connection
-	if (order.channel?.state === 'opening') {
+	if (order.channel?.state === BtOpenChannelState.OPENING) {
 		dispatch(setLightningSetupStep(3));
 	}
 
 	// given up
-	if (order.payment.bolt11Invoice.state === 'failed') {
+	if (order.payment.bolt11Invoice.state === BtBolt11PaymentState.FAILED) {
 		showToast({
 			type: 'warning',
 			title: i18n.t('lightning:order_given_up_title'),

--- a/src/utils/blocktank/index.ts
+++ b/src/utils/blocktank/index.ts
@@ -278,11 +278,7 @@ export const watchPendingOrders = (): void => {
 export const getPendingOrders = (): IBtOrder[] => {
 	const orders = getBlocktankStore().orders;
 	return orders.filter((order) => {
-		return [
-			BtOrderState2.CREATED,
-			BtOrderState2.EXECUTED,
-			BtOrderState2.EXPIRED,
-		].includes(order.state2);
+		return [BtOrderState2.CREATED, BtOrderState2.PAID].includes(order.state2);
 	});
 };
 


### PR DESCRIPTION
### Description

- use order.state2 and order.payment.state2 fields
- do not watch for EXECUTED or EXPIRED BT orders

### Linked Issues/Tasks



### Type of change

Bug fix

### Tests

No test

### Screenshot / Video



### QA Notes

