### PR TITLE
chore: remove release-profiler

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -927,10 +927,6 @@ PODS:
     - React-Core
   - react-native-randombytes (3.6.1):
     - React-Core
-  - react-native-release-profiler (0.1.6):
-    - glog
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core
   - react-native-restart (0.0.27):
     - React-Core
   - react-native-safe-area-context (4.9.0):
@@ -1213,7 +1209,6 @@ DEPENDENCIES:
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-quick-crypto (from `../node_modules/react-native-quick-crypto`)
   - react-native-randombytes (from `../node_modules/react-native-randombytes`)
-  - react-native-release-profiler (from `../node_modules/react-native-release-profiler`)
   - react-native-restart (from `../node_modules/react-native-restart`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - "react-native-skia (from `../node_modules/@shopify/react-native-skia`)"
@@ -1348,8 +1343,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-quick-crypto"
   react-native-randombytes:
     :path: "../node_modules/react-native-randombytes"
-  react-native-release-profiler:
-    :path: "../node_modules/react-native-release-profiler"
   react-native-restart:
     :path: "../node_modules/react-native-restart"
   react-native-safe-area-context:
@@ -1484,7 +1477,6 @@ SPEC CHECKSUMS:
   react-native-netinfo: bdb108d340cdb41875c9ced535977cac6d2ff321
   react-native-quick-crypto: 455c1b411db006dba1026a30681ececb19180187
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
-  react-native-release-profiler: 0d212252f56756942eb44e6873a2047185084aa0
   react-native-restart: 7595693413fe3ca15893702f2c8306c62a708162
   react-native-safe-area-context: b97eb6f9e3b7f437806c2ce5983f479f8eb5de4b
   react-native-skia: 24d41bf966446b911930f7f15aebae6310413cd3
@@ -1530,7 +1522,7 @@ SPEC CHECKSUMS:
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
   sodium-react-native-direct: 102289e2a55688b5c6c489c88b2a7915d4e31ec1
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
-  Yoga: 2a16e58450c48e110211dae1159fb114bbcdcfc0
+  Yoga: e5b887426cee15d2a326bdd34afc0282fc0486ad
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
 PODFILE CHECKSUM: a25ec9d4205c8710cfcf7ec52d853eaf4b026cc5

--- a/ios/bitkit.xcodeproj/project.pbxproj
+++ b/ios/bitkit.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		17074219BB5847259EAFC7A6 /* InterTight-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3815D562618543E7A9BC191E /* InterTight-Black.ttf */; };
+		51D00261347390AF845139A0 /* libPods-bitkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B279B4FB175BDA891A576AB3 /* libPods-bitkit.a */; };
 		57072143CA0F49089AE64F61 /* InterTight-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A223BA795CEB4CB2B344FBAF /* InterTight-ExtraBold.ttf */; };
 		6132EF182BDFF13200BBE14D /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 6132EF172BDFF13200BBE14D /* PrivacyInfo.xcprivacy */; };
 		6980B602E6DC4429841BE5EE /* InterTight-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D67AECF5F543462F90EC89AD /* InterTight-Medium.ttf */; };
@@ -20,8 +21,7 @@
 		925570EA7B1D43CC8AD07B91 /* InterTight-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CA37793F82F144678099A00D /* InterTight-Bold.ttf */; };
 		9952E811473D46FB9003A56D /* InterTight-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 50A8DA09F2974D05A3C58E87 /* InterTight-SemiBold.ttf */; };
 		B3BE07A9843E4B7DA375B877 /* InterTight-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 79DFAC55B0D745DE815EC2E0 /* InterTight-Regular.ttf */; };
-		B4337BFFC42CE551F61F8E99 /* libPods-bitkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F3C1CD3357EF3ECAECA5F84F /* libPods-bitkit.a */; };
-		E075F474859D9157F496492D /* libPods-bitkit-bitkitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C04AD6C0F1548788B47F5FA /* libPods-bitkit-bitkitTests.a */; };
+		C9838F5FCB708958D530EA89 /* libPods-bitkit-bitkitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A1AD7EA396E7252863B23FE0 /* libPods-bitkit-bitkitTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,7 +38,6 @@
 		00E356EE1AD99517003FC87E /* bitkitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = bitkitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* bitkitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bitkitTests.m; sourceTree = "<group>"; };
-		0210433554408A84E886A54E /* Pods-bitkit-bitkitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.release.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.release.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* bitkit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = bitkit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = bitkit/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = bitkit/AppDelegate.mm; sourceTree = "<group>"; };
@@ -46,20 +45,21 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = bitkit/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = bitkit/main.m; sourceTree = "<group>"; };
 		3815D562618543E7A9BC191E /* InterTight-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Black.ttf"; path = "../src/assets/fonts/InterTight-Black.ttf"; sourceTree = "<group>"; };
-		4C04AD6C0F1548788B47F5FA /* libPods-bitkit-bitkitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit-bitkitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		414EC933CA1AB3B91D0DDF60 /* Pods-bitkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.debug.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.debug.xcconfig"; sourceTree = "<group>"; };
 		50A8DA09F2974D05A3C58E87 /* InterTight-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-SemiBold.ttf"; path = "../src/assets/fonts/InterTight-SemiBold.ttf"; sourceTree = "<group>"; };
 		6132EF172BDFF13200BBE14D /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; name = PrivacyInfo.xcprivacy; path = bitkit/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		6DC9675F563720D46967122F /* Pods-bitkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.debug.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.debug.xcconfig"; sourceTree = "<group>"; };
+		78D53C330D7595FE6A5011C5 /* Pods-bitkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.release.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.release.xcconfig"; sourceTree = "<group>"; };
 		79DFAC55B0D745DE815EC2E0 /* InterTight-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Regular.ttf"; path = "../src/assets/fonts/InterTight-Regular.ttf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = bitkit/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		81D87CFB1643AED818224F69 /* Pods-bitkit-bitkitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.release.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.release.xcconfig"; sourceTree = "<group>"; };
+		A1AD7EA396E7252863B23FE0 /* libPods-bitkit-bitkitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit-bitkitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A223BA795CEB4CB2B344FBAF /* InterTight-ExtraBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-ExtraBold.ttf"; path = "../src/assets/fonts/InterTight-ExtraBold.ttf"; sourceTree = "<group>"; };
-		C49522670C126A5021ADA894 /* Pods-bitkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.release.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.release.xcconfig"; sourceTree = "<group>"; };
+		B279B4FB175BDA891A576AB3 /* libPods-bitkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		C6F3694E5EBAA8F412E46811 /* Pods-bitkit-bitkitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.debug.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		CA37793F82F144678099A00D /* InterTight-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Bold.ttf"; path = "../src/assets/fonts/InterTight-Bold.ttf"; sourceTree = "<group>"; };
-		D5A2648745D5B253AC9440EF /* Pods-bitkit-bitkitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.debug.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		D67AECF5F543462F90EC89AD /* InterTight-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Medium.ttf"; path = "../src/assets/fonts/InterTight-Medium.ttf"; sourceTree = "<group>"; };
 		DEC74C5375A34FFCAEBA0781 /* Damion-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Damion-Regular.ttf"; path = "../src/assets/fonts/Damion-Regular.ttf"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
-		F3C1CD3357EF3ECAECA5F84F /* libPods-bitkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,7 +67,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E075F474859D9157F496492D /* libPods-bitkit-bitkitTests.a in Frameworks */,
+				C9838F5FCB708958D530EA89 /* libPods-bitkit-bitkitTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -75,7 +75,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B4337BFFC42CE551F61F8E99 /* libPods-bitkit.a in Frameworks */,
+				51D00261347390AF845139A0 /* libPods-bitkit.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -117,8 +117,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				F3C1CD3357EF3ECAECA5F84F /* libPods-bitkit.a */,
-				4C04AD6C0F1548788B47F5FA /* libPods-bitkit-bitkitTests.a */,
+				B279B4FB175BDA891A576AB3 /* libPods-bitkit.a */,
+				A1AD7EA396E7252863B23FE0 /* libPods-bitkit-bitkitTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -181,10 +181,10 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				6DC9675F563720D46967122F /* Pods-bitkit.debug.xcconfig */,
-				C49522670C126A5021ADA894 /* Pods-bitkit.release.xcconfig */,
-				D5A2648745D5B253AC9440EF /* Pods-bitkit-bitkitTests.debug.xcconfig */,
-				0210433554408A84E886A54E /* Pods-bitkit-bitkitTests.release.xcconfig */,
+				414EC933CA1AB3B91D0DDF60 /* Pods-bitkit.debug.xcconfig */,
+				78D53C330D7595FE6A5011C5 /* Pods-bitkit.release.xcconfig */,
+				C6F3694E5EBAA8F412E46811 /* Pods-bitkit-bitkitTests.debug.xcconfig */,
+				81D87CFB1643AED818224F69 /* Pods-bitkit-bitkitTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -196,12 +196,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "bitkitTests" */;
 			buildPhases = (
-				27A70E247E6437E99AB24A30 /* [CP] Check Pods Manifest.lock */,
+				1BA0297A2D7B4E008FDF2318 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				722F9B7B019CD465BF43CF41 /* [CP] Embed Pods Frameworks */,
-				A27F8BE895E3AF13C40567C6 /* [CP] Copy Pods Resources */,
+				2136FFD33B2FCC6C4CA4C151 /* [CP] Embed Pods Frameworks */,
+				2F7DEF0543988F48813A71D4 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -217,13 +217,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "bitkit" */;
 			buildPhases = (
-				0DEFB311C84BF11A737D3057 /* [CP] Check Pods Manifest.lock */,
+				01112F91F8597A4A7D8E3E63 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				727FEE0EC0E54840E7FF38FE /* [CP] Embed Pods Frameworks */,
-				A9B832B629984A7E8DBCD57C /* [CP] Copy Pods Resources */,
+				CE529BF58ADC7075942FC513 /* [CP] Embed Pods Frameworks */,
+				3F10983C2A77F56A8BADAEC9 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -314,7 +314,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"../node_modules/react-native/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"../node_modules/react-native/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		0DEFB311C84BF11A737D3057 /* [CP] Check Pods Manifest.lock */ = {
+		01112F91F8597A4A7D8E3E63 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -336,7 +336,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		27A70E247E6437E99AB24A30 /* [CP] Check Pods Manifest.lock */ = {
+		1BA0297A2D7B4E008FDF2318 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -358,7 +358,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		722F9B7B019CD465BF43CF41 /* [CP] Embed Pods Frameworks */ = {
+		2136FFD33B2FCC6C4CA4C151 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -375,24 +375,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		727FEE0EC0E54840E7FF38FE /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A27F8BE895E3AF13C40567C6 /* [CP] Copy Pods Resources */ = {
+		2F7DEF0543988F48813A71D4 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -409,7 +392,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A9B832B629984A7E8DBCD57C /* [CP] Copy Pods Resources */ = {
+		3F10983C2A77F56A8BADAEC9 /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -424,6 +407,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		CE529BF58ADC7075942FC513 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -459,7 +459,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D5A2648745D5B253AC9440EF /* Pods-bitkit-bitkitTests.debug.xcconfig */;
+			baseConfigurationReference = C6F3694E5EBAA8F412E46811 /* Pods-bitkit-bitkitTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -487,7 +487,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0210433554408A84E886A54E /* Pods-bitkit-bitkitTests.release.xcconfig */;
+			baseConfigurationReference = 81D87CFB1643AED818224F69 /* Pods-bitkit-bitkitTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -512,7 +512,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6DC9675F563720D46967122F /* Pods-bitkit.debug.xcconfig */;
+			baseConfigurationReference = 414EC933CA1AB3B91D0DDF60 /* Pods-bitkit.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconOrange;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -544,7 +544,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C49522670C126A5021ADA894 /* Pods-bitkit.release.xcconfig */;
+			baseConfigurationReference = 78D53C330D7595FE6A5011C5 /* Pods-bitkit.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconOrange;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "react-native-randombytes": "3.6.1",
     "react-native-reanimated": "3.8.1",
     "react-native-reanimated-carousel": "3.5.1",
-    "react-native-release-profiler": "^0.1.6",
     "react-native-restart": "0.0.27",
     "react-native-safe-area-context": "4.9.0",
     "react-native-screens": "3.30.1",

--- a/src/screens/Settings/DevSettings/index.tsx
+++ b/src/screens/Settings/DevSettings/index.tsx
@@ -3,7 +3,6 @@ import RNFS, { unlink, writeFile } from 'react-native-fs';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Share from 'react-native-share';
 import { useTranslation } from 'react-i18next';
-import { startProfiling, stopProfiling } from 'react-native-release-profiler';
 
 import actions from '../../../store/actions/actions';
 import {
@@ -41,7 +40,6 @@ import { showToast } from '../../../utils/notifications';
 import { getFakeTransaction } from '../../../utils/wallet/testing';
 import Dialog from '../../../components/Dialog';
 import { resetBackupState } from '../../../store/slices/backup';
-import { updateUi } from '../../../store/slices/ui';
 import { __E2E__ } from '../../../constants/env';
 
 const DevSettings = ({
@@ -54,7 +52,6 @@ const DevSettings = ({
 	const selectedWallet = useAppSelector(selectedWalletSelector);
 	const selectedNetwork = useAppSelector(selectedNetworkSelector);
 	const addressType = useAppSelector(addressTypeSelector);
-	const isProfiling = useAppSelector((state) => state.ui.isProfiling);
 	const warnings = useAppSelector((state) => {
 		return warningsSelector(state, selectedWallet, selectedNetwork);
 	});
@@ -129,24 +126,7 @@ const DevSettings = ({
 		},
 		{
 			title: 'Debug',
-			data: [
-				{
-					title: isProfiling ? 'Stop Profiler' : 'Start Profiler',
-					type: EItemType.button,
-					value: isProfiling,
-					loading: isProfiling,
-					onPress: async (): Promise<void> => {
-						if (isProfiling) {
-							const path = await stopProfiling(true);
-							dispatch(updateUi({ isProfiling: false }));
-							console.log('profile file: ', path);
-						} else {
-							dispatch(updateUi({ isProfiling: true }));
-							startProfiling();
-						}
-					},
-				},
-			],
+			data: [],
 		},
 		{
 			title: 'Wallet Checks',

--- a/src/store/shapes/ui.ts
+++ b/src/store/shapes/ui.ts
@@ -36,7 +36,6 @@ export const initialUiState: TUiState = {
 	isElectrumThrottled: false,
 	isOnline: true,
 	isLDKReady: false, // LDK node running and connected
-	isProfiling: false,
 	language: 'en',
 	profileLink: { title: '', url: '' },
 	timeZone: 'UTC',

--- a/src/store/types/ui.ts
+++ b/src/store/types/ui.ts
@@ -76,7 +76,6 @@ export type TUiState = {
 	isElectrumThrottled: boolean;
 	isOnline: boolean;
 	isLDKReady: boolean;
-	isProfiling: boolean;
 	profileLink: TProfileLink;
 	viewControllers: TUiViewController;
 	timeZone: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2807,15 +2807,6 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/blur/-/blur-4.4.0.tgz#b2440dab17d94e480fbc4470e03155573b5b7375"
   integrity sha512-P+xdT2LIq1ewOsF3zx7C0nu4dj7nxl2NVTsMXEzRDjM3bWMdrrEbTRA7uwPV5ngn7/BXIommBPlT/JW4SAedrw==
 
-"@react-native-community/cli-clean@12.3.5":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-12.3.5.tgz#74426c70b2740ca2cdb70928a5df042574a76276"
-  integrity sha512-EsC1B3kOao+KCTq7vHICnFlQKnVh+bqRFnDq0gFheDzdWFxLHnBujyOaQ7t/gnEafosIGhSh6sOt1GIcVQXgzA==
-  dependencies:
-    "@react-native-community/cli-tools" "12.3.5"
-    chalk "^4.1.2"
-    execa "^5.0.0"
-
 "@react-native-community/cli-clean@12.3.6":
   version "12.3.6"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-clean/-/cli-clean-12.3.6.tgz#e8a7910bebc97266fd5068649013a03958021fc4"
@@ -2824,18 +2815,6 @@
     "@react-native-community/cli-tools" "12.3.6"
     chalk "^4.1.2"
     execa "^5.0.0"
-
-"@react-native-community/cli-config@12.3.5":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-config/-/cli-config-12.3.5.tgz#9b95589ad2075ba9a610029a824cf171ae188bd6"
-  integrity sha512-K65PzZQslNpx9/MV/2tlLs91fQZgJuy7zELXheC9JA4rvY7uTWGVrdOjrI7ZaX/4htIBsek+Gu0TKZW/DUo3Dw==
-  dependencies:
-    "@react-native-community/cli-tools" "12.3.5"
-    chalk "^4.1.2"
-    cosmiconfig "^5.1.0"
-    deepmerge "^4.3.0"
-    glob "^7.1.3"
-    joi "^17.2.1"
 
 "@react-native-community/cli-config@12.3.6":
   version "12.3.6"
@@ -2849,42 +2828,12 @@
     glob "^7.1.3"
     joi "^17.2.1"
 
-"@react-native-community/cli-debugger-ui@12.3.5":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-12.3.5.tgz#d4e2d56a8490d1553dfbbc0401ab349939201a28"
-  integrity sha512-zvJYbrxj98flvdvMoIfG5g7Cmi8kkPvdKor59B7A6jM9h4Km0Pu7n/bMvDhj3SW7qjn3HMG3JWw+i1/SMJ2JAA==
-  dependencies:
-    serve-static "^1.13.1"
-
 "@react-native-community/cli-debugger-ui@12.3.6":
   version "12.3.6"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-debugger-ui/-/cli-debugger-ui-12.3.6.tgz#418027a1ae76850079684d309a732eb378c7f690"
   integrity sha512-SjUKKsx5FmcK9G6Pb6UBFT0s9JexVStK5WInmANw75Hm7YokVvHEgtprQDz2Uvy5znX5g2ujzrkIU//T15KQzA==
   dependencies:
     serve-static "^1.13.1"
-
-"@react-native-community/cli-doctor@12.3.5":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-doctor/-/cli-doctor-12.3.5.tgz#11bfdab98690e62c05513770f08916bd85d9396c"
-  integrity sha512-1/kaUgMxSjc86X2oIdwas5cqbY/pMQCkGSn5m89SIQ9FJp5LDEuutNoWlGjpcnm4/gFBAZwTqsNE68SeSsjVpQ==
-  dependencies:
-    "@react-native-community/cli-config" "12.3.5"
-    "@react-native-community/cli-platform-android" "12.3.5"
-    "@react-native-community/cli-platform-ios" "12.3.5"
-    "@react-native-community/cli-tools" "12.3.5"
-    chalk "^4.1.2"
-    command-exists "^1.2.8"
-    deepmerge "^4.3.0"
-    envinfo "^7.10.0"
-    execa "^5.0.0"
-    hermes-profile-transformer "^0.0.6"
-    ip "^1.1.5"
-    node-stream-zip "^1.9.1"
-    ora "^5.4.1"
-    semver "^7.5.2"
-    strip-ansi "^5.2.0"
-    wcwidth "^1.0.1"
-    yaml "^2.2.1"
 
 "@react-native-community/cli-doctor@12.3.6":
   version "12.3.6"
@@ -2908,17 +2857,6 @@
     wcwidth "^1.0.1"
     yaml "^2.2.1"
 
-"@react-native-community/cli-hermes@12.3.5":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-12.3.5.tgz#48b3b100cbd3e67c0797afa400b5e7a407cf2f0b"
-  integrity sha512-sxHA26edHULMiSYG0YWtuObm8MNN0TvpVJciROEp7vJfy/Ajdi3MJ75FiAW0xZzEhVTfVDMbwkZVhSlJsxCFXA==
-  dependencies:
-    "@react-native-community/cli-platform-android" "12.3.5"
-    "@react-native-community/cli-tools" "12.3.5"
-    chalk "^4.1.2"
-    hermes-profile-transformer "^0.0.6"
-    ip "^1.1.5"
-
 "@react-native-community/cli-hermes@12.3.6":
   version "12.3.6"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-hermes/-/cli-hermes-12.3.6.tgz#5ac2c9ee26c69e1ce6b5047ba0f399984a6dea16"
@@ -2928,18 +2866,6 @@
     "@react-native-community/cli-tools" "12.3.6"
     chalk "^4.1.2"
     hermes-profile-transformer "^0.0.6"
-
-"@react-native-community/cli-platform-android@12.3.5":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-android/-/cli-platform-android-12.3.5.tgz#7bf23aa72059e9dba5cc0797b23ccd246c683e65"
-  integrity sha512-vkoEoP2qKwdf8jxkrL2b35k+9eTNRFO9J6QhkVJS8AgSDcwLDvSEUCHoDBNCHaohFHP1wDWixYG4QwDOx+GfFw==
-  dependencies:
-    "@react-native-community/cli-tools" "12.3.5"
-    chalk "^4.1.2"
-    execa "^5.0.0"
-    fast-xml-parser "^4.2.4"
-    glob "^7.1.3"
-    logkitty "^0.7.1"
 
 "@react-native-community/cli-platform-android@12.3.6":
   version "12.3.6"
@@ -2953,18 +2879,6 @@
     glob "^7.1.3"
     logkitty "^0.7.1"
 
-"@react-native-community/cli-platform-ios@12.3.5":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-12.3.5.tgz#95bb6451e268883f00a445da84ce6ccb950e0bd8"
-  integrity sha512-jfp4epfJ6PzJNHtyN66VydVKtGzmDdH9QTk2Dw7sHj6p7DY75QgQ9jKgNWeyMIV+u/1EGek7HGWlmwp6fkiTDg==
-  dependencies:
-    "@react-native-community/cli-tools" "12.3.5"
-    chalk "^4.1.2"
-    execa "^5.0.0"
-    fast-xml-parser "^4.0.12"
-    glob "^7.1.3"
-    ora "^5.4.1"
-
 "@react-native-community/cli-platform-ios@12.3.6":
   version "12.3.6"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-platform-ios/-/cli-platform-ios-12.3.6.tgz#e7decb5ee764f5fdc7a6ad1ba5e15de8929d54a5"
@@ -2977,30 +2891,10 @@
     glob "^7.1.3"
     ora "^5.4.1"
 
-"@react-native-community/cli-plugin-metro@12.3.5":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-12.3.5.tgz#93ef47d3a540d60262a5d29abe662c43ea3a26be"
-  integrity sha512-O2fGpGOGf0BCpVutfQBozYyyU7qPL594/BoVVIUt9ovfm7uZHjaxtt90RzUJSNu6mE2PLEh3vtxJcszrIXTQuA==
-
 "@react-native-community/cli-plugin-metro@12.3.6":
   version "12.3.6"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-12.3.6.tgz#ae62de18e998478db60a3fe10dc746162c272dbd"
   integrity sha512-3jxSBQt4fkS+KtHCPSyB5auIT+KKIrPCv9Dk14FbvOaEh9erUWEm/5PZWmtboW1z7CYeNbFMeXm9fM2xwtVOpg==
-
-"@react-native-community/cli-server-api@12.3.5":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-server-api/-/cli-server-api-12.3.5.tgz#6cb2a25f83339bf2e499fba0383903394fb7f5f8"
-  integrity sha512-Wyv0hSvjcYHx0+CW3RIDYfFuP3H4AGcw7Co0kAx2D6fhSTCqBappwdWUpKHyq07yQGrgQk0vdO3jAZOkVjfJpA==
-  dependencies:
-    "@react-native-community/cli-debugger-ui" "12.3.5"
-    "@react-native-community/cli-tools" "12.3.5"
-    compression "^1.7.1"
-    connect "^3.6.5"
-    errorhandler "^1.5.1"
-    nocache "^3.0.1"
-    pretty-format "^26.6.2"
-    serve-static "^1.13.1"
-    ws "^7.5.1"
 
 "@react-native-community/cli-server-api@12.3.6":
   version "12.3.6"
@@ -3017,22 +2911,6 @@
     serve-static "^1.13.1"
     ws "^7.5.1"
 
-"@react-native-community/cli-tools@12.3.5":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-12.3.5.tgz#1ab33a9188d7df2856f747c6d2a07529a4872d93"
-  integrity sha512-Q7LKvu9pt3dR8XngcMfqo42XVEKzOad+4vaqRkpBUkKkZwXv41UFDxeK16NmUP87rDpHQNBbgCjJcpSq57hWsw==
-  dependencies:
-    appdirsjs "^1.2.4"
-    chalk "^4.1.2"
-    find-up "^5.0.0"
-    mime "^2.4.1"
-    node-fetch "^2.6.0"
-    open "^6.2.0"
-    ora "^5.4.1"
-    semver "^7.5.2"
-    shell-quote "^1.7.3"
-    sudo-prompt "^9.0.0"
-
 "@react-native-community/cli-tools@12.3.6":
   version "12.3.6"
   resolved "https://registry.yarnpkg.com/@react-native-community/cli-tools/-/cli-tools-12.3.6.tgz#c39965982347635dfaf1daa7b3c0133b3bd45e64"
@@ -3048,13 +2926,6 @@
     semver "^7.5.2"
     shell-quote "^1.7.3"
     sudo-prompt "^9.0.0"
-
-"@react-native-community/cli-types@12.3.5":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli-types/-/cli-types-12.3.5.tgz#5116615cd9c3b5ea257551d784bc357b2b94cfcc"
-  integrity sha512-QP9/gRQsQWyQOPI7Xny/WJ1iCGobzn8G/DCp+c1JcksB6I8FCWb39WBvbu8r+3hJoyZ0v6mV1lio33gZHPGKLQ==
-  dependencies:
-    joi "^17.2.1"
 
 "@react-native-community/cli-types@12.3.6":
   version "12.3.6"
@@ -3077,30 +2948,6 @@
     "@react-native-community/cli-server-api" "12.3.6"
     "@react-native-community/cli-tools" "12.3.6"
     "@react-native-community/cli-types" "12.3.6"
-    chalk "^4.1.2"
-    commander "^9.4.1"
-    deepmerge "^4.3.0"
-    execa "^5.0.0"
-    find-up "^4.1.0"
-    fs-extra "^8.1.0"
-    graceful-fs "^4.1.3"
-    prompts "^2.4.2"
-    semver "^7.5.2"
-
-"@react-native-community/cli@^12.2.1":
-  version "12.3.5"
-  resolved "https://registry.yarnpkg.com/@react-native-community/cli/-/cli-12.3.5.tgz#0af88222fe382c84e8d99d7cd86c0b6a42d4a7e5"
-  integrity sha512-Kw/ZnQIIs7m35n26AVb4tzv106ZgX2vrPflRbXE3GQ72rpQ+O8UpEqvWTKqs5Sjt8eLgcUbbV8VR8Bxjorwohw==
-  dependencies:
-    "@react-native-community/cli-clean" "12.3.5"
-    "@react-native-community/cli-config" "12.3.5"
-    "@react-native-community/cli-debugger-ui" "12.3.5"
-    "@react-native-community/cli-doctor" "12.3.5"
-    "@react-native-community/cli-hermes" "12.3.5"
-    "@react-native-community/cli-plugin-metro" "12.3.5"
-    "@react-native-community/cli-server-api" "12.3.5"
-    "@react-native-community/cli-tools" "12.3.5"
-    "@react-native-community/cli-types" "12.3.5"
     chalk "^4.1.2"
     commander "^9.4.1"
     deepmerge "^4.3.0"
@@ -5391,11 +5238,6 @@ commander@9.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.3.0.tgz#f619114a5a2d2054e0d9ff1b31d5ccf89255e26b"
   integrity sha512-hv95iU5uXPbK83mjrJKuZyFM/LBAoCV/XhVGkS5Je6tl7sxr6A0ITMw5WoRV46/UaJ46Nllm3Xt7IaJhXTIkzw==
 
-commander@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
-  integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
-
 commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
@@ -7447,11 +7289,6 @@ io-ts@>=2.2.0:
   version "2.2.20"
   resolved "https://registry.yarnpkg.com/io-ts/-/io-ts-2.2.20.tgz#be42b75f6668a2c44f706f72ee6e4c906777c7f5"
   integrity sha512-Rq2BsYmtwS5vVttie4rqrOCIfHCS9TgpRLFpKQCM1wZBBRY9nWVGmEvm2FnDbSE2un1UE39DvFpTR5UL47YDcA==
-
-ip@^1.1.5:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.8.tgz#ae05948f6b075435ed3307acce04629da8cdbf48"
-  integrity sha512-PuExPYUiu6qMBQb4l06ecm6T6ujzhmh+MeJcW9wa89PoAz5pvd4zPgN5WJV104mb6S2T1AwNIAaB70JNrLQWhg==
 
 ip@^2.0.0:
   version "2.0.0"
@@ -10327,14 +10164,6 @@ react-native-reanimated@3.8.1:
     "@babel/preset-typescript" "^7.16.7"
     convert-source-map "^2.0.0"
     invariant "^2.2.4"
-
-react-native-release-profiler@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/react-native-release-profiler/-/react-native-release-profiler-0.1.6.tgz#e1429b50bbba7e446ae87f6180523a66a8c88b44"
-  integrity sha512-kSAPYjO3PDzV4xbjgj2NoiHtL7EaXmBira/WOcyz6S7mz1MVBoF0Bj74z5jAZo6BoBJRKqmQWI4ep+m0xvoF+g==
-  dependencies:
-    "@react-native-community/cli" "^12.2.1"
-    commander "^11.1.0"
 
 react-native-restart@0.0.27:
   version "0.0.27"


### PR DESCRIPTION
### Description

Removes the performance profiler, we're not using it and it adds a bit of time to startup since it's a native module. I pushed a branch with the feature at https://github.com/synonymdev/bitkit/tree/debug/release-profiler that we can use when debugging.