### PR TITLE
fix(ui): increase duration for some toasts

### DIFF
--- a/src/hooks/wallet.ts
+++ b/src/hooks/wallet.ts
@@ -123,6 +123,7 @@ export const useSwitchUnitAnnounced = (): (() => void) => {
 				description: t('balance_unit_switched_message', {
 					unit: toUnitText(unit),
 				}),
+				visibilityTime: 5000,
 			});
 			dispatch(ignoreSwitchUnitToast());
 		}

--- a/src/screens/Wallets/index.tsx
+++ b/src/screens/Wallets/index.tsx
@@ -72,6 +72,7 @@ const Wallets = ({ navigation, onFocus }: Props): ReactElement => {
 				type: 'info',
 				title: t('balance_hidden_title'),
 				description: t('balance_hidden_message'),
+				visibilityTime: 5000,
 			});
 			dispatch(ignoreHideBalanceToast());
 		}

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -515,6 +515,7 @@ export const subscribeToLightningPayments = ({
 						type: 'lightning',
 						title: i18n.t('lightning:channel_opened_title'),
 						description: i18n.t('lightning:channel_opened_msg'),
+						visibilityTime: 5000,
 					});
 				}
 

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -6,6 +6,7 @@ export type ToastOptions = {
 	title: string;
 	description: string;
 	autoHide?: boolean;
+	visibilityTime?: number;
 };
 
 const defaultOptions = {
@@ -20,6 +21,7 @@ export const showToast = ({
 	title,
 	description,
 	autoHide,
+	visibilityTime,
 }: ToastOptions): void => {
 	if (__E2E__) {
 		console.log('showToast', { type, title, description });
@@ -33,5 +35,6 @@ export const showToast = ({
 		text2: description,
 		position: 'top',
 		autoHide,
+		visibilityTime,
 	});
 };


### PR DESCRIPTION
### Description

Adds ability to add custom `visibilityTime` to toasts.

- [x] Toasts: Please add 1 second to ‘Switched to dollars’, Wallet Balance Hidden’, and ‘Spending Balance Ready’

### Linked Issues/Tasks

https://github.com/synonymdev/bitkit/issues/1864
