### PR TITLE
fix(ui): Replace showBottomSheet with toggleBottomSheet

### DIFF
--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { FadeIn } from 'react-native-reanimated';
 
 import { receiveIcon, sendIcon } from '../assets/icons/tabs';
-import { showBottomSheet } from '../store/utils/ui';
+import { toggleBottomSheet } from '../store/utils/ui';
 import { resetSendTransaction } from '../store/actions/wallet';
 import { viewControllersSelector } from '../store/reselect/ui';
 import useColors from '../hooks/colors';
@@ -39,13 +39,13 @@ const TabBar = ({
 	}, [viewControllers]);
 
 	const onReceivePress = (): void => {
-		showBottomSheet('receiveNavigation');
+		toggleBottomSheet('receiveNavigation');
 	};
 
 	const onSendPress = (): void => {
 		// make sure we start with a clean transaction state
 		resetSendTransaction();
-		showBottomSheet('sendNavigation');
+		toggleBottomSheet('sendNavigation');
 	};
 
 	const onScanPress = (): void => navigation.navigate('Scanner');

--- a/src/store/slices/ui.ts
+++ b/src/store/slices/ui.ts
@@ -19,6 +19,18 @@ export const uiSlice = createSlice({
 		setAppUpdateInfo: (state, action: PayloadAction<TAvailableUpdate>) => {
 			state.availableUpdate = action.payload;
 		},
+		toggleSheet: (
+			state,
+			action: PayloadAction<{
+				view: keyof ViewControllerParamList;
+				params: any;
+			}>,
+		) => {
+			state.viewControllers[action.payload.view] = {
+				...action.payload.params,
+				isOpen: !state.viewControllers[action.payload.view].isOpen,
+			};
+		},
 		showSheet: (
 			state,
 			action: PayloadAction<{
@@ -50,6 +62,7 @@ export const {
 	updateUi,
 	setAppUpdateInfo,
 	showSheet,
+	toggleSheet,
 	closeSheet,
 	updateProfileLink,
 	resetUiState,

--- a/src/store/utils/ui.ts
+++ b/src/store/utils/ui.ts
@@ -2,7 +2,12 @@ import { Platform } from 'react-native';
 import { getBuildNumber } from 'react-native-device-info';
 
 import { getActivityStore, dispatch } from '../helpers';
-import { closeSheet, setAppUpdateInfo, showSheet } from '../slices/ui';
+import {
+	closeSheet,
+	setAppUpdateInfo,
+	showSheet,
+	toggleSheet,
+} from '../slices/ui';
 import { vibrate } from '../../utils/helpers';
 import { EActivityType } from '../types/activity';
 import { TAvailableUpdate, ViewControllerParamList } from '../types/ui';
@@ -17,6 +22,15 @@ export const showBottomSheet = <View extends keyof ViewControllerParamList>(
 ): void => {
 	const [view, params] = args;
 	dispatch(showSheet({ view, params }));
+};
+
+export const toggleBottomSheet = <View extends keyof ViewControllerParamList>(
+	...args: undefined extends ViewControllerParamList[View]
+		? [view: View] | [view: View, params: ViewControllerParamList[View]]
+		: [view: View, params: ViewControllerParamList[View]]
+): void => {
+	const [view, params] = args;
+	dispatch(toggleSheet({ view, params }));
 };
 
 export const showNewOnchainTxPrompt = ({


### PR DESCRIPTION
### Description
- Replaces `showBottomSheet` with `toggleBottomSheet` to prevent stuck send/receive bottom-sheets on failed action updates.
- Previously, quickly tapping and closing either the Send or Receive buttons/bottom-sheets would prevent the close action from firing in the bottom-sheet component. This results in a stuck position where the app thinks the Send/Receive view is open, but it's actually closed. So tapping on Send or Receive will not do anything. This PR is a temp fix that re-enables the Send/Receive buttons after two presses instead of remaining in the stuck position, forcing the user to restart in order to re-enable them.
- Ideally in the future, we need to find a way to respond to interrupted open/close animations from the bottom-sheet wrapper.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test

### QA Notes
- Quickly tap and close either the Send or Receive view. Worst case scenario, you should now be able to re-open the Send/Receive view after no more than two taps instead of needing to close and re-open the app.
