### PR TITLE
chore: replace flipper with reactotron

### DIFF
--- a/.env.development.template
+++ b/.env.development.template
@@ -1,14 +1,8 @@
-# middleware for redux-flipper plugin
-ENABLE_REDUX_FLIPPER=true
-
 # middleware for redux-logger
 ENABLE_REDUX_LOGGER=true
 
 # middleware for immutable-state-invariant (disable if things are slow in development)
 ENABLE_REDUX_IMMUTABLE_CHECK=true
-
-# react-native-mmkv-flipper-plugin
-ENABLE_MMKV_FLIPPER=false
 
 # i18next debug mode
 ENABLE_I18NEXT_DEBUGGER=false

--- a/.env.test.template
+++ b/.env.test.template
@@ -1,14 +1,8 @@
-# middleware for redux-flipper plugin
-ENABLE_REDUX_FLIPPER=false
-
 # middleware for redux-logger
 ENABLE_REDUX_LOGGER=false
 
 # middleware for immutable-state-invariant (disable if things are slow in development)
 ENABLE_REDUX_IMMUTABLE_CHECK=false
-
-# react-native-mmkv-flipper-plugin
-ENABLE_MMKV_FLIPPER=false
 
 # i18next debug mode
 ENABLE_I18NEXT_DEBUGGER=false

--- a/.github/workflows/e2e-ios-macmini.yml
+++ b/.github/workflows/e2e-ios-macmini.yml
@@ -7,7 +7,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NO_FLIPPER: 1
   E2E_TESTS: 1 # build without transform-remove-console babel plugin
   DEBUG: 'lnurl* lnurl server'
   MACMINI: 1 # use iPhone 15 in .detoxrc

--- a/.github/workflows/react-native-skia-stub.patch
+++ b/.github/workflows/react-native-skia-stub.patch
@@ -4,7 +4,6 @@ index 34d9af05..f30d8004 100644
 +++ b/package.json
 @@ -180,5 +180,8 @@
      "react-native-svg-transformer": "^1.3.0",
-     "redux-flipper": "^2.0.2",
      "typescript": "5.3.3"
 +  },
 +  "react-native": {

--- a/ReactotronConfig.js
+++ b/ReactotronConfig.js
@@ -1,0 +1,9 @@
+import Reactotron from 'reactotron-react-native';
+import { reactotronRedux } from 'reactotron-redux';
+
+const reactotron = Reactotron.configure()
+	.use(reactotronRedux())
+	.useReactNative()
+	.connect();
+
+export default reactotron;

--- a/__mocks__/reactotron-react-native.ts
+++ b/__mocks__/reactotron-react-native.ts
@@ -1,0 +1,8 @@
+const reactotron = {
+	configure: () => reactotron,
+	useReactNative: () => reactotron,
+	use: () => reactotron,
+	connect: () => reactotron,
+};
+
+module.exports = reactotron;

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -131,7 +131,6 @@ dependencies {
     implementation("com.facebook.react:react-android")
     implementation files("../../node_modules/@synonymdev/react-native-ldk/android/libs/LDK-release.aar")
     implementation "androidx.multidex:multidex:2.0.1"
-    implementation("com.facebook.react:flipper-integration")
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")

--- a/android/app/src/main/java/com/bitkit/MainApplication.kt
+++ b/android/app/src/main/java/com/bitkit/MainApplication.kt
@@ -9,7 +9,6 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
-import com.facebook.react.flipper.ReactNativeFlipper
 import com.facebook.soloader.SoLoader
 import com.bitkit.modules.SplashScreen.SplashScreenPackage;
 
@@ -42,6 +41,5 @@ class MainApplication : Application(), ReactApplication {
       // If you opted-in for the New Architecture, we load the native entry point for this app.
       load()
     }
-    ReactNativeFlipper.initializeFlipper(this, reactNativeHost.reactInstanceManager)
   }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -24,9 +24,6 @@ android.useAndroidX=true
 # Automatically convert third-party libraries to use AndroidX
 android.enableJetifier=true
 
-# Version of flipper SDK to use with React Native
-FLIPPER_VERSION=0.250.0
-
 # Use this property to specify which architecture you want to build.
 # You can also override it from the CLI using
 # ./gradlew <task> -PreactNativeArchitectures=x86_64

--- a/index.js
+++ b/index.js
@@ -10,11 +10,16 @@ import { gestureHandlerRootHOC } from 'react-native-gesture-handler';
 import Root from './src/Root';
 import { name as appName } from './app.json';
 import './src/utils/fetch-polyfill';
+import { __E2E__, __JEST__ } from './src/constants/env';
 
 // TEMP: disable font scaling globally
 Text.defaultProps = Text.defaultProps || {};
 Text.defaultProps.allowFontScaling = false;
 TextInput.defaultProps = TextInput.defaultProps || {};
 TextInput.defaultProps.allowFontScaling = false;
+
+if (__DEV__ && !__JEST__ && !__E2E__) {
+	require('./ReactotronConfig');
+}
 
 AppRegistry.registerComponent(appName, () => gestureHandlerRootHOC(Root));

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -20,17 +20,6 @@ setup_permissions([
   'PhotoLibrary',
 ])
 
-# If you are using a `react-native-flipper` your iOS build will fail when `NO_FLIPPER=1` is set.
-# because `react-native-flipper` depends on (FlipperKit,...) that will be excluded
-#
-# To fix this you can also exclude `react-native-flipper` using a `react-native.config.js`
-# ```js
-# module.exports = {
-#   dependencies: {
-#     ...(process.env.NO_FLIPPER ? { 'react-native-flipper': { platforms: { ios: null } } } : {}),
-# ```
-flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled(["Debug"], { 'Flipper' => '0.203.0' })
-
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil
   Pod::UI.puts "Configuring Pod with #{linkage}ally linked Frameworks".green
@@ -44,11 +33,6 @@ target 'bitkit' do
 
   use_react_native!(
     :path => config[:reactNativePath],
-    # Enables Flipper.
-    #
-    # Note that if you have use_frameworks! enabled, Flipper will not work and
-    # you should disable the next line.
-    :flipper_configuration => flipper_config,
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -10,62 +10,6 @@ PODS:
     - React-Core (= 0.73.8)
     - React-jsi (= 0.73.8)
     - ReactCommon/turbomodule/core (= 0.73.8)
-  - Flipper (0.203.0):
-    - Flipper-Folly (~> 2.6)
-  - Flipper-Boost-iOSX (1.76.0.1.11)
-  - Flipper-DoubleConversion (3.2.0.1)
-  - Flipper-Fmt (7.1.7)
-  - Flipper-Folly (2.6.10):
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt (= 7.1.7)
-    - Flipper-Glog
-    - libevent (~> 2.1.12)
-    - OpenSSL-Universal (= 1.1.1100)
-  - Flipper-Glog (0.5.0.5)
-  - Flipper-PeerTalk (0.0.4)
-  - FlipperKit (0.203.0):
-    - FlipperKit/Core (= 0.203.0)
-  - FlipperKit/Core (0.203.0):
-    - Flipper (~> 0.203.0)
-    - FlipperKit/CppBridge
-    - FlipperKit/FBCxxFollyDynamicConvert
-    - FlipperKit/FBDefines
-    - FlipperKit/FKPortForwarding
-    - SocketRocket (~> 0.6.0)
-  - FlipperKit/CppBridge (0.203.0):
-    - Flipper (~> 0.203.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (0.203.0):
-    - Flipper-Folly (~> 2.6)
-  - FlipperKit/FBDefines (0.203.0)
-  - FlipperKit/FKPortForwarding (0.203.0):
-    - CocoaAsyncSocket (~> 7.6)
-    - Flipper-PeerTalk (~> 0.0.4)
-  - FlipperKit/FlipperKitHighlightOverlay (0.203.0)
-  - FlipperKit/FlipperKitLayoutHelpers (0.203.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutTextSearchable
-  - FlipperKit/FlipperKitLayoutIOSDescriptors (0.203.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-  - FlipperKit/FlipperKitLayoutPlugin (0.203.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitHighlightOverlay
-    - FlipperKit/FlipperKitLayoutHelpers
-    - FlipperKit/FlipperKitLayoutIOSDescriptors
-    - FlipperKit/FlipperKitLayoutTextSearchable
-  - FlipperKit/FlipperKitLayoutTextSearchable (0.203.0)
-  - FlipperKit/FlipperKitNetworkPlugin (0.203.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitReactPlugin (0.203.0):
-    - FlipperKit/Core
-  - FlipperKit/FlipperKitUserDefaultsPlugin (0.203.0):
-    - FlipperKit/Core
-  - FlipperKit/SKIOSNetworkPlugin (0.203.0):
-    - FlipperKit/Core
-    - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
   - hermes-engine (0.73.8):
@@ -963,8 +907,6 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - react-native-flipper (0.212.0):
-    - React-Core
   - react-native-image-picker (7.1.2):
     - glog
     - RCT-Folly (= 2022.05.16.00)
@@ -1234,26 +1176,6 @@ DEPENDENCIES:
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/React/FBReactNativeSpec`)
-  - Flipper (= 0.203.0)
-  - Flipper-Boost-iOSX (= 1.76.0.1.11)
-  - Flipper-DoubleConversion (= 3.2.0.1)
-  - Flipper-Fmt (= 7.1.7)
-  - Flipper-Folly (= 2.6.10)
-  - Flipper-Glog (= 0.5.0.5)
-  - Flipper-PeerTalk (= 0.0.4)
-  - FlipperKit (= 0.203.0)
-  - FlipperKit/Core (= 0.203.0)
-  - FlipperKit/CppBridge (= 0.203.0)
-  - FlipperKit/FBCxxFollyDynamicConvert (= 0.203.0)
-  - FlipperKit/FBDefines (= 0.203.0)
-  - FlipperKit/FKPortForwarding (= 0.203.0)
-  - FlipperKit/FlipperKitHighlightOverlay (= 0.203.0)
-  - FlipperKit/FlipperKitLayoutPlugin (= 0.203.0)
-  - FlipperKit/FlipperKitLayoutTextSearchable (= 0.203.0)
-  - FlipperKit/FlipperKitNetworkPlugin (= 0.203.0)
-  - FlipperKit/FlipperKitReactPlugin (= 0.203.0)
-  - FlipperKit/FlipperKitUserDefaultsPlugin (= 0.203.0)
-  - FlipperKit/SKIOSNetworkPlugin (= 0.203.0)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - hermes-engine (from `../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec`)
   - libevent (~> 2.1.12)
@@ -1267,7 +1189,6 @@ DEPENDENCIES:
   - React-callinvoker (from `../node_modules/react-native/ReactCommon/callinvoker`)
   - React-Codegen (from `build/generated/ios`)
   - React-Core (from `../node_modules/react-native/`)
-  - React-Core/DevSupport (from `../node_modules/react-native/`)
   - React-Core/RCTWebSocket (from `../node_modules/react-native/`)
   - React-CoreModules (from `../node_modules/react-native/React/CoreModules`)
   - React-cxxreact (from `../node_modules/react-native/ReactCommon/cxxreact`)
@@ -1286,7 +1207,6 @@ DEPENDENCIES:
   - react-native-address-generator (from `../node_modules/react-native-address-generator`)
   - react-native-biometrics (from `../node_modules/react-native-biometrics`)
   - "react-native-blur (from `../node_modules/@react-native-community/blur`)"
-  - react-native-flipper (from `../node_modules/react-native-flipper`)
   - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - "react-native-ldk (from `../node_modules/@synonymdev/react-native-ldk`)"
   - react-native-mmkv (from `../node_modules/react-native-mmkv`)
@@ -1342,14 +1262,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - CocoaAsyncSocket
-    - Flipper
-    - Flipper-Boost-iOSX
-    - Flipper-DoubleConversion
-    - Flipper-Fmt
-    - Flipper-Folly
-    - Flipper-Glog
-    - Flipper-PeerTalk
-    - FlipperKit
     - fmt
     - libevent
     - lottie-ios
@@ -1424,8 +1336,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-biometrics"
   react-native-blur:
     :path: "../node_modules/@react-native-community/blur"
-  react-native-flipper:
-    :path: "../node_modules/react-native-flipper"
   react-native-image-picker:
     :path: "../node_modules/react-native-image-picker"
   react-native-ldk:
@@ -1535,14 +1445,6 @@ SPEC CHECKSUMS:
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
   FBLazyVector: df34a309e356a77581809834f6ec3fbe7153f620
   FBReactNativeSpec: bbe8b686178e5ce03d1d8a356789f211f91f31b8
-  Flipper: c70899db07015da7ec9025f29463a997a0184d01
-  Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
-  Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
-  Flipper-Fmt: 60cbdd92fc254826e61d669a5d87ef7015396a9b
-  Flipper-Folly: 584845625005ff068a6ebf41f857f468decd26b3
-  Flipper-Glog: 70c50ce58ddaf67dc35180db05f191692570f446
-  Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  FlipperKit: 2bd3b69628fedcbdc66766d0dac0a8abd2de5f8f
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
   hermes-engine: b12d9bb1b7cee546f5e48212e7ea7e3c1665a367
@@ -1576,7 +1478,6 @@ SPEC CHECKSUMS:
   react-native-address-generator: fef3a05e58c1185b892b7ebf1a95a11ffaab1733
   react-native-biometrics: 352e5a794bfffc46a0c86725ea7dc62deb085bdc
   react-native-blur: 799045500f56146afc46245148080e7b7623cb75
-  react-native-flipper: 9c1957af24b76493ba74f46d000a5c1d485e7731
   react-native-image-picker: d3db110a3ded6e48c93aef7e8e51afdde8b16ed0
   react-native-ldk: ae65e6ae9b7b5604256f3722e4aec9a40236d695
   react-native-mmkv: 1fdc81aa70c1aba09370718e6a63a09cbbbac8d2
@@ -1632,6 +1533,6 @@ SPEC CHECKSUMS:
   Yoga: e5b887426cee15d2a326bdd34afc0282fc0486ad
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: 36b98823c4a3ba66ee1a0fe7afdf6d3486c78651
+PODFILE CHECKSUM: a25ec9d4205c8710cfcf7ec52d853eaf4b026cc5
 
 COCOAPODS: 1.15.2

--- a/ios/bitkit.xcodeproj/project.pbxproj
+++ b/ios/bitkit.xcodeproj/project.pbxproj
@@ -12,16 +12,16 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		17074219BB5847259EAFC7A6 /* InterTight-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3815D562618543E7A9BC191E /* InterTight-Black.ttf */; };
+		2C3A289853B01446F26DE07D /* libPods-bitkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B5E78A0A99310328B7054CC /* libPods-bitkit.a */; };
 		57072143CA0F49089AE64F61 /* InterTight-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A223BA795CEB4CB2B344FBAF /* InterTight-ExtraBold.ttf */; };
 		6132EF182BDFF13200BBE14D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 6132EF172BDFF13200BBE14D /* PrivacyInfo.xcprivacy */; };
 		6980B602E6DC4429841BE5EE /* InterTight-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D67AECF5F543462F90EC89AD /* InterTight-Medium.ttf */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		8BD8301E3A1B44DDA3C8A10D /* Damion-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DEC74C5375A34FFCAEBA0781 /* Damion-Regular.ttf */; };
 		925570EA7B1D43CC8AD07B91 /* InterTight-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CA37793F82F144678099A00D /* InterTight-Bold.ttf */; };
+		92E54D2F4FA19238DC2A9EDD /* libPods-bitkit-bitkitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 767A7259F23E73A34CE34240 /* libPods-bitkit-bitkitTests.a */; };
 		9952E811473D46FB9003A56D /* InterTight-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 50A8DA09F2974D05A3C58E87 /* InterTight-SemiBold.ttf */; };
 		B3BE07A9843E4B7DA375B877 /* InterTight-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 79DFAC55B0D745DE815EC2E0 /* InterTight-Regular.ttf */; };
-		E1DFE188CAB27EE16BD2079E /* libPods-bitkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2633C924B358FFEC202323C3 /* libPods-bitkit.a */; };
-		FEBB7A6D5994CF5307DC444F /* libPods-bitkit-bitkitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F8111C09F74436DF8D3D1E39 /* libPods-bitkit-bitkitTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,28 +38,28 @@
 		00E356EE1AD99517003FC87E /* bitkitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = bitkitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* bitkitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bitkitTests.m; sourceTree = "<group>"; };
-		09381D26DB8142B34372A368 /* Pods-bitkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.debug.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.debug.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* bitkit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = bitkit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = bitkit/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = bitkit/AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = bitkit/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = bitkit/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = bitkit/main.m; sourceTree = "<group>"; };
-		2633C924B358FFEC202323C3 /* libPods-bitkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		285E05CC53D54CC69BD0938A /* Pods-bitkit-bitkitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.release.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.release.xcconfig"; sourceTree = "<group>"; };
+		289DE5FD62BC39314CD28A51 /* Pods-bitkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.release.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.release.xcconfig"; sourceTree = "<group>"; };
 		3815D562618543E7A9BC191E /* InterTight-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Black.ttf"; path = "../src/assets/fonts/InterTight-Black.ttf"; sourceTree = "<group>"; };
 		50A8DA09F2974D05A3C58E87 /* InterTight-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-SemiBold.ttf"; path = "../src/assets/fonts/InterTight-SemiBold.ttf"; sourceTree = "<group>"; };
+		5B5E78A0A99310328B7054CC /* libPods-bitkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		6132EF172BDFF13200BBE14D /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = bitkit/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		6427E31D398FA605AE553E14 /* Pods-bitkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.debug.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.debug.xcconfig"; sourceTree = "<group>"; };
+		767A7259F23E73A34CE34240 /* libPods-bitkit-bitkitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit-bitkitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		79DFAC55B0D745DE815EC2E0 /* InterTight-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Regular.ttf"; path = "../src/assets/fonts/InterTight-Regular.ttf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = bitkit/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		88AB9CEE960771BD739E689F /* Pods-bitkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.release.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.release.xcconfig"; sourceTree = "<group>"; };
-		A1454C623FA7417B0E1B98E4 /* Pods-bitkit-bitkitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.debug.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		8AB8522F78A39FC54A4AF279 /* Pods-bitkit-bitkitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.release.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.release.xcconfig"; sourceTree = "<group>"; };
 		A223BA795CEB4CB2B344FBAF /* InterTight-ExtraBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-ExtraBold.ttf"; path = "../src/assets/fonts/InterTight-ExtraBold.ttf"; sourceTree = "<group>"; };
 		CA37793F82F144678099A00D /* InterTight-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Bold.ttf"; path = "../src/assets/fonts/InterTight-Bold.ttf"; sourceTree = "<group>"; };
 		D67AECF5F543462F90EC89AD /* InterTight-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Medium.ttf"; path = "../src/assets/fonts/InterTight-Medium.ttf"; sourceTree = "<group>"; };
 		DEC74C5375A34FFCAEBA0781 /* Damion-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Damion-Regular.ttf"; path = "../src/assets/fonts/Damion-Regular.ttf"; sourceTree = "<group>"; };
+		E59075B9660BC10C6787D7FC /* Pods-bitkit-bitkitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.debug.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
-		F8111C09F74436DF8D3D1E39 /* libPods-bitkit-bitkitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit-bitkitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,7 +67,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FEBB7A6D5994CF5307DC444F /* libPods-bitkit-bitkitTests.a in Frameworks */,
+				92E54D2F4FA19238DC2A9EDD /* libPods-bitkit-bitkitTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -75,7 +75,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E1DFE188CAB27EE16BD2079E /* libPods-bitkit.a in Frameworks */,
+				2C3A289853B01446F26DE07D /* libPods-bitkit.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -117,8 +117,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				2633C924B358FFEC202323C3 /* libPods-bitkit.a */,
-				F8111C09F74436DF8D3D1E39 /* libPods-bitkit-bitkitTests.a */,
+				5B5E78A0A99310328B7054CC /* libPods-bitkit.a */,
+				767A7259F23E73A34CE34240 /* libPods-bitkit-bitkitTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -181,10 +181,10 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				09381D26DB8142B34372A368 /* Pods-bitkit.debug.xcconfig */,
-				88AB9CEE960771BD739E689F /* Pods-bitkit.release.xcconfig */,
-				A1454C623FA7417B0E1B98E4 /* Pods-bitkit-bitkitTests.debug.xcconfig */,
-				285E05CC53D54CC69BD0938A /* Pods-bitkit-bitkitTests.release.xcconfig */,
+				6427E31D398FA605AE553E14 /* Pods-bitkit.debug.xcconfig */,
+				289DE5FD62BC39314CD28A51 /* Pods-bitkit.release.xcconfig */,
+				E59075B9660BC10C6787D7FC /* Pods-bitkit-bitkitTests.debug.xcconfig */,
+				8AB8522F78A39FC54A4AF279 /* Pods-bitkit-bitkitTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -196,12 +196,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "bitkitTests" */;
 			buildPhases = (
-				6208BF7743AAD6546A8FA557 /* [CP] Check Pods Manifest.lock */,
+				50AD31A4D8B3D5ABC2CF9F23 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				BAF49551543470305EE8DC1E /* [CP] Embed Pods Frameworks */,
-				1D485C8E1D21709C776C4E4A /* [CP] Copy Pods Resources */,
+				F4275AA1FC60BD98CB8CAB8E /* [CP] Embed Pods Frameworks */,
+				3473E8654EA8B89E069B7AB5 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -217,13 +217,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "bitkit" */;
 			buildPhases = (
-				0A8A3EEC6687419B38E975D4 /* [CP] Check Pods Manifest.lock */,
+				6AF8530F6842669322DB35B8 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				E5B046FE6B7B2164093367D4 /* [CP] Embed Pods Frameworks */,
-				78423B479FB1503344E846E2 /* [CP] Copy Pods Resources */,
+				E830198DEEFD6C742660EDEE /* [CP] Embed Pods Frameworks */,
+				4B87EAB55A3BC4B38E1A62B0 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -314,29 +314,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		0A8A3EEC6687419B38E975D4 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-bitkit-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		1D485C8E1D21709C776C4E4A /* [CP] Copy Pods Resources */ = {
+		3473E8654EA8B89E069B7AB5 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -353,7 +331,24 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6208BF7743AAD6546A8FA557 /* [CP] Check Pods Manifest.lock */ = {
+		4B87EAB55A3BC4B38E1A62B0 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		50AD31A4D8B3D5ABC2CF9F23 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -375,41 +370,29 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		78423B479FB1503344E846E2 /* [CP] Copy Pods Resources */ = {
+		6AF8530F6842669322DB35B8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Copy Pods Resources";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-bitkit-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BAF49551543470305EE8DC1E /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E5B046FE6B7B2164093367D4 /* [CP] Embed Pods Frameworks */ = {
+		E830198DEEFD6C742660EDEE /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -424,6 +407,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F4275AA1FC60BD98CB8CAB8E /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -459,7 +459,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A1454C623FA7417B0E1B98E4 /* Pods-bitkit-bitkitTests.debug.xcconfig */;
+			baseConfigurationReference = E59075B9660BC10C6787D7FC /* Pods-bitkit-bitkitTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -487,7 +487,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 285E05CC53D54CC69BD0938A /* Pods-bitkit-bitkitTests.release.xcconfig */;
+			baseConfigurationReference = 8AB8522F78A39FC54A4AF279 /* Pods-bitkit-bitkitTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -512,7 +512,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 09381D26DB8142B34372A368 /* Pods-bitkit.debug.xcconfig */;
+			baseConfigurationReference = 6427E31D398FA605AE553E14 /* Pods-bitkit.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconOrange;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -544,7 +544,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 88AB9CEE960771BD739E689F /* Pods-bitkit.release.xcconfig */;
+			baseConfigurationReference = 289DE5FD62BC39314CD28A51 /* Pods-bitkit.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconOrange;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;

--- a/package.json
+++ b/package.json
@@ -177,11 +177,10 @@
     "node-fetch": "^2.6.7",
     "prettier": "^2.8.8",
     "react-native-bundle-visualizer": "^3.1.3",
-    "react-native-flipper": "0.212.0",
-    "react-native-mmkv-flipper-plugin": "^1.0.0",
     "react-native-skia-stub": "0.0.1",
     "react-native-svg-transformer": "^1.3.0",
-    "redux-flipper": "^2.0.3",
+    "reactotron-react-native": "^5.1.6",
+    "reactotron-redux": "^3.1.9",
     "typescript": "5.4.5"
   }
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -4,9 +4,5 @@ module.exports = {
 		android: {},
 	},
 	assets: ['./src/assets/fonts/'],
-	dependencies: {
-		...(process.env.NO_FLIPPER
-			? { 'react-native-flipper': { platforms: { ios: null } } }
-			: {}),
-	},
+	dependencies: {},
 };

--- a/src/@types/env.d.ts
+++ b/src/@types/env.d.ts
@@ -1,8 +1,6 @@
 declare module '@env' {
-	export const ENABLE_REDUX_FLIPPER: string;
 	export const ENABLE_REDUX_LOGGER: string;
 	export const ENABLE_REDUX_IMMUTABLE_CHECK: string;
-	export const ENABLE_MMKV_FLIPPER: string;
 	export const ENABLE_I18NEXT_DEBUGGER: string;
 	export const ENABLE_MIGRATION_DEBUG: string;
 	export const ENABLE_LDK_LOGS: string;

--- a/src/constants/env.ts
+++ b/src/constants/env.ts
@@ -21,8 +21,6 @@ import {
 	ENABLE_I18NEXT_DEBUGGER,
 	ENABLE_LDK_LOGS,
 	ENABLE_MIGRATION_DEBUG,
-	ENABLE_MMKV_FLIPPER,
-	ENABLE_REDUX_FLIPPER,
 	ENABLE_REDUX_IMMUTABLE_CHECK,
 	ENABLE_REDUX_LOGGER,
 	SLASHTAGS_SEEDER_BASE_URL,
@@ -60,8 +58,6 @@ if (!BACKUPS_SERVER_HOST || !BACKUPS_SERVER_PUBKEY) {
 
 export const __JEST__ = process.env.JEST_WORKER_ID !== undefined;
 
-export const __ENABLE_REDUX_FLIPPER__ =
-	ENABLE_REDUX_FLIPPER === 'true' ?? false;
 export const __ENABLE_REDUX_LOGGER__ = ENABLE_REDUX_LOGGER === 'true' ?? true;
 export const __ENABLE_MIGRATION_DEBUG__ =
 	ENABLE_MIGRATION_DEBUG === 'true' ?? false;
@@ -70,8 +66,6 @@ export const __ENABLE_REDUX_IMMUTABLE_CHECK__ =
 		? ENABLE_REDUX_IMMUTABLE_CHECK === 'true'
 		: false;
 
-export const __ENABLE_MMKV_FLIPPER__ =
-	ENABLE_MMKV_FLIPPER === 'true' ?? __DEV__;
 export const __ENABLE_I18NEXT_DEBUGGER__ =
 	ENABLE_I18NEXT_DEBUGGER === 'true' ?? __DEV__;
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,6 +1,4 @@
 import { configureStore, Middleware } from '@reduxjs/toolkit';
-import createDebugger from 'redux-flipper';
-import logger from 'redux-logger';
 import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
 import {
 	persistReducer,
@@ -16,7 +14,6 @@ import {
 
 import {
 	__ENABLE_MIGRATION_DEBUG__,
-	__ENABLE_REDUX_FLIPPER__,
 	__ENABLE_REDUX_IMMUTABLE_CHECK__,
 	__ENABLE_REDUX_LOGGER__,
 	__JEST__,
@@ -26,13 +23,8 @@ import rootReducer, { RootReducer } from './reducers';
 import migrations from './migrations';
 
 const devMiddleware: Middleware[] = [];
-if (__ENABLE_REDUX_FLIPPER__) {
-	const reduxFlipperDebugger = createDebugger();
-	// @ts-ignore
-	devMiddleware.push(reduxFlipperDebugger);
-}
 if (__ENABLE_REDUX_LOGGER__) {
-	// @ts-ignore
+	const { logger } = require('redux-logger');
 	devMiddleware.push(logger);
 }
 
@@ -66,6 +58,14 @@ const store = configureStore({
 			return defaultMiddleware.concat(devMiddleware);
 		} else {
 			return defaultMiddleware;
+		}
+	},
+	enhancers: (getDefaultEnhancers) => {
+		if (__DEV__ && !__JEST__) {
+			const Reactotron = require('../../ReactotronConfig').default;
+			return getDefaultEnhancers().concat(Reactotron.createEnhancer());
+		} else {
+			return getDefaultEnhancers();
 		}
 	},
 });

--- a/src/store/mmkv-storage.ts
+++ b/src/store/mmkv-storage.ts
@@ -1,13 +1,7 @@
 import { MMKV } from 'react-native-mmkv';
 import { Storage } from 'redux-persist';
-import { initializeMMKVFlipper } from 'react-native-mmkv-flipper-plugin';
-import { __ENABLE_MMKV_FLIPPER__, __JEST__ } from '../constants/env';
 
 export const storage = new MMKV();
-
-if (__ENABLE_MMKV_FLIPPER__ && !__JEST__) {
-	initializeMMKVFlipper({ default: storage });
-}
 
 const mmkvStorage: Storage = {
 	setItem: (key, value) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5967,11 +5967,6 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
-cycle@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
-  integrity sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==
-
 dargs@^8.0.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-8.1.0.tgz#a34859ea509cbce45485e5aa356fef70bfcc7272"
@@ -5982,7 +5977,7 @@ data-uri-to-buffer@^4.0.0:
   resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
   integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
 
-dayjs@^1.8.15, dayjs@^1.8.29:
+dayjs@^1.8.15:
   version "1.11.7"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.7.tgz#4b296922642f70999544d1144a2c25730fce63e2"
   integrity sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ==
@@ -9489,6 +9484,11 @@ mirror-drive@^1.2.0:
     binary-stream-equals "^1.0.0"
     same-data "^1.0.0"
 
+mitt@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-3.0.1.tgz#ea36cf0cc30403601ae074c8f77b7092cdab36d1"
+  integrity sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==
+
 mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.6.tgz#7def03d2432dcae4ba1d611445c48396062255f6"
@@ -10696,11 +10696,6 @@ react-native-fetch-api@3.0.0:
   dependencies:
     p-defer "^3.0.0"
 
-react-native-flipper@0.212.0:
-  version "0.212.0"
-  resolved "https://registry.yarnpkg.com/react-native-flipper/-/react-native-flipper-0.212.0.tgz#b3fdd47676ecd09a25edd77a1466acace6276762"
-  integrity sha512-bDRfIgE3v/jjEEdnvGP0T6maDD+bXhDAQ/SZUYTKd/CQ6YIU1c0EF+e0urU62LNMv6XEFQKz226McdddyVhYZA==
-
 react-native-fs@2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.20.0.tgz#05a9362b473bfc0910772c0acbb73a78dbc810f6"
@@ -10743,11 +10738,6 @@ react-native-localize@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-3.0.2.tgz#43fa75c0097dbdb24a54ff320b3c8ad732407365"
   integrity sha512-/l/oE1LVNgIRRhLbhmfFMHiWV0xhUn0A0iz1ytLVRYywL7FTp8Rx2vkJS/q/RpExDvV7yLw2493XZBYIM1dnLQ==
-
-react-native-mmkv-flipper-plugin@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-mmkv-flipper-plugin/-/react-native-mmkv-flipper-plugin-1.0.0.tgz#f87f747d8cea51d2b12a1e711287feff5f212788"
-  integrity sha512-e3owMIBzXez45Wz8Ac84Vf1FmfwMXFVUpf/gCDWDLq19w7iCipVezQjlZo8ISVza8aQf1G4ggaK/r+qqtGmRlg==
 
 react-native-mmkv@2.12.2:
   version "2.12.2"
@@ -10991,6 +10981,31 @@ react@18.2.0:
   dependencies:
     loose-envify "^1.1.0"
 
+reactotron-core-client@2.9.3:
+  version "2.9.3"
+  resolved "https://registry.yarnpkg.com/reactotron-core-client/-/reactotron-core-client-2.9.3.tgz#5694ad2be95e40cfcaf792a7f3fcab14f8247481"
+  integrity sha512-Z+PdYPi2ZsMyibH4251R2QpnIVrpgRoIFJYjeDF7LyomizkrOAugZDnTUNtUhVAqDb0eEWi4qaxUeEfnvZsn4w==
+  dependencies:
+    reactotron-core-contract "0.2.3"
+
+reactotron-core-contract@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/reactotron-core-contract/-/reactotron-core-contract-0.2.3.tgz#4b72bbe2905fda2a7e69f2653fc32bbdaaebb052"
+  integrity sha512-GMeulATwiTsAqRnTKLWgM4gG3pUxAuspW412SWutHIW0fZNEOiHg8bWTEQURhm1WZj+u4tmdbkPiIWBfH8fvvQ==
+
+reactotron-react-native@^5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/reactotron-react-native/-/reactotron-react-native-5.1.6.tgz#5c5d2631d9a23c746144e3e28bea4cc567ebca62"
+  integrity sha512-1J+fRQ54mwBhrmJrz6HhBW8GdyUQ8JWXo1vcW3TA61CowYXLuhte7GPau3zt2FYNsTj/r8dd0Pf0wDuuwrzcGQ==
+  dependencies:
+    mitt "^3.0.1"
+    reactotron-core-client "2.9.3"
+
+reactotron-redux@^3.1.9:
+  version "3.1.9"
+  resolved "https://registry.yarnpkg.com/reactotron-redux/-/reactotron-redux-3.1.9.tgz#42108f3d2babaf2f8c623e954b984994bb6a2b41"
+  integrity sha512-XeeumUnuZDlymDvlk7AtNloyXjPAdDnAAot/eCWmtlbEtEFVtpCj4eOew0EBnRdobo+BZOA3X8qo4g0pTU2WzQ==
+
 readable-stream@^2.0.2, readable-stream@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
@@ -11034,14 +11049,6 @@ record-cache@^1.1.1:
   integrity sha512-kyy3HWCez2WrotaL3O4fTn0rsIdfRKOdQQcEJ9KpvmKmbffKVvwsloX063EgRUlpJIXHiDQFhJcTbZequ2uTZw==
   dependencies:
     b4a "^1.3.1"
-
-redux-flipper@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/redux-flipper/-/redux-flipper-2.0.3.tgz#5373af20bd0efd91b5a1f9efa92c3338780f5732"
-  integrity sha512-JpNEZnBnBE9kGiZZrmzi23cFD9gjRUFoJE6nX0MPfmMVeIqfvkJWMATnbqRsTn8xwBXvWtOk+7Qbs8u4RZZcVw==
-  dependencies:
-    cycle "^1.0.3"
-    dayjs "^1.8.29"
 
 redux-logger@3.0.6:
   version "3.0.6"


### PR DESCRIPTION
### Description

This removes Flipper from the app completely and adds Reactotron instead. Since 0.73 react-native disabled remote debugging out of the box. It is still possible to get Flipper working (I haven't managed) but I'd rather not rely on deprecated features. We can use Reactotron until Flipper works again with the new debugger.

See https://docs.infinite.red/reactotron/quick-start/react-native/

![Screenshot 2024-05-09 at 13 52 22](https://github.com/synonymdev/bitkit/assets/8538369/96548196-8f83-4422-8146-756905cf7327)

<img width="1055" alt="Screenshot 2024-05-10 at 18 31 37" src="https://github.com/synonymdev/bitkit/assets/8538369/ae2ade1f-9058-4434-be4a-f71b29c54373">

