### PR TITLE
chore: set android minSdk to 28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@
 buildscript {
     ext {
         buildToolsVersion = "34.0.0"
-        minSdkVersion = 24
+        minSdkVersion = 28
         compileSdkVersion = 34
         targetSdkVersion = 34
         kotlin_version = "1.8.0"


### PR DESCRIPTION
Closes #1826

### Description

Bumps min required Android version to `9`, to fix a known crash and many other unknown potential crashes/ bugs on obsolete Android devices that can't/won't upgrade to Android 9.

### Linked Issues/Tasks
- #1826

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Tests

- [x] No test

### QA Notes

Try installing on emulator or device with Android version under 9. It shouldn't succeed.
In the store users will be informed automatically their device can't install the app.