### PR TITLE
fix: Don't show rocket screen twice during restore

### DIFF
--- a/src/screens/Onboarding/RestoreFromSeed.tsx
+++ b/src/screens/Onboarding/RestoreFromSeed.tsx
@@ -33,7 +33,6 @@ import { useAppDispatch } from '../../hooks/redux';
 import { validateMnemonic } from '../../utils/wallet';
 import { restoreSeed } from '../../utils/startup';
 import { showToast } from '../../utils/notifications';
-import LoadingWalletScreen from './Loading';
 import NavigationHeader from '../../components/NavigationHeader';
 import { updateUser, verifyBackup } from '../../store/slices/user';
 
@@ -51,10 +50,11 @@ const RestoreFromSeed = (): ReactElement => {
 	const { t } = useTranslation('onboarding');
 	const enableButtons = useMemo(
 		() =>
+			!isRestoringWallet &&
 			!seed.includes(undefined) &&
 			!validWords.includes(false) &&
 			validateMnemonic(seed.join(' ')),
-		[seed, validWords],
+		[isRestoringWallet, seed, validWords],
 	);
 	const showRedExplanation = useMemo(
 		() => seed.some((word, index) => word !== undefined && !validWords[index]),
@@ -169,14 +169,6 @@ const RestoreFromSeed = (): ReactElement => {
 			/>
 		);
 	};
-
-	if (isRestoringWallet) {
-		return (
-			<ThemedView style={styles.root}>
-				<LoadingWalletScreen />
-			</ThemedView>
-		);
-	}
 
 	return (
 		<ThemedView style={styles.root}>


### PR DESCRIPTION
Fixes #1634 

### Description

Removes code that was displaying the loading screen (aka. rocket screen) from within the `RestoreFromSeed` screen (which is part of onboarding flow).

With this change only `App.tsx` remains to show the rocket screen, which is presented by the `RestoringScreen` subcomponent it loads, while we're waiting on a result from the long-running restore operations.

#### Rationale

> It's a small fix, it's not perfect (I mean we still see a black screen for a very short time after tapping `Restore`, before the rocket screen shows, but the rocket screen is pretty neat now, shows only once, the progress anims on it do feel like making more sense and all in all it should smooth the experience of users while restoring.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Tests

- [x] No test

### Screenshot / Video

<video src="https://github.com/synonymdev/bitkit/assets/4588074/1a3fc3fc-4080-4384-a7ce-641f9cb39e39" style="max-width: 315px;"></video>

### QA Notes

#### To Test

Just restore a wallet, it should be more user-friendly now that we don't show the rocket-screen twice, each time starting from 0%.

#### Context

Check out this comment on what this PR fixes:
- https://github.com/synonymdev/bitkit/issues/1634#issuecomment-2088361555

Compare the video of the BEFORE with the AFTER video/ your experience while validating this 👍🏻 