### PR TITLE
fix: create RBF by default, do not allow fee smaller than minimum

### DIFF
--- a/src/navigation/bottom-sheet/SendNavigation.tsx
+++ b/src/navigation/bottom-sheet/SendNavigation.tsx
@@ -117,7 +117,7 @@ const SendNavigation = (): ReactElement => {
 		if (!transaction?.lightningInvoice) {
 			await updateOnchainFeeEstimates({ selectedNetwork, forceUpdate: true });
 			if (!transaction?.inputs.length) {
-				await setupOnChainTransaction();
+				await setupOnChainTransaction({ rbf: true });
 			}
 			setupFeeForOnChainTransaction();
 		}

--- a/src/screens/Wallets/Send/Amount.tsx
+++ b/src/screens/Wallets/Send/Amount.tsx
@@ -109,6 +109,7 @@ const Amount = ({ navigation }: SendScreenProps<'Amount'>): ReactElement => {
 					utxos,
 					satsPerByte: transaction.satsPerByte,
 					outputs: [output],
+					rbf: true,
 				});
 				const result = getNumberPadText(0, denomination, unit);
 				setText(result);

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -58,6 +58,7 @@
 	"send_fee_speed": "Speed",
 	"send_fee_error": "Fee Invalid",
 	"max_possible_fee_rate": "Max possible fee rate",
+	"min_possible_fee_rate": "Min possible fee rate",
 	"sats_per_vbyte": "sats/vbyte",
 	"send_output_to_small_title": "Send Amount Too Small",
 	"send_output_to_small_description": "Please increase your send amount to proceed.",

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -616,7 +616,7 @@ export const processBitcoinTransactionData = async ({
 	try {
 		// Reset existing transaction state and prepare for a new one.
 		await resetSendTransaction();
-		await setupOnChainTransaction({});
+		await setupOnChainTransaction({ rbf: true });
 
 		let response;
 		let error: ToastOptions | undefined; //Information that will be passed as a notification.


### PR DESCRIPTION
### Description

- Use RBF when scanning or entering address by hand
- Do not use RBF in case of paying for BT channel
- Do not allow set fee bellow mempool.space minimum fee in FeeCustom screen 

### Linked Issues/Tasks

#1741

### Type of change

Bug fix

### Tests

No test

### QA Notes

Make sure new tx is RBF, test RBF fee bump
