### PR TITLE
fix(transfer): prevent NaN percentage

### DIFF
--- a/src/screens/Lightning/QuickConfirm.tsx
+++ b/src/screens/Lightning/QuickConfirm.tsx
@@ -52,10 +52,10 @@ const QuickConfirm = ({
 	const lspFee = purchaseFeeValue.fiatValue - clientBalance.fiatValue;
 
 	const savingsAmount = onchainBalance - spendingAmount;
-	const spendingPercentage = Math.round(
-		(spendingAmount / onchainBalance) * 100,
-	);
-	const savingsPercentage = Math.round((savingsAmount / onchainBalance) * 100);
+	const spendingPercentage =
+		Math.round((spendingAmount / onchainBalance) * 100) || 0;
+	const savingsPercentage =
+		Math.round((savingsAmount / onchainBalance) * 100) || 0;
 
 	const handleConfirm = async (): Promise<void> => {
 		setLoading(true);


### PR DESCRIPTION
### Description

Fixes a small issue where the `QuickConfirm` screen shows `NaN` as percentage when the user has 0 onchain balance.

![Simulator Screenshot - iPhone 15 - 2024-05-29 at 23 42 46](https://github.com/synonymdev/bitkit/assets/8538369/e6cfaccb-4187-43c9-81bb-7d5ed070d351)
