### PR TITLE
fix(lightning): include unspendable reserve in balances

### DIFF
--- a/e2e/lightning.e2e.js
+++ b/e2e/lightning.e2e.js
@@ -163,7 +163,7 @@ d('Lightning', () => {
 			await waitFor(
 				element(by.id('MoneyText').withAncestor(by.id('TotalBalance'))),
 			)
-				.toHaveText('49 000')
+				.toHaveText('50 000')
 				.withTimeout(10000);
 
 			// send funds to LDK, 111 sats invoice
@@ -193,7 +193,7 @@ d('Lightning', () => {
 			await waitFor(
 				element(by.id('MoneyText').withAncestor(by.id('TotalBalance'))),
 			)
-				.toHaveText('49 111')
+				.toHaveText('50 111')
 				.withTimeout(10000);
 
 			// send funds to LND, 0 invoice
@@ -219,7 +219,7 @@ d('Lightning', () => {
 			await waitFor(
 				element(by.id('MoneyText').withAncestor(by.id('TotalBalance'))),
 			)
-				.toHaveText('49 000')
+				.toHaveText('50 000')
 				.withTimeout(10000);
 
 			// send funds to LND, 10000 invoice
@@ -246,7 +246,7 @@ d('Lightning', () => {
 			await waitFor(
 				element(by.id('MoneyText').withAncestor(by.id('TotalBalance'))),
 			)
-				.toHaveText('48 000')
+				.toHaveText('49 000')
 				.withTimeout(10000);
 
 			// check tx history
@@ -380,7 +380,7 @@ d('Lightning', () => {
 			await waitFor(
 				element(by.id('MoneyText').withAncestor(by.id('TotalBalance'))),
 			)
-				.toHaveText('48 000')
+				.toHaveText('49 000')
 				.withTimeout(10000);
 
 			// check tx history

--- a/src/components/Balances.tsx
+++ b/src/components/Balances.tsx
@@ -24,12 +24,12 @@ const Balances = (): ReactElement => {
 	const accountVersion = useAppSelector(accountVersionSelector);
 	const {
 		onchainBalance,
-		spendingBalance,
+		lightningBalance,
 		balanceInTransferToSpending,
 		balanceInTransferToSavings,
 	} = useBalance();
 
-	const canTransfer = (onchainBalance || spendingBalance) && !isGeoBlocked;
+	const canTransfer = (onchainBalance || lightningBalance) && !isGeoBlocked;
 
 	const onSavingsPress = (): void => {
 		navigation.navigate('Wallet', { screen: 'ActivitySavings' });
@@ -78,7 +78,7 @@ const Balances = (): ReactElement => {
 			</View>
 			<NetworkRow
 				title={t('details_spending_title')}
-				balance={spendingBalance}
+				balance={lightningBalance}
 				pendingBalance={balanceInTransferToSpending}
 				icon={<LightningCircleIcon width={32} height={32} />}
 				testID="ActivitySpending"

--- a/src/components/LightningChannel.tsx
+++ b/src/components/LightningChannel.tsx
@@ -18,7 +18,7 @@ const LightningChannel = ({
 	channel: TChannel;
 	status: TStatus;
 }): ReactElement => {
-	const { spendingAvailable, receivingAvailable, capacity } =
+	const { spendingTotal, receivingAvailable, capacity } =
 		useLightningChannelBalance(channel);
 
 	let spendingColor: keyof IThemeColors = 'purple50';
@@ -34,7 +34,7 @@ const LightningChannel = ({
 	}
 
 	const spendingAvailableStyle = {
-		width: `${100 * (spendingAvailable / capacity)}%` as DimensionValue,
+		width: `${100 * (spendingTotal / capacity)}%` as DimensionValue,
 	};
 
 	const receivingAvailableStyle = {
@@ -47,7 +47,7 @@ const LightningChannel = ({
 				<View style={styles.balance}>
 					<UpArrow color={spendingAvailableColor} width={14} height={14} />
 					<Money
-						sats={spendingAvailable}
+						sats={spendingTotal}
 						color={spendingAvailableColor}
 						size="captionB"
 						unit={EUnit.BTC}

--- a/src/hooks/lightning.ts
+++ b/src/hooks/lightning.ts
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 
 import { ellipsis } from '../utils/helpers';
 import { useAppSelector } from '../hooks/redux';
-import { TUseChannelBalance } from '../store/types/lightning';
 import { usePaidBlocktankOrders } from './blocktank';
 import {
 	channelsSelector,
@@ -45,20 +44,16 @@ export const useLightningBalance = (
 
 /**
  * Returns channel balance information for a given channel.
- * @param {TChannel} channel
- * @returns {TUseChannelBalance}
  */
 export const useLightningChannelBalance = (
 	channel: TChannel,
-): TUseChannelBalance => {
-	const balance: TUseChannelBalance = {
-		spendingTotal: 0, // How many sats the user has reserved in the channel. (Outbound capacity + Punishment Reserve)
-		spendingAvailable: 0, // How much the user is able to spend from a channel. (Outbound capacity - Punishment Reserve)
-		receivingTotal: 0, // How many sats the counterparty has reserved in the channel. (Inbound capacity + Punishment Reserve)
-		receivingAvailable: 0, // How many sats the user is able to receive in a channel. (Inbound capacity - Punishment Reserve)
-		capacity: 0, // Total capacity of the channel. (spendingTotal + receivingTotal)
-	};
-
+): {
+	spendingTotal: number; // How many sats the user has reserved in the channel. (Outbound capacity + Punishment Reserve)
+	spendingAvailable: number; // How much the user is able to spend from a channel. (Outbound capacity - Punishment Reserve)
+	receivingTotal: number; // How many sats the counterparty has reserved in the channel. (Inbound capacity + Punishment Reserve)
+	receivingAvailable: number; // How many sats the user is able to receive in a channel. (Inbound capacity - Punishment Reserve)
+	capacity: number; // Total capacity of the channel. (spendingTotal + receivingTotal)
+} => {
 	const {
 		channel_value_satoshis,
 		balance_sat,
@@ -70,13 +65,13 @@ export const useLightningChannelBalance = (
 	// user punishment reserve balance
 	const localReserve = unspendable_punishment_reserve ?? 0;
 
-	balance.spendingTotal = outbound_capacity_sat + localReserve;
-	balance.spendingAvailable = outbound_capacity_sat;
-	balance.receivingTotal = channel_value_satoshis - balance_sat;
-	balance.receivingAvailable = inbound_capacity_sat;
-	balance.capacity = channel_value_satoshis;
-
-	return balance;
+	return {
+		spendingTotal: outbound_capacity_sat + localReserve,
+		spendingAvailable: outbound_capacity_sat,
+		receivingTotal: channel_value_satoshis - balance_sat,
+		receivingAvailable: inbound_capacity_sat,
+		capacity: channel_value_satoshis,
+	};
 };
 
 /**

--- a/src/hooks/wallet.ts
+++ b/src/hooks/wallet.ts
@@ -78,8 +78,7 @@ export const useBalance = (): {
 		inTransferToSpending = 0;
 	}
 
-	// we don't include the LN reserve balance in the total balance
-	const totalBalance = onchainBalance + spendingBalance + inTransferToSpending;
+	const totalBalance = onchainBalance + lightningBalance + inTransferToSpending;
 
 	return {
 		onchainBalance,

--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -230,7 +230,7 @@ const Channels = ({
 
 	const colors = useColors();
 	const { onchainBalance } = useBalance();
-	const { localBalance, remoteBalance } = useLightningBalance(false);
+	const { localBalance, remoteBalance } = useLightningBalance();
 	const selectedWallet = useAppSelector(selectedWalletSelector);
 	const selectedNetwork = useAppSelector(selectedNetworkSelector);
 	const enableDevOptions = useAppSelector(enableDevOptionsSelector);

--- a/src/store/types/lightning.ts
+++ b/src/store/types/lightning.ts
@@ -60,14 +60,6 @@ export type TLightningNodeVersion = {
 	c_bindings: string;
 };
 
-export type TUseChannelBalance = {
-	spendingTotal: number; // How many sats the user has reserved in the channel. (Outbound capacity + Punishment Reserve)
-	spendingAvailable: number; // How much the user is able to spend from a channel. (Outbound capacity - Punishment Reserve)
-	receivingTotal: number; // How many sats the counterparty has reserved in the channel. (Inbound capacity + Punishment Reserve)
-	receivingAvailable: number; // How many sats the user is able to receive in a channel. (Inbound capacity - Punishment Reserve)
-	capacity: number; // Total capacity of the channel. (spendingTotal + receivingTotal)
-};
-
 export type TChannels = {
 	[id: string]: TChannel;
 };

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -1488,9 +1488,9 @@ export const getBalance = ({
 	});
 	const claimableBalances = node?.claimableBalances[selectedNetwork];
 
-	// Get the total spending & reserved balance of all open channels
-	const { localBalance: spendingBalance } = getLightningBalance();
+	const { localBalance } = getLightningBalance();
 	const reserveBalance = getLightningReserveBalance();
+	const spendingBalance = localBalance - reserveBalance;
 
 	// TODO: filter out some types of claimable balances
 	const result = reduceValue(claimableBalances, 'amount_satoshis');
@@ -1498,9 +1498,9 @@ export const getBalance = ({
 
 	const onchainBalance =
 		wallet.getBalance() ?? currentWallet.balance[selectedNetwork];
-	const lightningBalance = spendingBalance + claimableBalance;
-	const spendableBalance = onchainBalance + spendingBalance - reserveBalance;
-	const totalBalance = onchainBalance + spendingBalance + claimableBalance;
+	const lightningBalance = localBalance + claimableBalance;
+	const spendableBalance = onchainBalance + spendingBalance;
+	const totalBalance = onchainBalance + lightningBalance;
 
 	return {
 		onchainBalance,


### PR DESCRIPTION
### Description

Include unspendable punishment reserve in total balance and other cumulative lightning balances, subtract from max amount in send flow. Since we don't know exact routing fees at the moment the max amount will be an estimation.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/8538369/d322d4e1-ddac-4795-a0f2-86b62a565f73

### QA Notes

Make sure balances add up.