### PR TITLE
fix: android navigation bar color

### DIFF
--- a/android/app/src/main/java/com/bitkit/modules/SplashScreen/SplashScreenModule.java
+++ b/android/app/src/main/java/com/bitkit/modules/SplashScreen/SplashScreenModule.java
@@ -67,6 +67,7 @@ public class SplashScreenModule extends ReactContextBaseJavaModule {
 
         // Set app background color back to black
         activity.getWindow().setBackgroundDrawableResource(R.color.black);
+        activity.getWindow().setNavigationBarColor(ContextCompat.getColor(activity, R.color.black));
 
         activity.runOnUiThread(() -> {
             // Leave out the second argument if you're not using animations


### PR DESCRIPTION
### Description

Fixes android navigation bar color on non-Pixel devices

### Linked Issues/Tasks

https://github.com/synonymdev/bitkit/pull/1803

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/8538369/e0c170d9-e464-490f-bb12-173f6b64e968

### QA Notes

Make sure navigation bar is always black on all phones independent of dark/light theme OS settings.
