### PR TITLE
fix: show error when trying to create LN invoice with amount > remoteBalance

### DIFF
--- a/src/screens/Wallets/Receive/ReceiveQR.tsx
+++ b/src/screens/Wallets/Receive/ReceiveQR.tsx
@@ -64,6 +64,7 @@ import { receiveSelector } from '../../../store/reselect/receive';
 import { ReceiveScreenProps } from '../../../navigation/types';
 import { isGeoBlockedSelector } from '../../../store/reselect/user';
 import { getWalletStore } from '../../../store/helpers';
+import { showToast } from '../../../utils/notifications';
 
 type Slide = () => ReactElement;
 
@@ -113,11 +114,17 @@ const ReceiveQR = ({
 	}, [jitInvoice, lightningBalance.remoteBalance]);
 
 	const getLightningInvoice = useCallback(async (): Promise<void> => {
-		if (
-			!receiveNavigationIsOpen ||
-			!lightningBalance.remoteBalance ||
-			lightningBalance.remoteBalance < amount
-		) {
+		if (!receiveNavigationIsOpen || !lightningBalance.remoteBalance) {
+			return;
+		}
+
+		if (lightningBalance.remoteBalance < amount) {
+			setLightningInvoice('');
+			showToast({
+				type: 'error',
+				title: t('receive_insufficient_title'),
+				description: t('receive_insufficient_text'),
+			});
 			return;
 		}
 

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -208,5 +208,7 @@
 	"refresh_error_title": "Refresh Failed",
 	"refresh_error_throttle_title": "Connection Throttled",
 	"refresh_error_throttle_description": "Electrum server connection is throttled. Please wait several minutes before trying again.",
-	"ldk_sync_error_title": "Lightning Sync Error"
+	"ldk_sync_error_title": "Lightning Sync Error",
+	"receive_insufficient_title": "Insufficient receiving balance.",
+	"receive_insufficient_text": "Insufficient receiving capacity to receive this amount over Lightning."
 }


### PR DESCRIPTION
### Description

Without this fix it just shows you old / 0-amount invoice, confusing

### Linked Issues/Tasks



### Type of change

Bug fix

### Tests

No test

### Screenshot / Video



### QA Notes

- open LN channel
- try to generate invoice with amount > incoming capacity
- error should appear
