### PR TITLE
fix: slider when do re-balance

### DIFF
--- a/src/components/FancySlider.tsx
+++ b/src/components/FancySlider.tsx
@@ -179,6 +179,7 @@ const FancySlider = ({
 							active.current = false;
 							handlePanEnd();
 						});
+						return;
 					}
 
 					if (pan.x._value < snapPointX && pan.x._value >= snapPointX * 0.65) {
@@ -191,8 +192,8 @@ const FancySlider = ({
 							active.current = false;
 							handlePanEnd();
 						});
+						return;
 					}
-					return;
 				}
 
 				active.current = false;


### PR DESCRIPTION
### Description

Fixing the #1887 fix

### Linked Issues/Tasks

#1908 

### Type of change

Bug fix

### Tests

No test

### QA Notes

Fixes the slider on Quick screen.
Continue button now should work fine
