### PR TITLE
refactor(lightning): Remove LDK Account Version Checks

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1629,7 +1629,7 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   sodium-react-native-direct: 102289e2a55688b5c6c489c88b2a7915d4e31ec1
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
-  Yoga: e5b887426cee15d2a326bdd34afc0282fc0486ad
+  Yoga: 2a16e58450c48e110211dae1159fb114bbcdcfc0
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 36b98823c4a3ba66ee1a0fe7afdf6d3486c78651

--- a/src/components/Balances.tsx
+++ b/src/components/Balances.tsx
@@ -14,14 +14,11 @@ import { useBalance } from '../hooks/wallet';
 import { useAppSelector } from '../hooks/redux';
 import { RootNavigationProp } from '../navigation/types';
 import { isGeoBlockedSelector } from '../store/reselect/user';
-import { accountVersionSelector } from '../store/reselect/lightning';
-import { showToast } from '../utils/notifications';
 
 const Balances = (): ReactElement => {
 	const { t } = useTranslation('wallet');
 	const navigation = useNavigation<RootNavigationProp>();
 	const isGeoBlocked = useAppSelector(isGeoBlockedSelector);
-	const accountVersion = useAppSelector(accountVersionSelector);
 	const {
 		onchainBalance,
 		lightningBalance,
@@ -40,15 +37,6 @@ const Balances = (): ReactElement => {
 	};
 
 	const onTransfer = (): void => {
-		if (accountVersion < 2) {
-			showToast({
-				type: 'warning',
-				title: t('migrating_ldk_title'),
-				description: t('migrating_ldk_description'),
-			});
-			return;
-		}
-
 		if (canTransfer) {
 			navigation.navigate('LightningRoot', { screen: 'QuickSetup' });
 		}

--- a/src/screens/Lightning/Introduction.tsx
+++ b/src/screens/Lightning/Introduction.tsx
@@ -3,9 +3,6 @@ import { Trans, useTranslation } from 'react-i18next';
 
 import { Display } from '../../styles/text';
 import OnboardingScreen from '../../components/OnboardingScreen';
-import { useAppSelector } from '../../hooks/redux';
-import { showToast } from '../../utils/notifications';
-import { accountVersionSelector } from '../../store/reselect/lightning';
 import type { LightningScreenProps } from '../../navigation/types';
 
 const imageSrc = require('../../assets/illustrations/lightning.png');
@@ -14,18 +11,8 @@ const Introduction = ({
 	navigation,
 }: LightningScreenProps<'Introduction'>): ReactElement => {
 	const { t } = useTranslation('lightning');
-	const accountVersion = useAppSelector(accountVersionSelector);
 
 	const onContinue = (): void => {
-		if (accountVersion < 2) {
-			showToast({
-				type: 'warning',
-				title: t('migrating_ldk_title'),
-				description: t('migrating_ldk_description'),
-			});
-			return;
-		}
-
 		navigation.navigate('Funding');
 	};
 

--- a/src/screens/Settings/DevSettings/index.tsx
+++ b/src/screens/Settings/DevSettings/index.tsx
@@ -17,20 +17,15 @@ import { resetUserState } from '../../../store/slices/user';
 import { resetActivityState } from '../../../store/slices/activity';
 import { resetBlocktankState } from '../../../store/slices/blocktank';
 import { resetFeesState } from '../../../store/slices/fees';
-import {
-	updateLdkAccountVersion,
-	resetLightningState,
-} from '../../../store/slices/lightning';
+import { resetLightningState } from '../../../store/slices/lightning';
 import { resetMetadataState } from '../../../store/slices/metadata';
 import { resetSettingsState } from '../../../store/slices/settings';
 import { resetSlashtagsState } from '../../../store/slices/slashtags';
 import { resetWidgetsState } from '../../../store/slices/widgets';
-import { updateLightningNodeIdThunk } from '../../../store/utils/lightning';
 import { resetTodosState } from '../../../store/slices/todos';
 import { wipeApp } from '../../../store/utils/settings';
 import { getStore, getWalletStore } from '../../../store/helpers';
 import { warningsSelector } from '../../../store/reselect/checks';
-import { accountVersionSelector } from '../../../store/reselect/lightning';
 import {
 	addressTypeSelector,
 	selectedNetworkSelector,
@@ -45,7 +40,6 @@ import { zipLogs } from '../../../utils/lightning/logs';
 import { runChecks } from '../../../utils/wallet/checks';
 import { showToast } from '../../../utils/notifications';
 import { getFakeTransaction } from '../../../utils/wallet/testing';
-import { createDefaultLdkAccount, setupLdk } from '../../../utils/lightning';
 import Dialog from '../../../components/Dialog';
 import { resetBackupState } from '../../../store/slices/backup';
 import { updateUi } from '../../../store/slices/ui';
@@ -60,7 +54,6 @@ const DevSettings = ({
 	const selectedWallet = useAppSelector(selectedWalletSelector);
 	const selectedNetwork = useAppSelector(selectedNetworkSelector);
 	const addressType = useAppSelector(addressTypeSelector);
-	const accountVersion = useAppSelector(accountVersionSelector);
 	const isProfiling = useAppSelector((state) => state.ui.isProfiling);
 	const warnings = useAppSelector((state) => {
 		return warningsSelector(state, selectedWallet, selectedNetwork);
@@ -244,55 +237,6 @@ const DevSettings = ({
 					type: EItemType.textButton,
 					value: '',
 					testID: 'Warnings',
-				},
-			],
-		},
-		{
-			title: 'LDK Account Migration',
-			data: [
-				{
-					title: `LDK Account Version: ${accountVersion}`,
-					type: EItemType.textButton,
-					value: '',
-					testID: 'LDKAccountVersion',
-				},
-				{
-					title: 'Force LDK V2 Account Migration',
-					type: EItemType.button,
-					testID: 'ForceV2Migration',
-					onPress: async (): Promise<void> => {
-						dispatch(updateLdkAccountVersion(2));
-						await createDefaultLdkAccount({
-							version: 2,
-							selectedWallet,
-							selectedNetwork,
-						});
-						await setupLdk({
-							selectedWallet,
-							selectedNetwork,
-							shouldRefreshLdk: true,
-						});
-						await updateLightningNodeIdThunk();
-					},
-				},
-				{
-					title: 'Revert to LDK V1 Account',
-					type: EItemType.button,
-					testID: 'RevertToLDKV1',
-					onPress: async (): Promise<void> => {
-						dispatch(updateLdkAccountVersion(1));
-						await createDefaultLdkAccount({
-							version: 1,
-							selectedWallet,
-							selectedNetwork,
-						});
-						await setupLdk({
-							selectedWallet,
-							selectedNetwork,
-							shouldRefreshLdk: true,
-						});
-						await updateLightningNodeIdThunk();
-					},
 				},
 			],
 		},

--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -61,7 +61,6 @@ import {
 } from '../../../store/reselect/wallet';
 import {
 	closedChannelsSelector,
-	accountVersionSelector,
 	openChannelsSelector,
 	pendingChannelsSelector,
 } from '../../../store/reselect/lightning';
@@ -234,7 +233,6 @@ const Channels = ({
 	const selectedWallet = useAppSelector(selectedWalletSelector);
 	const selectedNetwork = useAppSelector(selectedNetworkSelector);
 	const enableDevOptions = useAppSelector(enableDevOptionsSelector);
-	const accountVersion = useAppSelector(accountVersionSelector);
 
 	const blocktankOrders = useAppSelector(blocktankOrdersSelector);
 	const paidOrders = useAppSelector(blocktankPaidOrdersSelector);
@@ -254,14 +252,6 @@ const Channels = ({
 	const pendingConnections = [...pendingOrders, ...pendingChannels];
 
 	const handleAdd = useCallback((): void => {
-		if (accountVersion < 2) {
-			showToast({
-				type: 'warning',
-				title: t('migrating_ldk_title'),
-				description: t('migrating_ldk_description'),
-			});
-			return;
-		}
 		navigation.navigate('LightningRoot', {
 			screen: 'CustomSetup',
 			params: { spending: true },
@@ -269,7 +259,7 @@ const Channels = ({
 
 		// TODO: Update this view once we enable creating channels with nodes other than Blocktank.
 		// navigation.navigate('LightningAddConnection');
-	}, [accountVersion, navigation, t]);
+	}, [navigation]);
 
 	const handleExportLogs = useCallback(async (): Promise<void> => {
 		const result = await zipLogs();

--- a/src/screens/Wallets/Receive/ReceiveDetails.tsx
+++ b/src/screens/Wallets/Receive/ReceiveDetails.tsx
@@ -36,7 +36,6 @@ import { createCJitEntry } from '../../../utils/blocktank';
 import { blocktankInfoSelector } from '../../../store/reselect/blocktank';
 import { isGeoBlockedSelector } from '../../../store/reselect/user';
 import { useLightningBalance } from '../../../hooks/lightning';
-import { accountVersionSelector } from '../../../store/reselect/lightning';
 import {
 	denominationSelector,
 	nextUnitSelector,
@@ -65,7 +64,6 @@ const ReceiveDetails = ({
 	const blocktank = useAppSelector(blocktankInfoSelector);
 	const lightningBalance = useLightningBalance(false);
 	const isGeoBlocked = useAppSelector(isGeoBlockedSelector);
-	const accountVersion = useAppSelector(accountVersionSelector);
 
 	const { maxChannelSizeSat } = blocktank.options;
 	const minChannelSize = Math.round(2.5 * invoice.amount);
@@ -84,8 +82,7 @@ const ReceiveDetails = ({
 		if (
 			!enableInstant ||
 			isGeoBlocked ||
-			lightningBalance.remoteBalance >= invoice.amount ||
-			accountVersion < 2
+			lightningBalance.remoteBalance >= invoice.amount
 		) {
 			return;
 		}
@@ -115,7 +112,6 @@ const ReceiveDetails = ({
 		invoice.amount,
 		invoice.message,
 		isGeoBlocked,
-		accountVersion,
 		lightningBalance.remoteBalance,
 		navigation,
 		dispatch,

--- a/src/screens/Wallets/Receive/ReceiveQR.tsx
+++ b/src/screens/Wallets/Receive/ReceiveQR.tsx
@@ -63,7 +63,6 @@ import {
 import { receiveSelector } from '../../../store/reselect/receive';
 import { ReceiveScreenProps } from '../../../navigation/types';
 import { isGeoBlockedSelector } from '../../../store/reselect/user';
-import { accountVersionSelector } from '../../../store/reselect/lightning';
 import { getWalletStore } from '../../../store/helpers';
 
 type Slide = () => ReactElement;
@@ -89,7 +88,6 @@ const ReceiveQR = ({
 	const selectedAddressType = useAppSelector(addressTypeSelector);
 	const addressType = useAppSelector(addressTypeSelector);
 	const isGeoBlocked = useAppSelector(isGeoBlockedSelector);
-	const accountVersion = useAppSelector(accountVersionSelector);
 	const { id, amount, message, tags, jitOrder } =
 		useAppSelector(receiveSelector);
 	const lightningBalance = useLightningBalance(false);
@@ -118,8 +116,7 @@ const ReceiveQR = ({
 		if (
 			!receiveNavigationIsOpen ||
 			!lightningBalance.remoteBalance ||
-			lightningBalance.remoteBalance < amount ||
-			accountVersion < 2
+			lightningBalance.remoteBalance < amount
 		) {
 			return;
 		}
@@ -337,11 +334,8 @@ const ReceiveQR = ({
 	const qrSize = Math.min(qrMaxWidth, qrMaxHeight);
 
 	const displayReceiveInstantlySwitch = useMemo((): boolean => {
-		if (accountVersion < 2) {
-			return false;
-		}
 		return !(isGeoBlocked && !lightningBalance.remoteBalance);
-	}, [isGeoBlocked, accountVersion, lightningBalance.remoteBalance]);
+	}, [isGeoBlocked, lightningBalance.remoteBalance]);
 
 	const QrIcon = useCallback((): ReactElement => {
 		return (

--- a/src/store/types/lightning.ts
+++ b/src/store/types/lightning.ts
@@ -17,7 +17,7 @@ export type TCreateLightningInvoice = TCreatePaymentReq & {
 	selectedWallet?: TWalletName;
 };
 
-export type TLdkAccountVersion = 1 | 2;
+export type TLdkAccountVersion = 1;
 
 export enum EChannelStatus {
 	open = 'open',

--- a/src/store/utils/backup.ts
+++ b/src/store/utils/backup.ts
@@ -19,7 +19,6 @@ import {
 import { bytesToString } from '../../utils/converters';
 import { isObjPartialMatch } from '../../utils/helpers';
 import {
-	checkAccountVersion,
 	getLdkAccount,
 	setAccount,
 	setLdkStoragePath,
@@ -76,8 +75,7 @@ export const performLdkRestore = async ({
 		return err(storageRes.error);
 	}
 
-	const version = await checkAccountVersion();
-	const lightningAccount = await getLdkAccount({ selectedNetwork, version });
+	const lightningAccount = await getLdkAccount({ selectedNetwork });
 	if (lightningAccount.isErr()) {
 		return err(lightningAccount.error);
 	}
@@ -233,8 +231,7 @@ export const performFullRestoreFromLatestBackup = async (
 				network = ENetworks.regtest;
 				break;
 		}
-		const version = await checkAccountVersion();
-		const lightningAccount = await getLdkAccount({ selectedNetwork, version });
+		const lightningAccount = await getLdkAccount({ selectedNetwork });
 		if (lightningAccount.isErr()) {
 			return err(lightningAccount.error);
 		}

--- a/src/utils/ledger.ts
+++ b/src/utils/ledger.ts
@@ -48,10 +48,10 @@ export const getChannelCloseTime = async (
 	}
 
 	// search for channel address
-	const vout = fundingTx.result.vout[funding_txo_index];
-	if (!vout) {
+	if (!fundingTx.result?.vout?.[funding_txo_index]) {
 		return err('channel address not found');
 	}
+	const vout = fundingTx.result.vout[funding_txo_index];
 	const address = vout.scriptPubKey.address;
 	if (!address) {
 		return err('channel address not found');

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -38,6 +38,7 @@ import {
 	transactionExists,
 } from '../wallet/electrum';
 import {
+	getBip39Passphrase,
 	getCurrentAddressIndex,
 	getMnemonicPhrase,
 	getOnChainWalletData,
@@ -55,11 +56,7 @@ import {
 	getWalletStore,
 } from '../../store/helpers';
 import { defaultHeader } from '../../store/shapes/wallet';
-import {
-	updateBackupState,
-	updateLdkAccountVersion,
-	updateLightningNodeId,
-} from '../../store/slices/lightning';
+import { updateBackupState } from '../../store/slices/lightning';
 import {
 	moveMetaIncPaymentTags,
 	removePeer,
@@ -86,14 +83,12 @@ import { closeSheet, updateUi } from '../../store/slices/ui';
 import { showBottomSheet } from '../../store/utils/ui';
 import { updateSlashPayConfig2 } from '../slashtags2';
 import {
-	TLdkAccountVersion,
 	TLightningNodeVersion,
 	TChannel,
 	EChannelStatus,
 } from '../../store/types/lightning';
 import { getBlocktankInfo, isGeoBlocked, logToBlocktank } from '../blocktank';
 import { refreshOnchainFeeEstimates } from '../../store/utils/fees';
-import { reportLdkChannelMigrations } from '../checks';
 import {
 	__BACKUPS_SERVER_HOST__,
 	__BACKUPS_SERVER_PUBKEY__,
@@ -172,7 +167,6 @@ export const wipeLdkStorage = async ({
 };
 
 const LDK_ACCOUNT_SUFFIX_V1 = 'ldkaccount';
-const LDK_ACCOUNT_SUFFIX_V2 = 'ldkaccountv2';
 
 export const setLdkStoragePath = (): Promise<Result<string>> =>
 	lm.setBaseStoragePath(`${RNFS.DocumentDirectoryPath}/ldk/`);
@@ -258,13 +252,7 @@ export const setupLdk = async ({
 			dispatch(updateUi({ isLDKReady: false }));
 		}
 
-		const accountVersion = await checkAccountVersion(
-			selectedWallet,
-			selectedNetwork,
-		);
-
 		const account = await getLdkAccount({
-			version: accountVersion,
 			selectedWallet,
 			selectedNetwork,
 		});
@@ -368,12 +356,6 @@ export const setupLdk = async ({
 		}
 
 		subscribeToLightningPayments({
-			selectedWallet,
-			selectedNetwork,
-		});
-
-		await handleAccountMigrations({
-			accountVersion,
 			selectedWallet,
 			selectedNetwork,
 		});
@@ -693,11 +675,6 @@ export const refreshLdk = async ({
 
 		await updateClaimableBalancesThunk();
 
-		const accountVersion = getLightningStore()?.accountVersion;
-		if (!accountVersion || accountVersion < 2) {
-			// Attempt to migrate on refresh.
-			await migrateToLdkV2Account(selectedWallet, selectedNetwork);
-		}
 		dispatch(updateUi({ isLDKReady: true }));
 
 		resolveAllPendingRefreshPromises(ok(''));
@@ -720,7 +697,7 @@ export const setAccount = async ({
 	try {
 		if (!name) {
 			name = getSelectedWallet();
-			name = `${name}${LDK_ACCOUNT_SUFFIX_V2}`;
+			name = `${name}${LDK_ACCOUNT_SUFFIX_V1}`;
 		}
 		const account: TAccount = {
 			name,
@@ -743,33 +720,6 @@ export const setAccount = async ({
 };
 
 /**
- * Checks if v1 account exists in storage. Otherwise, updates to v2.
- * @param {TWalletName} selectedWallet
- * @param {EAvailableNetwork} selectedNetwork
- * @returns {Promise<Result<string>>}
- */
-export const checkAccountVersion = async (
-	selectedWallet: TWalletName = getSelectedWallet(),
-	selectedNetwork: EAvailableNetwork = getSelectedNetwork(),
-): Promise<TLdkAccountVersion> => {
-	let accountVersion = getLightningStore().accountVersion;
-	if (accountVersion === 1) {
-		// Check if a v1 account exists in storage.
-		const v1AccountExists = await getExistingLdkAccount({
-			version: accountVersion,
-			selectedWallet,
-			selectedNetwork,
-		});
-		if (v1AccountExists.isErr()) {
-			// If no v1 account exists in storage, update version number.
-			dispatch(updateLdkAccountVersion(2));
-			accountVersion = 2;
-		}
-	}
-	return accountVersion;
-};
-
-/**
  * Retrieve LDK account info from storage.
  * @param {number} version
  * @param {boolean} shouldCreateAccount When set to true, it will create a new account if none is found.
@@ -777,18 +727,15 @@ export const checkAccountVersion = async (
  * @param {EAvailableNetwork} [selectedNetwork]
  */
 export const getLdkAccount = async ({
-	version = 2,
 	shouldCreateAccount = true,
 	selectedWallet = getSelectedWallet(),
 	selectedNetwork = getSelectedNetwork(),
 }: {
-	version?: TLdkAccountVersion;
 	shouldCreateAccount?: boolean;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 } = {}): Promise<Result<TAccount>> => {
 	const existingAccountRes = await getExistingLdkAccount({
-		version,
 		selectedWallet,
 		selectedNetwork,
 	});
@@ -802,15 +749,13 @@ export const getLdkAccount = async ({
 	}
 
 	// If no account was found, attempt to create one.
-	return createDefaultLdkAccount({ version, selectedWallet, selectedNetwork });
+	return createDefaultLdkAccount({ selectedWallet, selectedNetwork });
 };
 
 export const createDefaultLdkAccount = async ({
-	version,
 	selectedWallet = getSelectedWallet(),
 	selectedNetwork = getSelectedNetwork(),
 }: {
-	version: TLdkAccountVersion;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<TAccount>> => {
@@ -818,11 +763,12 @@ export const createDefaultLdkAccount = async ({
 	if (mnemonicPhrase.isErr()) {
 		return err(mnemonicPhrase.error.message);
 	}
-	const name = getLdkAccountName({ version, selectedWallet, selectedNetwork });
+	const bip39Passphrase = await getBip39Passphrase(selectedWallet);
+	const name = getLdkAccountName({ selectedWallet, selectedNetwork });
 	const defaultAccount = getDefaultLdkAccount({
 		name,
 		mnemonic: mnemonicPhrase.value,
-		version,
+		bip39Passphrase,
 	});
 	// Setup default account.
 	const setAccountResponse = await setAccount(defaultAccount);
@@ -836,21 +782,18 @@ export const createDefaultLdkAccount = async ({
 /**
  * Returns existing LDK account from storage.
  * Returns error if none exist.
- * @param {TLdkAccountVersion} version
  * @param {TWalletName} [selectedWallet]
  * @param {EAvailableNetwork} [selectedNetwork]
  * @returns {Promise<Result<TAccount>>}
  */
 const getExistingLdkAccount = async ({
-	version,
 	selectedWallet = getSelectedWallet(),
 	selectedNetwork = getSelectedNetwork(),
 }: {
-	version: TLdkAccountVersion;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<TAccount>> => {
-	const name = getLdkAccountName({ version, selectedWallet, selectedNetwork });
+	const name = getLdkAccountName({ selectedWallet, selectedNetwork });
 	const result = await Keychain.getGenericPassword({ service: name });
 	if (!!result && result?.password) {
 		// Return existing account.
@@ -860,209 +803,45 @@ const getExistingLdkAccount = async ({
 };
 
 /**
- * Attempts to migrate LDK accounts to the next version.
- * @param {TLdkAccountVersion} accountVersion
- * @param {TWalletName} selectedWallet
- * @param {EAvailableNetwork} selectedNetwork
- * @returns {Promise<void>}
- */
-const handleAccountMigrations = async ({
-	accountVersion,
-	selectedWallet = getSelectedWallet(),
-	selectedNetwork = getSelectedNetwork(),
-}: {
-	accountVersion: TLdkAccountVersion;
-	selectedWallet: TWalletName;
-	selectedNetwork: EAvailableNetwork;
-}): Promise<void> => {
-	if (accountVersion >= 2) {
-		return;
-	}
-	if (!__DEV__ && selectedNetwork !== 'bitcoin') {
-		// We only care about migrating mainnet accounts outside of development.
-		return;
-	}
-	if (accountVersion === 1) {
-		// Close v1 account and migrate to v2
-		await closeLdkV1Account(selectedWallet, selectedNetwork);
-	}
-};
-
-/**
- * Attempts to close all open channels and migrate to v2.
- * @param {TWalletName} selectedWallet
- * @param {EAvailableNetwork} selectedNetwork
- * @returns {Promise<Result<string>>}
- */
-const closeLdkV1Account = async (
-	selectedWallet = getSelectedWallet(),
-	selectedNetwork = getSelectedNetwork(),
-): Promise<Result<string>> => {
-	const channels = getOpenChannels();
-	if (channels.length) {
-		const closeRes = await closeAllChannels();
-		if (closeRes.isErr()) {
-			return err(closeRes.error.message);
-		}
-		if (closeRes.value.length) {
-			await reportLdkChannelMigrations({
-				channels: closeRes.value,
-				selectedNetwork,
-			});
-		}
-		await sleep(1000);
-		await lm.syncLdk();
-		await sleep(1000);
-	}
-	return migrateToLdkV2Account(selectedWallet, selectedNetwork);
-};
-
-let isMigrating = false;
-export const migrateToLdkV2Account = async (
-	selectedWallet: TWalletName,
-	selectedNetwork: EAvailableNetwork,
-): Promise<Result<string>> => {
-	if (isMigrating) {
-		return err('Currently Migrating.');
-	}
-	isMigrating = true;
-	try {
-		if (!__DEV__ && selectedNetwork !== 'bitcoin') {
-			return err('Only migrate if mainnet.');
-		}
-		const lightningBalance = getLightningBalance({
-			includeReserve: true,
-		});
-		const openChannels = getOpenChannels();
-		const claimableBalances = await getClaimableBalances();
-		const result = reduceValue(claimableBalances, 'amount_satoshis');
-		const claimableBalance = result.isOk() ? result.value : 0;
-
-		const nodeId = await getNodeId();
-		if (nodeId.isErr()) {
-			return err(nodeId.error.message);
-		}
-
-		if (
-			lightningBalance.localBalance ||
-			lightningBalance.remoteBalance ||
-			claimableBalance ||
-			openChannels.length
-		) {
-			return err('Not ready to migrate.');
-		}
-
-		const oldNodeId = await getNodeId();
-		if (oldNodeId.isErr()) {
-			return err(oldNodeId.error.message);
-		}
-		dispatch(updateLdkAccountVersion(2));
-		await sleep(1000);
-		await setupLdk({
-			selectedWallet,
-			selectedNetwork,
-			shouldRefreshLdk: false,
-		});
-		// Ensure the LDK Account was created.
-		const ldkAccount = await getLdkAccount({
-			version: 2,
-			selectedWallet,
-			selectedNetwork,
-		});
-		if (ldkAccount.isErr()) {
-			// Attempt to create the v2 account for the next retry.
-			await createDefaultLdkAccount({
-				version: 2,
-				selectedWallet,
-				selectedNetwork,
-			});
-			return err('Unable to get v2 LDK account.');
-		}
-		await ldk.stop();
-		await sleep(1000);
-		await refreshLdk({
-			selectedWallet,
-			selectedNetwork,
-		});
-		const newNodeId = await getNodeId();
-		if (newNodeId.isErr()) {
-			return err(newNodeId.error.message);
-		}
-		if (oldNodeId.value === newNodeId.value) {
-			// Revert version to try again later.
-			dispatch(updateLdkAccountVersion(1));
-			return err('Failed to migrate to v2.');
-		}
-		dispatch(
-			updateLightningNodeId({
-				nodeId: newNodeId.value,
-				selectedWallet,
-				selectedNetwork,
-			}),
-		);
-		return ok('Migrated to v2.');
-	} catch (e) {
-		return err(e);
-	} finally {
-		isMigrating = false;
-	}
-};
-
-/**
  * Retrieves LDK account name for the provided version, wallet and network.
- * @param {TLdkAccountVersion} version
  * @param {TWalletName} [selectedWallet]
  * @param {EAvailableNetwork} [selectedNetwork]
  * @returns {string}
  */
 export const getLdkAccountName = ({
-	version,
 	selectedWallet = getSelectedWallet(),
 	selectedNetwork = getSelectedNetwork(),
 }: {
-	version: TLdkAccountVersion;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
 }): string => {
-	const suffix = version === 1 ? LDK_ACCOUNT_SUFFIX_V1 : LDK_ACCOUNT_SUFFIX_V2;
-	return `${selectedWallet}${selectedNetwork}${suffix}`;
+	return `${selectedWallet}${selectedNetwork}${LDK_ACCOUNT_SUFFIX_V1}`;
 };
 
 /**
  * Returns the default LDK account for the provided name, mnemonic & version.
  * @param {string} name
  * @param {string} mnemonic
- * @param {TLdkAccountVersion} version
+ * @param {string} [bip39Passphrase]
  * @returns {TAccount}
  */
 export const getDefaultLdkAccount = ({
 	name,
 	mnemonic,
-	version,
+	bip39Passphrase,
 }: {
 	name: string;
 	mnemonic: string;
-	version: TLdkAccountVersion;
+	bip39Passphrase?: string;
 }): TAccount => {
-	switch (version) {
-		case 1:
-			// @ts-ignore
-			const ldkSeed = bitcoin.crypto.sha256(mnemonic).toString('hex');
-			return {
-				name,
-				seed: ldkSeed,
-			};
-		case 2:
-			return {
-				name,
-				seed: getSha256(mnemonic),
-			};
-		default:
-			return {
-				name,
-				seed: getSha256(mnemonic),
-			};
+	let seed = mnemonic;
+	if (bip39Passphrase) {
+		seed = `${mnemonic} ${bip39Passphrase}`;
 	}
+	return {
+		name,
+		seed: getSha256(seed),
+	};
 };
 
 /**

--- a/src/utils/scanner.ts
+++ b/src/utils/scanner.ts
@@ -23,7 +23,7 @@ import {
 	getOnchainTransactionData,
 	getTransactionInputValue,
 } from './wallet/transactions';
-import { dispatch, getLightningStore } from '../store/helpers';
+import { dispatch } from '../store/helpers';
 import { showToast, ToastOptions } from './notifications';
 import {
 	resetSendTransaction,
@@ -925,12 +925,6 @@ export const handleData = async ({
 			return ok({ type: qrDataType });
 		}
 		case EQRDataType.lnurlChannel: {
-			const accountVersion = getLightningStore().accountVersion;
-			if (accountVersion < 2) {
-				return err(
-					'LDK is currently in the process of migrating. Please restart your app, wait a few blocks and try again.',
-				);
-			}
 			const params = data.lnUrlParams! as LNURLChannelParams;
 			rootNavigation.navigate('LightningRoot', {
 				screen: 'LNURLChannel',
@@ -943,12 +937,6 @@ export const handleData = async ({
 			return await handleLnurlAuth({ params, selectedWallet, selectedNetwork });
 		}
 		case EQRDataType.lnurlWithdraw: {
-			const accountVersion = getLightningStore().accountVersion;
-			if (accountVersion < 2) {
-				return err(
-					'LDK is currently in the process of migrating. Please restart your app, wait a few blocks and try again.',
-				);
-			}
 			let params = data.lnUrlParams as LNURLWithdrawParams;
 
 			//Convert msats to sats.


### PR DESCRIPTION
### Description
- Removes LDK account migration and account version checks throughout app
- Now includes `bip39Passphrase` in `getDefaultLdkAccount` when creating LDK seed.

### Type of change
- [x] Refactoring (improving code without creating new functionality)

### Tests
- [x] No test

### QA Notes
- The LDK seed should now be generated using the correct v2 method by default. The LDK seed should now incorporate the bip39Passphrase when generating the seed prior to being hashed like so: `${mnemonic} ${bip39Passphrase}`
