### PR TITLE
refactor(wallet): Remove Autopilot Coin Selection Options

### DIFF
--- a/src/screens/Settings/CoinSelectPreference/index.tsx
+++ b/src/screens/Settings/CoinSelectPreference/index.tsx
@@ -5,16 +5,13 @@ import { useTranslation } from 'react-i18next';
 import { EItemType, IListData } from '../../../components/List';
 import SettingsView from '../SettingsView';
 import { updateSettings } from '../../../store/slices/settings';
-import {
-	coinSelectAutoSelector,
-	coinSelectPreferenceSelector,
-} from '../../../store/reselect/settings';
+import { coinSelectAutoSelector } from '../../../store/reselect/settings';
 
 const CoinSelectSettings = (): ReactElement => {
 	const { t } = useTranslation('settings');
 	const dispatch = useAppDispatch();
 	const selectedAutoPilot = useAppSelector(coinSelectAutoSelector);
-	const coinSelectPreference = useAppSelector(coinSelectPreferenceSelector);
+	//const coinSelectPreference = useAppSelector(coinSelectPreferenceSelector);
 
 	const settingsListData: IListData[] = useMemo(
 		() => [
@@ -39,58 +36,59 @@ const CoinSelectSettings = (): ReactElement => {
 					},
 				],
 			},
-			{
-				title: selectedAutoPilot ? t('adv.cs_auto_mode') : '',
-				data: [
-					{
-						title: t('adv.cs_max'),
-						description: t('adv.cs_max_description'),
-						value: coinSelectPreference === 'large',
-						type: EItemType.button,
-						hide: !selectedAutoPilot,
-						onPress: (): void => {
-							dispatch(
-								updateSettings({
-									coinSelectAuto: true,
-									coinSelectPreference: 'large',
-								}),
-							);
-						},
+			/*{
+			// TODO: Re-Add and enable this feature once thoroughly tested in Beignet.
+			title: selectedAutoPilot ? t('adv.cs_auto_mode') : '',
+			data: [
+				{
+					title: t('adv.cs_max'),
+					description: t('adv.cs_max_description'),
+					value: coinSelectPreference === 'large',
+					type: EItemType.button,
+					hide: !selectedAutoPilot,
+					onPress: (): void => {
+						dispatch(
+							updateSettings({
+								coinSelectAuto: true,
+								coinSelectPreference: 'large',
+							}),
+						);
 					},
-					{
-						title: t('adv.cs_min'),
-						description: t('adv.cs_min_description'),
-						value: coinSelectPreference === 'small',
-						type: EItemType.button,
-						hide: !selectedAutoPilot,
-						onPress: (): void => {
-							dispatch(
-								updateSettings({
-									coinSelectAuto: true,
-									coinSelectPreference: 'small',
-								}),
-							);
-						},
+				},
+				{
+					title: t('adv.cs_min'),
+					description: t('adv.cs_min_description'),
+					value: coinSelectPreference === 'small',
+					type: EItemType.button,
+					hide: !selectedAutoPilot,
+					onPress: (): void => {
+						dispatch(
+							updateSettings({
+								coinSelectAuto: true,
+								coinSelectPreference: 'small',
+							}),
+						);
 					},
-					{
-						title: t('adv.cs_consolidate'),
-						description: t('adv.cs_consolidate_description'),
-						value: coinSelectPreference === 'consolidate',
-						type: EItemType.button,
-						hide: !selectedAutoPilot,
-						onPress: (): void => {
-							dispatch(
-								updateSettings({
-									coinSelectAuto: true,
-									coinSelectPreference: 'consolidate',
-								}),
-							);
-						},
+				},
+				{
+					title: t('adv.cs_consolidate'),
+					description: t('adv.cs_consolidate_description'),
+					value: coinSelectPreference === 'consolidate',
+					type: EItemType.button,
+					hide: !selectedAutoPilot,
+					onPress: (): void => {
+						dispatch(
+							updateSettings({
+								coinSelectAuto: true,
+								coinSelectPreference: 'consolidate',
+							}),
+						);
 					},
-				],
-			},
+				},
+			],
+			},*/
 		],
-		[selectedAutoPilot, coinSelectPreference, t, dispatch],
+		[selectedAutoPilot, t, dispatch],
 	);
 
 	return (


### PR DESCRIPTION
### Description
- Comments out autopilot options in the `CoinSelectPreference` component until these features are more thoroughly tested and vetted in Beignet.

### Linked Issues/Tasks

Add any links to GitHub issues or Asana tasks that are relevant to this pull request.

### Type of change
- [x] Refactoring (improving code without creating new functionality)

### Tests
- [x] No test

### QA Notes
Autopilot options should be removed from Settings->Advanced->Coin Selection.

![Simulator Screenshot - iPhone 15 - 2024-04-30 at 10 57 15](https://github.com/synonymdev/bitkit/assets/8532651/2feedae0-a6a6-493d-9c0b-3cc4c1e26c4e)


