### PR TITLE
fix(settings): prevent crash on channels screen

### DIFF
--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -243,7 +243,7 @@ const Channels = ({
 	const closedChannels = useAppSelector(closedChannelsSelector);
 	const isGeoBlocked = useAppSelector(isGeoBlockedSelector);
 	const blocktankNodeKey = useAppSelector((state) => {
-		return state.blocktank.info.nodes[0].pubkey;
+		return state.blocktank.info.nodes[0]?.pubkey;
 	});
 
 	const { pendingOrders, failedOrders } = getPendingBlocktankChannels(


### PR DESCRIPTION
### Description

Simple patch for the support ticket `Error: Cannot read property 'pubkey' of undefined` submitted by JC, to prevent the app from crashing.

The underlying cause here seems to be a rather illegal state in the app's redux store, which should have a `ILspNode` object in `state.blocktank.info.nodes[0]` at this point.

Hard for me to tell what could've caused the illegal state, but I don't expect this to be a regular issue nor heard of it before.

We should keep an eye if this occurs again, since there's more places where we read this state object and always expect it to be non-nullable.

### Linked Issues/Tasks

[Error: Cannot read property 'pubkey' of undefined](https://app.asana.com/0/1189635884316057/1207078246603120/f)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Tests

- [x] No test

### QA Notes

Unlikely to have a way to test this fix with reproducing the issue it solves, but we can always trust TypeScript's null safety operator `?.`, can't we? 😅 