### PR TITLE
fix(transfer): add validation for quick setup numberpad

### DIFF
--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -20,7 +20,7 @@ import FancySlider from '../../components/FancySlider';
 import TransferTextField from '../../components/TransferTextField';
 import NumberPadLightning from './NumberPadLightning';
 import { useAppSelector } from '../../hooks/redux';
-import { useSwitchUnit } from '../../hooks/wallet';
+import { useBalance, useSwitchUnit } from '../../hooks/wallet';
 import {
 	resetSendTransaction,
 	setupOnChainTransaction,
@@ -48,6 +48,7 @@ const QuickSetup = ({
 }: LightningScreenProps<'QuickSetup'>): ReactElement => {
 	const { t } = useTranslation('lightning');
 	const switchUnit = useSwitchUnit();
+	const { lightningBalance } = useBalance();
 	const unit = useAppSelector(unitSelector);
 	const nextUnit = useAppSelector(nextUnitSelector);
 	const conversionUnit = useAppSelector(conversionUnitSelector);
@@ -325,6 +326,7 @@ const QuickSetup = ({
 					<NumberPadLightning
 						style={styles.numberpad}
 						value={textFieldValue}
+						minAmount={lightningBalance}
 						maxAmount={lnSetup.slider.maxValue}
 						onChange={setTextFieldValue}
 						onChangeUnit={onChangeUnit}

--- a/src/utils/i18n/locales/en/lightning.json
+++ b/src/utils/i18n/locales/en/lightning.json
@@ -24,15 +24,9 @@
 		"title_numpad": "Spending <accent>Balance</accent>",
 		"text_slider": "Choose how much money you want to be able to spend instantly and how much you want to keep in savings.",
 		"text_numpad": "Enter the amount of money you want to be able to spend instantly.",
-		"swipe": "Swipe To Transfer"
-	},
-	"quick_setup": {
-		"nav_title": "Transfer Funds",
-		"title_slider": "Balance\n<accent>your funds</accent>",
-		"title_numpad": "Spending <accent>Balance</accent>",
-		"text_slider": "Choose how much money you want to be able to spend instantly and how much you want to keep in savings.",
-		"text_numpad": "Enter the amount of money you want to be able to spend instantly.",
-		"swipe": "Swipe To Transfer"
+		"swipe": "Swipe To Transfer",
+		"error_min_amount": "Spending amount needs to be at least ₿ {amount}",
+		"error_max_amount": "Spending amount needs to be smaller than ₿ {amount}"
 	},
 	"error_channel_purchase": "Instant Payments Setup Failed",
 	"error_channel_receiving": "Receiving amount needs to be greater than ${usdValue}",
@@ -134,7 +128,7 @@
 	"support": "Support",
 	"connection_closed": {
 		"title": "Connection Closed",
-		"description": "A Lightning Connection has closed. The funds will move back to your savings."
+		"description": "Your Lightning Connection has successfully closed. Your funds will be transferred to your savings."
 	},
 	"close_conn": "Close Connection",
 	"close_error": "Transfer Failed",


### PR DESCRIPTION
### Description

Adds validation for minimum amount when enter spending amount via numberpad in the QuickSetup.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/8538369/e764cc0e-4223-4b0c-b0b6-54c97103d571

### QA Notes

Make sure you can't continue with an invalid amount in the numberpad
