### PR TITLE
fix: add lnSetupSelector amount test

### DIFF
--- a/__tests__/reselect.ts
+++ b/__tests__/reselect.ts
@@ -218,5 +218,36 @@ describe('Reselect', () => {
 
 			expect(received1).toMatchObject(expected1);
 		});
+
+		it('should not produce different slider.maxVlalue for the different spending amount', () => {
+			const s1 = cloneDeep(s);
+			s1.wallet.wallets.wallet0.balance.bitcoinRegtest = 600000;
+			s1.blocktank.info.options = {
+				...s1.blocktank.info.options,
+				max0ConfClientBalanceSat: 0,
+				maxChannelSizeSat: 1500000,
+				maxClientBalanceSat: 1450000,
+				minChannelSizeSat: 100000,
+			};
+			const channel1 = {
+				channel_id: 'channel1',
+				status: EChannelStatus.open,
+				is_channel_ready: true,
+				balance_sat: 370000,
+				channel_value_satoshis: 700000,
+				outbound_capacity_sat: 400000,
+			} as TChannel;
+			const lnWallet = s1.lightning.nodes.wallet0;
+			lnWallet.channels.bitcoinRegtest = { channel1 };
+
+			const r0 = lnSetupSelector(s1, 0);
+			const r1 = lnSetupSelector(s1, 1000);
+			const r2 = lnSetupSelector(s1, 8000);
+			const r3 = lnSetupSelector(s1, 500000);
+
+			expect(r0.slider.maxValue).toEqual(r1.slider.maxValue);
+			expect(r0.slider.maxValue).toEqual(r2.slider.maxValue);
+			expect(r0.slider.maxValue).toEqual(r3.slider.maxValue);
+		});
 	});
 });


### PR DESCRIPTION
### Description

https://github.com/synonymdev/bitkit/blame/master/src/store/reselect/aggregations.ts#L81

https://github.com/synonymdev/bitkit/assets/155891/0a9812c0-f98c-4026-8d4c-b58b91e37b70



Please include a summary of changes and which issues are fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Linked Issues/Tasks

Add any links to GitHub issues or Asana tasks that are relevant to this pull request.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [ ] No test

### Screenshot / Video

Insert relevant screenshot / recording

### QA Notes

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce during the Bitkit testing session. You can also leave a video of the PR in action.
