### PR TITLE
chore(wallet): Upgrade Beignet

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1629,7 +1629,7 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   sodium-react-native-direct: 102289e2a55688b5c6c489c88b2a7915d4e31ec1
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
-  Yoga: e5b887426cee15d2a326bdd34afc0282fc0486ad
+  Yoga: 2a16e58450c48e110211dae1159fb114bbcdcfc0
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: 36b98823c4a3ba66ee1a0fe7afdf6d3486c78651

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@synonymdev/web-relay": "1.0.7",
     "backpack-client": "github:synonymdev/bitkit-backup-client#f08fdb28529d8a3f8bfecc789443c43b966a7581",
     "bech32": "2.0.0",
-    "beignet": "0.0.35",
+    "beignet": "0.0.37",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
     "bip39": "3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4690,10 +4690,10 @@ bech32@^1.1.2, bech32@^1.1.4:
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
 
-beignet@0.0.35:
-  version "0.0.35"
-  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.35.tgz#b3255587d51fc16cdd95e2fdd5e9231b1cff4c48"
-  integrity sha512-hOT26TzgX4L9ALOh9vWz3Vfs3RKQhrtFNIL2ZjxIAjnmPRlSmxaqkO4REqtHSQ4CHi1hsnBZ9rrvqzeb7Al5QQ==
+beignet@0.0.37:
+  version "0.0.37"
+  resolved "https://registry.yarnpkg.com/beignet/-/beignet-0.0.37.tgz#bd2ff2c2d1803bf308cb9c03ca493d54d35e6e34"
+  integrity sha512-Snn3l4irPUJIDbtLKLb6A2LZ8Qu+AJBsdTXpNxtegnmVg+r8SVPIWWwvFvbzTcFU7ZO1KyhK/CXNxk3ts3KlvQ==
   dependencies:
     "@bitcoinerlab/secp256k1" "1.0.5"
     bech32 "2.0.0"
@@ -4706,7 +4706,7 @@ beignet@0.0.35:
     ecpair "2.1.0"
     lodash.clonedeep "4.5.0"
     net "1.0.2"
-    rn-electrum-client "^0.0.15"
+    rn-electrum-client "0.0.16"
 
 big-sparse-array@^1.0.3:
   version "1.0.3"
@@ -11256,10 +11256,10 @@ rn-android-keyboard-adjust@2.1.2:
   resolved "https://registry.yarnpkg.com/rn-android-keyboard-adjust/-/rn-android-keyboard-adjust-2.1.2.tgz#f2b792628700dcb026215420192317ce43fd954f"
   integrity sha512-pUYiMT7aucw5YnV4geGdalyl6o6rEwRYhDnw2oPQwDym1BZHtmKsxFLupky1Kj2ZNkNKadpEyoyHOElLo+f3sA==
 
-rn-electrum-client@^0.0.15:
-  version "0.0.15"
-  resolved "https://registry.yarnpkg.com/rn-electrum-client/-/rn-electrum-client-0.0.15.tgz#cdedd21140bcfc6918e3656ae65deec804135a40"
-  integrity sha512-C7AJ+TWGUz7jPHJo/hmzfgS/VhHT3hNMtfuujwLmsN4XYF06yzPiRocWvY4MvzOg40MHgo+5lpcOwVn0uLVOqg==
+rn-electrum-client@0.0.16:
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/rn-electrum-client/-/rn-electrum-client-0.0.16.tgz#2fd2b0db8dd7e8e8dd14c60666d4d7fd232ec8da"
+  integrity sha512-qzkJlAjJBLPMGHe/N8IG35hv+j34JPBR5Ml2McCFY18xpjbshycPfOWylm7YZQjXxLeYEKYqbZ/2Gxp8o2mWgQ==
 
 "rn-electrum-client@github:synonymdev/react-native-electrum-client#a32a292d4e4918a04d280137e24e5961c74c543f":
   version "0.0.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12873,3 +12873,4 @@ z32@^1.0.0:
   integrity sha512-p3DhBJckAZj5XwYMJYeLlkgJJ+aEyCoOjTpK17I/MofVs70eR+WQPXQpk1LEmMweB2JbUx0naFXPPI2EGaVX6w==
   dependencies:
     b4a "^1.5.3"
+


### PR DESCRIPTION
### Description
- Upgrades Beignet to `0.0.37` to include the following updates:
    - https://github.com/synonymdev/beignet/pull/59
    - https://github.com/synonymdev/beignet/pull/58
    - https://github.com/synonymdev/react-native-electrum-client/pull/22

### Type of change
- [x] Dependency Upgrade

### Tests
- [x] No test

### QA Notes
- On-chain functionality should continue working as expected.
- Bitkit should continue to be able to establish a connection with the Electrum server.
