### PR TITLE
fix(widgets): hide settings for news & facts

### DIFF
--- a/src/screens/Widgets/Widget.tsx
+++ b/src/screens/Widgets/Widget.tsx
@@ -116,21 +116,26 @@ const Widget = ({
 						</BodyM>
 					)}
 
-					<TouchableOpacity
-						style={styles.item}
-						activeOpacity={0.6}
-						testID="WidgetEdit"
-						onPress={onEdit}>
-						<View style={styles.columnLeft}>
-							<BodyM color="white">{t('widget_edit')}</BodyM>
-						</View>
-						<View style={styles.columnRight}>
-							<BodyM style={styles.valueText} testID="Value">
-								{hasEdited ? t('widget_edit_custom') : t('widget_edit_default')}
-							</BodyM>
-							<ChevronRight color="white50" width={24} height={24} />
-						</View>
-					</TouchableOpacity>
+					{(config.type === SUPPORTED_FEED_TYPES.PRICE_FEED ||
+						config.type === SUPPORTED_FEED_TYPES.BLOCKS_FEED) && (
+						<TouchableOpacity
+							style={styles.item}
+							activeOpacity={0.6}
+							testID="WidgetEdit"
+							onPress={onEdit}>
+							<View style={styles.columnLeft}>
+								<BodyM color="white">{t('widget_edit')}</BodyM>
+							</View>
+							<View style={styles.columnRight}>
+								<BodyM style={styles.valueText} testID="Value">
+									{hasEdited
+										? t('widget_edit_custom')
+										: t('widget_edit_default')}
+								</BodyM>
+								<ChevronRight color="white50" width={24} height={24} />
+							</View>
+						</TouchableOpacity>
+					)}
 
 					<View style={styles.footer}>
 						<Caption13Up style={styles.caption} color="white50">


### PR DESCRIPTION
### Description

Hides widget settings for news and facts widget, since the page was empty.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

![image](https://github.com/synonymdev/bitkit/assets/8538369/25428e0b-1fee-4a1c-8f55-54fa251c1d93)
