### PR TITLE
fix: ignore Continue on QuickSetup screen when Slider is active

### DIFF
--- a/src/components/HeadlinesWidget.tsx
+++ b/src/components/HeadlinesWidget.tsx
@@ -121,7 +121,9 @@ const HeadlinesWidget = ({
 					activeOpacity={0.9}
 					hitSlop={{ right: 15, bottom: 15, left: 15 }}
 					onPress={(): void => {
-						if (link) openAppURL(link);
+						if (link) {
+							openAppURL(link);
+						}
 					}}>
 					<View style={styles.columnLeft}>
 						<CaptionB color="secondary" numberOfLines={1}>


### PR DESCRIPTION
### Description

ignore Continue on QuckSetup screen when Slider is active

### Linked Issues/Tasks

#1800

### Type of change

Bug fix

### Tests

No test
