### PR TITLE
chore(wallet): Update env templates

### DIFF
--- a/.env.development.template
+++ b/.env.development.template
@@ -21,7 +21,7 @@ BACKUPS_SERVER_PUBKEY=02c03b8b8c1b5500b622646867d99bf91676fac0f38e2182c91a9ff0d0
 WEB_RELAY=https://webrelay.slashtags.to
 
 # Blocktank
-BLOCKTANK_HOST=https://api.stag.blocktank.to
+BLOCKTANK_HOST=https://api1.blocktank.to/api
 
 # Network
 ELECTRUM_BITCOIN_HOST=35.187.18.233

--- a/.env.test.template
+++ b/.env.test.template
@@ -21,7 +21,7 @@ BACKUPS_SERVER_PUBKEY=0319c4ff23820afec0c79ce3a42031d7fef1dff78b7bdd69b5560684f3
 WEB_RELAY=https://webrelay.slashtags.to
 
 # Blocktank
-BLOCKTANK_HOST=https://api.stag.blocktank.to
+BLOCKTANK_HOST=https://api1.blocktank.to/api
 
 # Network
 ELECTRUM_BITCOIN_HOST=35.187.18.233


### PR DESCRIPTION
### Description
- Updates `BLOCKTANK_HOST` to `https://api1.blocktank.to/api` in  `.env` templates.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test

### QA Notes
- Opening channels with Blocktank and returning exchange rates from `getExchangeRates` should continue working as expected.
