### PR TITLE
chore(wallet): Increase Gap Limit

### DIFF
--- a/src/store/shapes/wallet.ts
+++ b/src/store/shapes/wallet.ts
@@ -164,8 +164,8 @@ export const defaultWalletShape: Readonly<IWallet> = {
 };
 
 const defaultGapLimitOptions = {
-	lookAhead: 5,
-	lookBehind: 5,
+	lookAhead: 10,
+	lookBehind: 10,
 };
 
 export const getDefaultGapLimitOptions = (): TGapLimitOptions => {

--- a/src/utils/wallet/constants.ts
+++ b/src/utils/wallet/constants.ts
@@ -2,15 +2,6 @@ export const BITKIT_WALLET_SEED_HASH_PREFIX = Buffer.from(
 	'@Bitkit/wallet-uuid',
 );
 
-// How many addresses to generate when more are needed.
-export const GENERATE_ADDRESS_AMOUNT = 5;
-
-// TODO: Add this as a settings for users to adjust when needed.
-export const GAP_LIMIT = 20;
-
-// TODO: remove chunk logic and move it to rn-electrum library
-export const CHUNK_LIMIT = 15;
-
 export const TRANSACTION_DEFAULTS = {
 	recommendedBaseFee: 256, // Total recommended tx base fee in sats
 	dustLimit: 546, // Minimum value in sats for an output. Outputs below the dust limit may not be processed because the fees required to include them in a block would be greater than the value of the transaction itself.


### PR DESCRIPTION
### Description
- Increases default gap limit to `10` for new wallets.
- Removes unused constants.

### Type of change
- [x] Refactoring (improving code without creating new functionality)

### Tests
- [x] No test

### QA Notes
- New wallets should now have a default gap limit of 10 that can be confirmed by navigating to "Settings->Advanced->Address Gap Limit".
