### PR TITLE
fix: backport run refresh wallet after initialisation to beta

### DIFF
--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -97,6 +97,20 @@ const bip32 = BIP32Factory(ecc);
 
 let wallet: TWallet;
 
+/*
+ * Wait for wallet to be ready
+ */
+const waitForWallet = async (): Promise<void> => {
+	if (wallet) {
+		return;
+	}
+	return new Promise((resolve) => {
+		setTimeout(() => {
+			resolve(waitForWallet());
+		}, 100);
+	});
+};
+
 export const refreshWallet = async ({
 	onchain = true,
 	lightning = true,
@@ -117,6 +131,8 @@ export const refreshWallet = async ({
 		await new Promise((resolve) => {
 			InteractionManager.runAfterInteractions(() => resolve(null));
 		});
+
+		await waitForWallet();
 
 		let notificationTxid: string | undefined;
 


### PR DESCRIPTION
### Description

See:
- #1773

### Type of change

Bug fix (non-breaking change which fixes an issue)

### Tests

No test

### QA Notes

Already validated, mainly prevents `TypeError: Cannot read property 'refreshWallet' of undefined` errors.

Might also reduce the number of times we see electrum connection errors within the logs.