### PR TITLE
fix(ui): Fix Backup Modal

### DIFF
--- a/src/screens/Settings/BackupSettings/index.tsx
+++ b/src/screens/Settings/BackupSettings/index.tsx
@@ -10,7 +10,7 @@ import { lightningBackupSelector } from '../../../store/reselect/lightning';
 import { forceBackup } from '../../../store/slices/backup';
 import { TBackupItem } from '../../../store/types/backup';
 import { EBackupCategories } from '../../../store/utils/backup';
-import { showBottomSheet } from '../../../store/utils/ui';
+import { toggleBottomSheet } from '../../../store/utils/ui';
 import {
 	ScrollView,
 	View as ThemedView,
@@ -217,7 +217,7 @@ const BackupSettings = ({
 						type: EItemType.button,
 						testID: 'BackupWallet',
 						onPress: (): void => {
-							showBottomSheet('backupNavigation');
+							toggleBottomSheet('backupNavigation');
 						},
 					},
 					{


### PR DESCRIPTION
### Description
- Swaps backup modal button to `toggleBottomSheet('backupNavigation');` to prevent getting hard-locked.
- Related to #1829.

### Linked Issues/Tasks
- #1927

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Tests
- [x] No test

### QA Notes
- Pressing the "Back up your wallet" button repeatedly in "Settings->Back up or Restore" should no longer hard-lock the modal closed.
