### PR TITLE
fix: switch unit on confirmation screen

### DIFF
--- a/src/hooks/displayValues.ts
+++ b/src/hooks/displayValues.ts
@@ -5,11 +5,13 @@ import { IDisplayValues } from '../utils/displayValues/types';
 import {
 	denominationSelector,
 	selectedCurrencySelector,
+	unitSelector,
 } from '../store/reselect/settings';
 import {
 	exchangeRateSelector,
 	exchangeRatesSelector,
 } from '../store/reselect/wallet';
+import { EUnit } from '../store/types/wallet';
 
 export const useDisplayValues = (
 	satoshis: number,
@@ -67,4 +69,17 @@ export const useExchangeRate = (currency = 'USD'): number => {
 	return useMemo(() => {
 		return exchangeRates[currency]?.rate ?? 0;
 	}, [currency, exchangeRates]);
+};
+
+/**
+ * Returns the formatted display value for the current unit
+ */
+export const useCurrentDisplayValue = (
+	...props: Parameters<typeof useDisplayValues>
+): string => {
+	const unit = useAppSelector(unitSelector);
+	const dv = useDisplayValues(...props);
+	return unit === EUnit.BTC
+		? '₿' + dv.bitcoinFormatted
+		: dv.fiatSymbol + dv.fiatFormatted;
 };

--- a/src/navigation/lightning/LightningNavigator.tsx
+++ b/src/navigation/lightning/LightningNavigator.tsx
@@ -19,6 +19,7 @@ import Success from '../../screens/Lightning/Success';
 import LNURLChannel from '../../screens/Lightning/LNURLChannel';
 import LNURLChannelSuccess from '../../screens/Lightning/LNURLChannelSuccess';
 import { __E2E__ } from '../../constants/env';
+import { EUnit } from '../../store/types/wallet';
 
 export type LightningNavigationProp =
 	NativeStackNavigationProp<LightningStackParamList>;
@@ -30,6 +31,7 @@ export type LightningStackParamList = {
 	QuickConfirm: {
 		spendingAmount: number;
 		orderId?: string;
+		onChangeUnitOutside: (nextUnit: EUnit) => void;
 	};
 	CustomSetup: { spending: boolean; spendingAmount?: number };
 	CustomConfirm: {

--- a/src/screens/Lightning/CustomSetup.tsx
+++ b/src/screens/Lightning/CustomSetup.tsx
@@ -497,7 +497,9 @@ const CustomSetup = ({
 							{channelOpenFee[`${spendingAmount}-${amount}`] && (
 								<AnimatedView entering={FadeIn} exiting={FadeOut}>
 									<Caption13Up style={styles.amountCaptionCost} color="gray2">
-										(Cost: {channelOpenFee[`${spendingAmount}-${amount}`]})
+										{t('cost', {
+											amount: channelOpenFee[`${spendingAmount}-${amount}`],
+										})}
 									</Caption13Up>
 								</AnimatedView>
 							)}

--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -42,6 +42,7 @@ import {
 	nextUnitSelector,
 	unitSelector,
 } from '../../store/reselect/settings';
+import { EUnit } from '../../store/types/wallet';
 
 const QuickSetup = ({
 	navigation,
@@ -117,11 +118,20 @@ const QuickSetup = ({
 		setTextFieldValue(result);
 	}, [lnSetup.slider.maxValue, denomination, unit]);
 
-	const onChangeUnit = (): void => {
+	const onChangeUnit = useCallback((): void => {
 		const result = getNumberPadText(spendingAmount, denomination, nextUnit);
 		setTextFieldValue(result);
 		switchUnit();
-	};
+	}, [denomination, spendingAmount, nextUnit, switchUnit]);
+
+	/** Used to update the unit on other screens */
+	const onChangeUnitOutside = useCallback(
+		(newUnit: EUnit): void => {
+			const result = getNumberPadText(spendingAmount, denomination, newUnit);
+			setTextFieldValue(result);
+		},
+		[denomination, spendingAmount],
+	);
 
 	const onSliderChange = useCallback(
 		(value: number) => {
@@ -156,7 +166,10 @@ const QuickSetup = ({
 		}
 
 		if (isTransferringToSavings) {
-			navigation.navigate('QuickConfirm', { spendingAmount });
+			navigation.navigate('QuickConfirm', {
+				spendingAmount,
+				onChangeUnitOutside,
+			});
 			return;
 		}
 
@@ -182,6 +195,7 @@ const QuickSetup = ({
 		navigation.push('QuickConfirm', {
 			spendingAmount,
 			orderId: purchaseResponse.value.id,
+			onChangeUnitOutside,
 		});
 	}, [
 		lnSetup,
@@ -189,6 +203,7 @@ const QuickSetup = ({
 		navigation,
 		sliderActive,
 		spendingAmount,
+		onChangeUnitOutside,
 		t,
 	]);
 

--- a/src/utils/i18n/locales/en/lightning.json
+++ b/src/utils/i18n/locales/en/lightning.json
@@ -55,6 +55,7 @@
 	"spending_amount_bitcoin": "Choose how much money you want to be able to spend instantly.",
 	"receiving_amount_money": "Choose how much money you want to be able to receive instantly.",
 	"receiving_amount_bitcoin": "Enter the amount of Bitcoin you want to be able to receive instantly.",
+	"cost": "(Cost: {amount})",
 	"enter_custom_amount": "Enter Amount",
 	"custom_confirm_header": "Please\n<accent>confirm</accent>",
 	"custom_confirm_cost": "It costs <accent>{txFee}</accent> in network fees and <accent>{lspFee}</accent> in service provider fees to transfer your funds. Your spending balance should stay active for at least <accentWithKeyboard>{weeks, plural, one {# week} other {# weeks}}.<penIcon/></accentWithKeyboard>",


### PR DESCRIPTION
### Description

- add unit switching on QuickConfirm screen. Had to add `onChangeUnitOutside` callback to make it work
- i18n 
- show LSP and onchain fees in current unit

### Linked Issues/Tasks

closes #1792 #1926

### Type of change

Bug fix

### Tests

Detox test

### Screenshot / Video



### QA Notes


