### PR TITLE
fix: do not run refreshWallet until the wallet is initialized

### DIFF
--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -131,6 +131,20 @@ export const setupAddressGenerator = async ({
 	}
 };
 
+/*
+ * Wait for wallet to be ready
+ */
+const waitForWallet = async (): Promise<void> => {
+	if (wallet) {
+		return;
+	}
+	return new Promise((resolve) => {
+		setTimeout(() => {
+			resolve(waitForWallet());
+		}, 100);
+	});
+};
+
 export const refreshWallet = async ({
 	onchain = true,
 	lightning = true,
@@ -151,6 +165,8 @@ export const refreshWallet = async ({
 		await new Promise((resolve) => {
 			InteractionManager.runAfterInteractions(() => resolve(null));
 		});
+
+		await waitForWallet();
 
 		let notificationTxid: string | undefined;
 


### PR DESCRIPTION
### Description

Before initializing `wallet` in the `setupOnChainWallet` function, `wallet.refreshWallet` is called from the `getWalletData` callback. To avoid this, I am introducing a function to ensure that `wallet` is defined before running `refreshWallet`. Similar situations may arise, and we could consider changing the variable type to `TWallet | undefined` in the future. What are your thoughts, @coreyphillips?

### Linked Issues/Tasks



### Type of change

Bug fix

### Tests

No test

### Screenshot / Video


### QA Notes

Make sure that error `TypeError: Cannot read property 'refreshWallet' of undefined` doesn't appear on app start