### PR TITLE
fix(wallet): Set Fast Fee Rate For CPFP When Able

### DIFF
--- a/src/screens/Wallets/BoostPrompt.tsx
+++ b/src/screens/Wallets/BoostPrompt.tsx
@@ -38,6 +38,7 @@ import {
 	transactionSelector,
 } from '../../store/reselect/wallet';
 import { validateTransaction } from 'beignet';
+import { EUnit } from '../../store/types/wallet.ts';
 
 const BoostForm = ({
 	activityItem,
@@ -198,7 +199,12 @@ const BoostForm = ({
 
 	const Title = (
 		<View style={styles.adjustValueRow}>
-			<Money sats={transaction.satsPerByte} size="bodyMSB" symbol={true} />
+			<Money
+				sats={transaction.satsPerByte}
+				unit={EUnit.BTC}
+				size="bodyMSB"
+				symbol={true}
+			/>
 			<BodyMSB> {t('sat_vbyte_compact')}</BodyMSB>
 		</View>
 	);

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -962,6 +962,20 @@ export const setupCpfp = async ({
 	satsPerByte?: number;
 }): Promise<Result<ISendTransaction>> => {
 	const transaction = getOnChainWalletTransaction();
+	// Set fastest fee-rate, if able. Otherwise, set the highest fee-rate.
+	if (!satsPerByte) {
+		const fees = getFeesStore().onchain;
+		satsPerByte = fees[ETransactionSpeed.fast];
+		const wallet = getOnChainWallet();
+		const feeInfo = wallet.getFeeInfo();
+		if (feeInfo.isErr()) {
+			return err(feeInfo.error.message);
+		}
+		const { maxSatPerByte } = feeInfo.value;
+		if (!satsPerByte || satsPerByte > maxSatPerByte) {
+			satsPerByte = maxSatPerByte;
+		}
+	}
 	return await transaction.setupCpfp({ txid, satsPerByte });
 };
 


### PR DESCRIPTION
### Description
- Updates `setupCpfp` to set the fastest fee-rate when able.
- Fixes `BoostPrompt` `Title` to always display the correct sats per vbyte value.

### Linked Issues/Tasks
- Closes #1777

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test

### QA Notes
- Send some sats to the wallet.
- Tap on the Activity entry for the, unconfirmed, received funds and tap "Boost".
- The default sats per vbyte should either be the "fast" fee preference or the highest satsPerByte value the wallet can achieve depending on the user's balance.
