### PR TITLE
fix: #1735 android crash on resume

### DIFF
--- a/android/app/src/main/java/com/bitkit/MainActivity.kt
+++ b/android/app/src/main/java/com/bitkit/MainActivity.kt
@@ -19,7 +19,7 @@ class MainActivity : ReactActivity() {
    * We override the [onCreate] method to show the splash screen.
    */
   override fun onCreate(savedInstanceState: Bundle?) {
-      super.onCreate(savedInstanceState)
+      super.onCreate(null)
       SplashScreenModule.show(this)
   }
 


### PR DESCRIPTION
### Description

Fixes the app crashing when opening from background after some time on Android.

### Linked Issues/Tasks

Closes #1735 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

Put the app to background for 15 minutes and then open it again. It shouldn't crash.
