### PR TITLE
fix(send): update send success/error screen

### DIFF
--- a/src/navigation/bottom-sheet/SendNavigation.tsx
+++ b/src/navigation/bottom-sheet/SendNavigation.tsx
@@ -17,7 +17,8 @@ import Tags from '../../screens/Wallets/Send/Tags';
 import AutoRebalance from '../../screens/Wallets/Send/AutoRebalance';
 import PinCheck from '../../screens/Wallets/Send/PinCheck';
 import Pending from '../../screens/Wallets/Send/Pending';
-import Result from '../../screens/Wallets/Send/Result';
+import Success from '../../screens/Wallets/Send/Success';
+import Error from '../../screens/Wallets/Send/Error';
 import Contacts from '../../screens/Wallets/Send/Contacts';
 import Address from '../../screens/Wallets/Send/Address';
 import Scanner from '../../screens/Wallets/Send/Scanner';
@@ -56,12 +57,8 @@ export type SendStackParamList = {
 	Tags: undefined;
 	AutoRebalance: undefined;
 	Pending: { txId: string };
-	Result: {
-		success: boolean;
-		txId?: string;
-		errorTitle?: string;
-		errorMessage?: string;
-	};
+	Success: { amount: number; txId: string };
+	Error: { errorMessage: string };
 };
 
 const Stack = createNativeStackNavigator<SendStackParamList>();
@@ -149,7 +146,8 @@ const SendNavigation = (): ReactElement => {
 					<Stack.Screen name="AutoRebalance" component={AutoRebalance} />
 					<Stack.Screen name="PinCheck" component={PinCheck} />
 					<Stack.Screen name="Pending" component={Pending} />
-					<Stack.Screen name="Result" component={Result} />
+					<Stack.Screen name="Success" component={Success} />
+					<Stack.Screen name="Error" component={Error} />
 				</Stack.Navigator>
 			</NavigationContainer>
 		</BottomSheetWrapper>

--- a/src/screens/Wallets/Send/Success.tsx
+++ b/src/screens/Wallets/Send/Success.tsx
@@ -1,0 +1,129 @@
+import React, { memo, ReactElement } from 'react';
+import { StyleSheet, View, Image } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import Lottie from 'lottie-react-native';
+
+import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
+import SafeAreaInset from '../../../components/SafeAreaInset';
+import GradientView from '../../../components/GradientView';
+import AmountToggle from '../../../components/AmountToggle';
+import Button from '../../../components/Button';
+import { useAppDispatch, useAppSelector } from '../../../hooks/redux';
+import { closeSheet } from '../../../store/slices/ui';
+import { activityItemSelector } from '../../../store/reselect/activity';
+import { rootNavigation } from '../../../navigation/root/RootNavigator';
+import type { SendScreenProps } from '../../../navigation/types';
+
+const confettiSrc = require('../../../assets/lottie/confetti-green.json');
+const imageSrc = require('../../../assets/illustrations/check.png');
+
+const Success = ({ route }: SendScreenProps<'Success'>): ReactElement => {
+	const { t } = useTranslation('wallet');
+	const { amount, txId } = route.params;
+	const dispatch = useAppDispatch();
+	const activityItem = useAppSelector((state) => {
+		return activityItemSelector(state, txId);
+	});
+
+	const navigateToTxDetails = (): void => {
+		if (activityItem) {
+			dispatch(closeSheet('sendNavigation'));
+			rootNavigation.navigate('ActivityDetail', { id: activityItem.id });
+		}
+	};
+
+	const handleClose = (): void => {
+		dispatch(closeSheet('sendNavigation'));
+	};
+
+	return (
+		<GradientView style={styles.root}>
+			<View style={styles.confetti} pointerEvents="none" testID="SendSuccess">
+				<Lottie
+					style={styles.lottie}
+					source={confettiSrc}
+					resizeMode="cover"
+					autoPlay
+					loop
+				/>
+			</View>
+
+			<BottomSheetNavigationHeader
+				title={t('send_sent')}
+				displayBackButton={false}
+			/>
+
+			<View style={styles.content}>
+				<AmountToggle
+					amount={amount}
+					testID="NewTxPrompt"
+					onPress={navigateToTxDetails}
+				/>
+
+				<View style={styles.imageContainer}>
+					<Image style={styles.image} source={imageSrc} />
+				</View>
+
+				<View style={styles.buttonContainer}>
+					<Button
+						style={styles.button}
+						variant="secondary"
+						size="large"
+						disabled={!activityItem}
+						text={t('send_details')}
+						onPress={navigateToTxDetails}
+					/>
+					<Button
+						style={styles.button}
+						size="large"
+						text={t('close')}
+						testID="Close"
+						onPress={handleClose}
+					/>
+				</View>
+			</View>
+			<SafeAreaInset type="bottom" minPadding={16} />
+		</GradientView>
+	);
+};
+
+const styles = StyleSheet.create({
+	root: {
+		flex: 1,
+	},
+	confetti: {
+		...StyleSheet.absoluteFillObject,
+		zIndex: 0,
+	},
+	lottie: {
+		height: '100%',
+	},
+	content: {
+		flex: 1,
+		paddingHorizontal: 16,
+	},
+	imageContainer: {
+		flexShrink: 1,
+		justifyContent: 'center',
+		alignItems: 'center',
+		alignSelf: 'center',
+		width: 256,
+		aspectRatio: 1,
+		marginTop: 'auto',
+	},
+	image: {
+		flex: 1,
+		resizeMode: 'contain',
+	},
+	buttonContainer: {
+		flexDirection: 'row',
+		justifyContent: 'center',
+		marginTop: 'auto',
+		gap: 16,
+	},
+	button: {
+		flex: 1,
+	},
+});
+
+export default memo(Success);


### PR DESCRIPTION
### Description

- split `Result` into `Success` and `Error` screens for better readability
- don't wait for electrum to show amount on `Success`
- style `Error` according to design

### Linked Issues/Tasks

Closes #1638 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/8538369/3088bf9c-3596-4c97-9f79-421d09232ed8
