### PR TITLE
fix(lightning): Remove lspNodeId

### DIFF
--- a/src/screens/Lightning/CustomSetup.tsx
+++ b/src/screens/Lightning/CustomSetup.tsx
@@ -299,7 +299,6 @@ const CustomSetup = ({
 				lspBalance: amount,
 				options: {
 					clientBalanceSat: spendingAmount,
-					lspNodeId: blocktankInfo.nodes[0].pubkey,
 					turboChannel:
 						spendingAmount <= blocktankInfo.options.max0ConfClientBalanceSat,
 				},

--- a/src/screens/Lightning/QuickSetup.tsx
+++ b/src/screens/Lightning/QuickSetup.tsx
@@ -164,7 +164,6 @@ const QuickSetup = ({
 		const purchaseResponse = await startChannelPurchase({
 			clientBalance,
 			lspBalance,
-			lspNodeId: blocktankInfo.nodes[0].pubkey,
 			zeroConfPayment: clientBalance <= max0ConfClientBalance,
 		});
 		setLoading(false);
@@ -183,7 +182,6 @@ const QuickSetup = ({
 			orderId: purchaseResponse.value.id,
 		});
 	}, [
-		blocktankInfo.nodes,
 		lnSetup,
 		max0ConfClientBalance,
 		navigation,


### PR DESCRIPTION
### Description
- Removes `lspNodeId` from `createOrder` options.

### Linked Issues/Tasks
- #1912

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
