### PR TITLE
fix(activity): wrong txId in some places

### DIFF
--- a/src/screens/Activity/ActivityDetail.tsx
+++ b/src/screens/Activity/ActivityDetail.tsx
@@ -170,7 +170,7 @@ const OnchainActivityDetail = ({
 			return;
 		}
 
-		getTransactions({ txHashes: [{ tx_hash: id }] }).then((txResponse) => {
+		getTransactions({ txHashes: [{ tx_hash: txId }] }).then((txResponse) => {
 			if (txResponse.isErr()) {
 				showToast({
 					type: 'warning',
@@ -191,21 +191,21 @@ const OnchainActivityDetail = ({
 			const data = txData[0].result;
 			setTxDetails(data);
 		});
-	}, [id, activityType, extended, selectedNetwork, txDetails, t]);
+	}, [txId, activityType, extended, selectedNetwork, txDetails, t]);
 
 	const showBoost = useMemo(() => {
 		if (confirmed || isBoosted) {
 			return false;
 		}
-		return canBoost(id).canBoost;
-	}, [confirmed, isBoosted, id]);
+		return canBoost(txId).canBoost;
+	}, [confirmed, isBoosted, txId]);
 
 	const boostedParents = useMemo(() => {
 		return getBoostedTransactionParents({
-			txid: id,
+			txId,
 			boostedTransactions,
 		});
-	}, [boostedTransactions, id]);
+	}, [boostedTransactions, txId]);
 
 	const hasBoostedParents = useMemo(() => {
 		return boostedParents.length > 0;
@@ -213,7 +213,11 @@ const OnchainActivityDetail = ({
 
 	const handleBoostParentPress = useCallback(
 		(parentTxId) => {
-			const activityItem = activityItems.find((i) => i.id === parentTxId);
+			const activityItem = activityItems.find((i) => {
+				return (
+					i.activityType === EActivityType.onchain && i.txId === parentTxId
+				);
+			});
 			if (activityItem) {
 				navigation.push('ActivityDetail', { id: activityItem.id });
 			}
@@ -250,7 +254,7 @@ const OnchainActivityDetail = ({
 		}
 	};
 
-	const blockExplorerUrl = getBlockExplorerLink(id);
+	const blockExplorerUrl = getBlockExplorerLink(txId);
 
 	const handleExplore = (): void => {
 		navigation.push('ActivityDetail', {
@@ -589,10 +593,8 @@ const OnchainActivityDetail = ({
 								<Section
 									title={t('activity_input', { count: txDetails.vin.length })}
 									value={txDetails.vin.map((v) => {
-										const txid = v.txid;
-										const vout = v.vout;
-										const i = txid + ':' + vout;
-										return <BodySSB key={i}>{i}</BodySSB>;
+										const input = `${v.txid}:${v.vout}`;
+										return <BodySSB key={input}>{input}</BodySSB>;
 									})}
 								/>
 							</View>
@@ -626,7 +628,7 @@ const OnchainActivityDetail = ({
 													onPress={(): void => {
 														handleBoostParentPress(parent);
 													}}>
-													<BodySSB numberOfLines={1} ellipsizeMode={'middle'}>
+													<BodySSB numberOfLines={1} ellipsizeMode="middle">
 														{parent}
 													</BodySSB>
 												</TouchableOpacity>

--- a/src/utils/boost.ts
+++ b/src/utils/boost.ts
@@ -25,19 +25,19 @@ export const getBoostedTransactions = ({
 
 /**
  * Returns an array of parents for a boosted transaction id.
- * @param {string} txid
+ * @param {string} txId
  * @param {IBoostedTransactions} [boostedTransactions]
  * @param {TWalletName} [selectedWallet]
  * @param {EAvailableNetwork} [selectedNetwork]
  * @returns {string[]}
  */
 export const getBoostedTransactionParents = ({
-	txid,
+	txId,
 	boostedTransactions,
 	selectedWallet = getSelectedWallet(),
 	selectedNetwork = getSelectedNetwork(),
 }: {
-	txid: string;
+	txId: string;
 	boostedTransactions?: IBoostedTransactions;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
@@ -49,28 +49,28 @@ export const getBoostedTransactionParents = ({
 		});
 	}
 	const boostObj = Object.values(boostedTransactions).find((boostObject) => {
-		return boostObject.childTransaction === txid;
+		return boostObject.childTransaction === txId;
 	});
 
 	return boostObj?.parentTransactions ?? [];
 };
 
 /**
- * Determines if a given txid has any boosted parents.
+ * Determines if a given txId has any boosted parents.
  * // TODO: Migrate to Beignet
- * @param {string} txid
+ * @param {string} txId
  * @param {IBoostedTransactions} [boostedTransactions]
  * @param {TWalletName} [selectedWallet]
  * @param {EAvailableNetwork} [selectedNetwork]
  * @returns {boolean}
  */
 export const hasBoostedParents = ({
-	txid,
+	txId,
 	boostedTransactions,
 	selectedWallet = getSelectedWallet(),
 	selectedNetwork = getSelectedNetwork(),
 }: {
-	txid: string;
+	txId: string;
 	boostedTransactions?: IBoostedTransactions;
 	selectedWallet?: TWalletName;
 	selectedNetwork?: EAvailableNetwork;
@@ -82,15 +82,15 @@ export const hasBoostedParents = ({
 		});
 	}
 	const boostedParents = getBoostedTransactionParents({
-		txid,
+		txId,
 		boostedTransactions,
 	});
 	return boostedParents.length > 0;
 };
 
 /**
- * Returns the initially boosted transaction's activity item for a given txid.
- * @param {string} txid
+ * Returns the initially boosted transaction's activity item for a given txId.
+ * @param {string} txId
  * @param {IActivityItem[]} [items]
  * @param {IBoostedTransactions} [boostedTransactions]
  * @param {TWalletName} [selectedWallet]
@@ -98,13 +98,13 @@ export const hasBoostedParents = ({
  * @returns {TOnchainActivityItem|undefined}
  */
 export const getRootParentActivity = ({
-	txid,
+	txId,
 	items,
 	boostedTransactions,
 	selectedWallet = getSelectedWallet(),
 	selectedNetwork = getSelectedNetwork(),
 }: {
-	txid: string;
+	txId: string;
 	items: TOnchainActivityItem[];
 	boostedTransactions?: IBoostedTransactions;
 	selectedWallet?: TWalletName;
@@ -117,7 +117,7 @@ export const getRootParentActivity = ({
 		});
 	}
 	const boostedParents = getBoostedTransactionParents({
-		txid,
+		txId,
 		boostedTransactions,
 	});
 	if (!boostedParents.length) {
@@ -169,7 +169,7 @@ export const formatBoostedActivityItems = ({
 	const formattedItems: TOnchainActivityItem[] = [];
 
 	items.forEach((item) => {
-		const txid = item.id;
+		const txId = item.id;
 
 		// if boosted tx don't add for now
 		if (item.id in boostedTransactions) {
@@ -177,7 +177,7 @@ export const formatBoostedActivityItems = ({
 		}
 
 		const rootParent = getRootParentActivity({
-			txid,
+			txId,
 			items,
 			boostedTransactions,
 			selectedWallet,
@@ -246,7 +246,7 @@ export const calculateBoostTransactionValue = ({
 		return currentActivityItem.value;
 	}
 	const rootParent = getRootParentActivity({
-		txid: currentActivityItem.id,
+		txId: currentActivityItem.id,
 		items,
 		boostedTransactions,
 	});


### PR DESCRIPTION
### Description

Follow up to https://github.com/synonymdev/bitkit/pull/1866. Fix needed because transfer activity item id refers to the funding tx and not the sweep tx.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/1902

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
