### PR TITLE
refactor: Add priority to isOnline for LN checks in App Status

### DIFF
--- a/src/screens/Settings/AppStatus/index.tsx
+++ b/src/screens/Settings/AppStatus/index.tsx
@@ -105,13 +105,16 @@ const AppStatus = ({}: SettingsScreenProps<'AppStatus'>): ReactElement => {
 			return 'pending';
 		}
 		return isConnectedToElectrum ? 'ready' : 'error';
-	}, [isConnectedToElectrum, isElectrumThrottled, isOnline]);
+	}, [isOnline, isConnectedToElectrum, isElectrumThrottled]);
 
 	const lightningNodeState: TItemState = useMemo(() => {
-		return isLDKReady ? 'ready' : 'error';
-	}, [isLDKReady]);
+		return isOnline && isLDKReady ? 'ready' : 'error';
+	}, [isOnline, isLDKReady]);
 
 	const lightningConnectionState: TItemState = useMemo(() => {
+		if (!isOnline) {
+			return 'error';
+		}
 		if (openChannels.length > 0) {
 			return 'ready';
 		} else if (
@@ -121,7 +124,12 @@ const AppStatus = ({}: SettingsScreenProps<'AppStatus'>): ReactElement => {
 			return 'pending';
 		}
 		return 'error';
-	}, [openChannels, pendingChannels, paidOrders]);
+	}, [
+		isOnline,
+		openChannels.length,
+		pendingChannels.length,
+		paidOrders.created,
+	]);
 
 	// Keep checking backup status
 	useEffect(() => {


### PR DESCRIPTION
### Description

Adds pre-condition for internet connection to be active for determining Lightning connections and Lightning node state on the AppStatus screen.

Additionally, it also ensures these 2 status items would refresh on UI each time internet connection status changes.

### Linked Issues/Tasks

n/a, slack convo

### Type of change

- [x] Refactoring (improving code without creating new functionality)

### Tests

- [x] Detox test (existing tests should validate this change)

### QA Notes

Nothing special here, just optimisation for faster update of the _real_ LN status on this screen. Also makes a lot of sense to prioritise internet connection as a preliminary check for these internet-dependent features (LN node, LN peer conns).