### PR TITLE
fix: currency conversions with classic denomination

### DIFF
--- a/__tests__/numberpad.ts
+++ b/__tests__/numberpad.ts
@@ -1,6 +1,32 @@
-// Fix 'getDispatch is not a function'
 import '../src/store/utils/ui';
-import { handleNumberPadPress } from '../src/utils/numberpad';
+import {
+	resetExchangeRates,
+	updateExchangeRates,
+} from '../src/store/actions/wallet';
+import { EDenomination, EUnit } from '../src/store/types/wallet';
+import { getNumberPadText, handleNumberPadPress } from '../src/utils/numberpad';
+
+// @ts-ignore
+global.fetch = jest.fn(() =>
+	Promise.resolve({
+		json: () =>
+			Promise.resolve({
+				tickers: [
+					{
+						symbol: 'BTCUSD',
+						lastPrice: '50000.00',
+						base: 'BTC',
+						baseName: 'Bitcoin',
+						quote: 'USD',
+						quoteName: 'US Dollar',
+						currencySymbol: '$',
+						currencyFlag: '🇺🇸',
+						lastUpdatedAt: 1702295629052,
+					},
+				],
+			}),
+	}),
+);
 
 describe('Receive/Send NumberPad', () => {
 	it('can add a character', () => {
@@ -73,5 +99,67 @@ describe('Receive/Send NumberPad', () => {
 
 		const result = handleNumberPadPress(input, current);
 		expect(result).toEqual(expected);
+	});
+});
+
+describe('getNumberPadText', () => {
+	describe('can work without exchange rates', () => {
+		beforeAll(() => resetExchangeRates());
+
+		it('can convert to BTC with classic denomination', () => {
+			const r = getNumberPadText(100000, EDenomination.classic, EUnit.BTC);
+			expect(r).toEqual('0.001');
+		});
+	});
+
+	describe('with exchange rates', () => {
+		beforeAll(async () => {
+			const r = await updateExchangeRates({});
+			if (r.isErr()) {
+				throw r.error;
+			}
+		});
+
+		it('if amount is 0, return empty string', () => {
+			const r = getNumberPadText(0, EDenomination.classic, EUnit.BTC);
+			expect(r).toEqual('');
+		});
+
+		it('can convert to BTC with classic denomination', () => {
+			const r = getNumberPadText(100000, EDenomination.classic, EUnit.BTC);
+			expect(r).toEqual('0.001');
+		});
+
+		it('can convert to BTC with modern denomination', () => {
+			const r = getNumberPadText(100000, EDenomination.modern, EUnit.BTC);
+			expect(r).toEqual('100000');
+		});
+
+		it('can convert to FIAT with classic denomination', () => {
+			const r = getNumberPadText(100000, EDenomination.classic, EUnit.fiat);
+			expect(r).toEqual('50');
+		});
+
+		it('can convert to FIAT with modern denomination', () => {
+			const r = getNumberPadText(100000, EDenomination.classic, EUnit.fiat);
+			expect(r).toEqual('50');
+		});
+
+		it('can round FIAT value', () => {
+			const r1 = getNumberPadText(
+				33333,
+				EDenomination.classic,
+				EUnit.fiat,
+				false,
+			);
+			expect(r1).toEqual('16.6665');
+			const r2 = getNumberPadText(
+				33333,
+				EDenomination.classic,
+				EUnit.fiat,
+				true,
+			);
+			expect(r2).toEqual('17');
+		});
 	});
 });

--- a/src/utils/conversion.ts
+++ b/src/utils/conversion.ts
@@ -36,7 +36,9 @@ export const convertToSats = (
 	}
 
 	if (unit === EConversionUnit.fiat) {
-		return fiatToBitcoinUnit({ amount });
+		const denomination = getSettingsStore().denomination;
+		const btcUnit = fiatToBitcoinUnit({ amount });
+		return denomination === EDenomination.modern ? btcUnit : btcToSats(btcUnit);
 	}
 
 	return amount;

--- a/src/utils/displayValues/index.ts
+++ b/src/utils/displayValues/index.ts
@@ -70,6 +70,7 @@ export const getBitcoinDisplayValues = ({
 
 export const getFiatDisplayValues = ({
 	satoshis,
+	denomination,
 	exchangeRate,
 	exchangeRates,
 	currency,
@@ -78,6 +79,7 @@ export const getFiatDisplayValues = ({
 	shouldRoundUp = false,
 }: {
 	satoshis: number;
+	denomination?: EDenomination;
 	exchangeRate?: number;
 	exchangeRates?: IExchangeRates;
 	currency?: string;
@@ -85,7 +87,9 @@ export const getFiatDisplayValues = ({
 	locale?: string;
 	shouldRoundUp?: boolean;
 }): IFiatDisplayValues => {
-	const denomination = getSettingsStore().denomination;
+	if (!denomination) {
+		denomination = getSettingsStore().denomination;
+	}
 
 	if (!exchangeRates) {
 		exchangeRates = getWalletStore().exchangeRates;
@@ -248,6 +252,7 @@ export const getDisplayValues = ({
 	});
 	const fiatDisplayValues = getFiatDisplayValues({
 		satoshis,
+		denomination,
 		exchangeRate,
 		currency,
 		currencySymbol,

--- a/src/utils/numberpad/index.ts
+++ b/src/utils/numberpad/index.ts
@@ -71,9 +71,9 @@ export const getNumberPadText = (
 		return '';
 	}
 
-	const displayValue = getDisplayValues({ satoshis: amount });
+	const displayValue = getDisplayValues({ satoshis: amount, denomination });
 
-	if (denomination === EDenomination.classic) {
+	if (denomination === EDenomination.classic && unit === EUnit.BTC) {
 		const { bitcoinWhole, bitcoinDecimal } = displayValue;
 		const decimalPart = Number(bitcoinDecimal) ? `.${bitcoinDecimal}` : '';
 		return `${bitcoinWhole}${decimalPart}`;


### PR DESCRIPTION
### Description

- fix convertToSats when convering from fiat with classic denomination
- fix getNumberPadText when convering from fiat with classic denomination
- fix getDisplayValues to show correct bitcoinFormatted when using classic denomination
- add tests for these cases

### Linked Issues/Tasks

### Type of change

Bug fix

### Tests

Unit test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/155891/36567260-34b2-479b-8e4e-6e389e75200e


### QA Notes

- switch to classic denomination
- test all places where we are using custom number keyboard
