### PR TITLE
fix(ui): don't refresh wallet in background

### DIFF
--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -1,3 +1,4 @@
+import { AppState } from 'react-native';
 import { err, ok, Result } from '@synonymdev/result';
 
 import actions from './actions';
@@ -849,8 +850,15 @@ export const setWalletData = async <K extends keyof IWalletData>(
 				const header = data as IHeader;
 				const selectedNetwork = getNetworkFromBeignet(network);
 				updateHeader({ header, selectedNetwork });
-				// Make sure transactions are updated after a new block is received.
-				await refreshWallet({ lightning: false });
+
+				const appState = AppState.currentState;
+				const appInBackground = ['background', 'inactive'].includes(appState);
+
+				// If the app is in the background, refreshing will fail.
+				if (!appInBackground) {
+					// Make sure transactions are updated after a new block is received.
+					await refreshWallet({ lightning: false });
+				}
 				break;
 			case 'feeEstimates':
 				updateOnchainFeeEstimates({

--- a/src/utils/wallet/electrum.ts
+++ b/src/utils/wallet/electrum.ts
@@ -224,7 +224,7 @@ export const connectToElectrum = async ({
 	const electrum = getOnChainWalletElectrum();
 
 	// Attempt to disconnect from any old/lingering connections
-	await electrum.disconnect();
+	await electrum?.disconnect();
 
 	// Fetch any stored custom peers.
 	if (!customPeers) {

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -217,7 +217,7 @@ const refreshBeignet = async (
 	checkGapLimit();
 };
 
-const handleRefreshError = (msg): void => {
+const handleRefreshError = (msg: string): void => {
 	// If the error is due to the batch limit being exceeded, show a toast and set the throttled state.
 	if (msg.includes('Batch limit exceeded')) {
 		showToast({


### PR DESCRIPTION
### Description

Prevent wallet refreshing on new incoming block when the app is in background. Because electrum is not connected it will fail showing an error toast. Wallet will still be up-to-date when resuming.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/2004

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/synonymdev/bitkit/assets/8538369/3b017bfd-e500-4f91-9479-66cecfe55294

### QA Notes

No more false error toasts, refresh should still work as expected