### PR TITLE
fix: do not show UnifiedIcon if ln invoice is not available

### DIFF
--- a/src/screens/Wallets/Receive/ReceiveQR.tsx
+++ b/src/screens/Wallets/Receive/ReceiveQR.tsx
@@ -352,7 +352,7 @@ const ReceiveQR = ({
 						<LightningCircleIcon width={50} height={50} />
 					) : (
 						<>
-							{enableInstant ? (
+							{enableInstant && lightningInvoice ? (
 								<UnifiedIcon width={50} height={50} />
 							) : (
 								<BitcoinCircleIcon width={50} height={50} />
@@ -362,7 +362,7 @@ const ReceiveQR = ({
 				</View>
 			</View>
 		);
-	}, [jitInvoice, enableInstant]);
+	}, [jitInvoice, enableInstant, lightningInvoice]);
 
 	const Slide1 = useCallback((): ReactElement => {
 		return (


### PR DESCRIPTION
### Description

Do not show Unified LN/Onchain icon on qrcode if LN invoice failed 

### Linked Issues/Tasks

closes #1923

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video

![image](https://github.com/synonymdev/bitkit/assets/155891/41f92e95-1cf6-4607-8fdc-4ae0a5461289)


### QA Notes


