### PR TITLE
fix: update Slashpay config on LN channel open/close event

### DIFF
--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -506,6 +506,7 @@ export const subscribeToLightningPayments = ({
 			EEventTypes.new_channel,
 			async (res: TChannelUpdate) => {
 				await refreshLdk({ selectedWallet, selectedNetwork });
+				updateSlashPayConfig({ selectedWallet, selectedNetwork });
 
 				const openChannels = getOpenChannels();
 				const closedChannels = getClosedChannels();
@@ -535,6 +536,7 @@ export const subscribeToLightningPayments = ({
 					// counterparty force closed the channel
 					showBottomSheet('connectionClosed');
 				}
+				updateSlashPayConfig({ selectedWallet, selectedNetwork });
 				syncLedger(); // TChannelManagerChannelClosed is different from TChannelMonitor
 			},
 		);


### PR DESCRIPTION
### Description

Update Slashpay config on LN channel open/close event

### Linked Issues/Tasks

closes #2027

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video



### QA Notes

- new wallet with no LN connections
- create Slashtags profile
- open a LN channel without restarting the app
- make sure you profile has LN invoice published
