### PR TITLE
fix: text on Restoring/Loading screen

### DIFF
--- a/src/screens/Onboarding/Loading.tsx
+++ b/src/screens/Onboarding/Loading.tsx
@@ -180,6 +180,8 @@ const styles = StyleSheet.create({
 		fontSize: 48,
 		color: '#FF4400',
 		letterSpacing: -1,
+		flex: 1,
+		textAlign: 'center',
 	},
 	circleContainer: {
 		position: 'absolute',

--- a/src/screens/Recovery/RecoveryNavigator.tsx
+++ b/src/screens/Recovery/RecoveryNavigator.tsx
@@ -14,7 +14,6 @@ export type RecoveryStackParamList = {
 	AuthCheck: { onSuccess: () => void };
 	Recovery: undefined;
 	Mnemonic: undefined;
-	Lightning: undefined;
 };
 
 const Stack = createStackNavigator<RecoveryStackParamList>();


### PR DESCRIPTION
### Description

Set `flex: 1` to text so it doesn't flicker during wallet restoring

### Linked Issues/Tasks

closes #2034

### Type of change

Bug fix

### Tests

No test
