### PR TITLE
fix: disable add button if error on add contact screen

### DIFF
--- a/src/screens/Contacts/AddContact.tsx
+++ b/src/screens/Contacts/AddContact.tsx
@@ -125,7 +125,7 @@ const AddContact = ({
 					<Button
 						style={styles.button}
 						size="large"
-						disabled={!url}
+						disabled={!url || Boolean(error)}
 						text={t('contact_add_button')}
 						testID="AddContactButton"
 						onPress={(): void => handleAddContact()}


### PR DESCRIPTION
### Description

disable add button if error on add contact screen

### Linked Issues/Tasks

closes #1828

### Type of change

Bug fix

### Tests

No test
