### PR TITLE
fix(wallet): Fix Boost Fee Conversion

### DIFF
--- a/src/screens/Wallets/BoostPrompt.tsx
+++ b/src/screens/Wallets/BoostPrompt.tsx
@@ -19,7 +19,6 @@ import {
 	updateFee,
 } from '../../utils/wallet/transactions';
 import { showToast } from '../../utils/notifications';
-import { btcToSats } from '../../utils/conversion';
 import { TOnchainActivityItem } from '../../store/types/activity';
 import {
 	useBottomSheetBackPress,
@@ -57,7 +56,7 @@ const BoostForm = ({
 	const [showCustom, setShowCustom] = useState(false);
 	const boostData = useMemo(() => canBoost(activityItem.id), [activityItem.id]);
 
-	const activityItemFee = btcToSats(activityItem.fee);
+	const activityItemFee = activityItem.fee;
 	const recommendedFee = feeEstimates.fast;
 	const { description: duration } = useFeeText(transaction.satsPerByte);
 

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -4,7 +4,7 @@ import validate, { getAddressInfo } from 'bitcoin-address-validation';
 import { __E2E__ } from '../../constants/env';
 import { EAvailableNetwork } from '../networks';
 import { reduceValue } from '../helpers';
-import { btcToSats, satsToBtc } from '../conversion';
+import { btcToSats } from '../conversion';
 import { TWalletName } from '../../store/types/wallet';
 import {
 	getBalance,
@@ -1103,7 +1103,7 @@ export const broadcastBoost = async ({
 		const updatedActivityItemData: Partial<TOnchainActivityItem> = {
 			txId: newTxId,
 			address: transaction.changeAddress,
-			fee: oldFee + satsToBtc(transaction.fee),
+			fee: oldFee + transaction.fee,
 			isBoosted: true,
 			timestamp: new Date().getTime(),
 		};


### PR DESCRIPTION
### Description
- Removes `btcToSats` method when calculating boost fees.
- Fixes #1816

### Linked Issues/Tasks
- #1816

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test

### QA Notes
- Have the wallet send Bitcoin to itself by copying the Receive address and then sending an amount to it (Not the max amount). Afterwards, tap on the transaction from the activity list and proceed to boost it. Previously, the boost would result in an amount that displays decimals as shown in [this issue](https://github.com/synonymdev/bitkit/issues/1816). As of this PR the amount should be accurate and not display decimals as showcased in the linked issue.
