### PR TITLE
refactor: remove async storage

### DIFF
--- a/ReactotronConfig.js
+++ b/ReactotronConfig.js
@@ -1,8 +1,11 @@
 import Reactotron from 'reactotron-react-native';
 import { reactotronRedux } from 'reactotron-redux';
+import mmkvPlugin from 'reactotron-react-native-mmkv';
+import { storage } from './src/store/mmkv-storage';
 
 const reactotron = Reactotron.configure()
 	.use(reactotronRedux())
+	.use(mmkvPlugin({ storage }))
 	.useReactNative()
 	.connect();
 

--- a/__mocks__/@react-native-async-storage/async-storage.js
+++ b/__mocks__/@react-native-async-storage/async-storage.js
@@ -1,1 +1,0 @@
-export * from '@react-native-async-storage/async-storage/jest/async-storage-mock';

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1361,8 +1361,6 @@ PODS:
     - React-utils (= 0.74.3)
   - ReactNativeCameraKit (14.0.0-beta15):
     - React-Core
-  - RNCAsyncStorage (1.22.3):
-    - React-Core
   - RNCClipboard (1.14.1):
     - React-Core
   - RNDeviceInfo (11.1.0):
@@ -1560,7 +1558,6 @@ DEPENDENCIES:
   - React-utils (from `../node_modules/react-native/ReactCommon/react/utils`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - ReactNativeCameraKit (from `../node_modules/react-native-camera-kit`)
-  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCClipboard (from `../node_modules/@react-native-clipboard/clipboard`)"
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
   - RNExitApp (from `../node_modules/react-native-exit-app`)
@@ -1731,8 +1728,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   ReactNativeCameraKit:
     :path: "../node_modules/react-native-camera-kit"
-  RNCAsyncStorage:
-    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCClipboard:
     :path: "../node_modules/@react-native-clipboard/clipboard"
   RNDeviceInfo:
@@ -1845,7 +1840,6 @@ SPEC CHECKSUMS:
   React-utils: a06061b3887c702235d2dac92dacbd93e1ea079e
   ReactCommon: f00e436b3925a7ae44dfa294b43ef360fbd8ccc4
   ReactNativeCameraKit: 71343efc1256720184ce980f164c7eedb78d5c16
-  RNCAsyncStorage: 10591b9e0a91eaffee14e69b3721009759235125
   RNCClipboard: 0a720adef5ec193aa0e3de24c3977222c7e52a37
   RNDeviceInfo: b899ce37a403a4dea52b7cb85e16e49c04a5b88e
   RNExitApp: 00036cabe7bacbb413d276d5520bf74ba39afa6a

--- a/ios/bitkit.xcodeproj/project.pbxproj
+++ b/ios/bitkit.xcodeproj/project.pbxproj
@@ -11,17 +11,17 @@
 		13B07FBC1A68108700A75B9A /* AppDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.mm */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
-		14C7F078B9ECCF6D5CE4E4E0 /* libPods-bitkit-bitkitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82BD64DFFBDCF84B062DF0EC /* libPods-bitkit-bitkitTests.a */; };
 		17074219BB5847259EAFC7A6 /* InterTight-Black.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 3815D562618543E7A9BC191E /* InterTight-Black.ttf */; };
 		57072143CA0F49089AE64F61 /* InterTight-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = A223BA795CEB4CB2B344FBAF /* InterTight-ExtraBold.ttf */; };
+		60997BC491E87E00BD548D53 /* libPods-bitkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 928E53689DAD68A69BBCB608 /* libPods-bitkit.a */; };
 		6980B602E6DC4429841BE5EE /* InterTight-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D67AECF5F543462F90EC89AD /* InterTight-Medium.ttf */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		8BD8301E3A1B44DDA3C8A10D /* Damion-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = DEC74C5375A34FFCAEBA0781 /* Damion-Regular.ttf */; };
 		925570EA7B1D43CC8AD07B91 /* InterTight-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CA37793F82F144678099A00D /* InterTight-Bold.ttf */; };
 		9952E811473D46FB9003A56D /* InterTight-SemiBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 50A8DA09F2974D05A3C58E87 /* InterTight-SemiBold.ttf */; };
 		B3BE07A9843E4B7DA375B877 /* InterTight-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 79DFAC55B0D745DE815EC2E0 /* InterTight-Regular.ttf */; };
-		C3D28AA3BD0927627BB234A5 /* libPods-bitkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 31EFC5E3853CF2172202D5AF /* libPods-bitkit.a */; };
 		E2F35FC226645CE623C61C03 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 919FE2A2B4A7605C9F606896 /* PrivacyInfo.xcprivacy */; };
+		E34B496ADC4F6C5B741EEAF0 /* libPods-bitkit-bitkitTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EA8F92DE89C468BB2C951F57 /* libPods-bitkit-bitkitTests.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -38,7 +38,7 @@
 		00E356EE1AD99517003FC87E /* bitkitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = bitkitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* bitkitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = bitkitTests.m; sourceTree = "<group>"; };
-		0D94393DE57BB1237C3FD9BE /* Pods-bitkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.release.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.release.xcconfig"; sourceTree = "<group>"; };
+		099E9C7EAC08F36D9B473DEF /* Pods-bitkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.debug.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.debug.xcconfig"; sourceTree = "<group>"; };
 		13B07F961A680F5B00A75B9A /* bitkit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = bitkit.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = bitkit/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = bitkit/AppDelegate.mm; sourceTree = "<group>"; };
@@ -46,20 +46,20 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = bitkit/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = bitkit/main.m; sourceTree = "<group>"; };
 		13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = PrivacyInfo.xcprivacy; path = bitkit/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
-		31EFC5E3853CF2172202D5AF /* libPods-bitkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3815D562618543E7A9BC191E /* InterTight-Black.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Black.ttf"; path = "../src/assets/fonts/InterTight-Black.ttf"; sourceTree = "<group>"; };
-		3C7EE2A2C59CB47BD0CFDF03 /* Pods-bitkit-bitkitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.release.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.release.xcconfig"; sourceTree = "<group>"; };
 		50A8DA09F2974D05A3C58E87 /* InterTight-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-SemiBold.ttf"; path = "../src/assets/fonts/InterTight-SemiBold.ttf"; sourceTree = "<group>"; };
+		574B6E043E5D2189612CCE8B /* Pods-bitkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.release.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.release.xcconfig"; sourceTree = "<group>"; };
+		57AC9D3A9F933BCDCFD2FBCA /* Pods-bitkit-bitkitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.release.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.release.xcconfig"; sourceTree = "<group>"; };
 		79DFAC55B0D745DE815EC2E0 /* InterTight-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Regular.ttf"; path = "../src/assets/fonts/InterTight-Regular.ttf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = bitkit/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		82BD64DFFBDCF84B062DF0EC /* libPods-bitkit-bitkitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit-bitkitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		919FE2A2B4A7605C9F606896 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = bitkit/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		928E53689DAD68A69BBCB608 /* libPods-bitkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A223BA795CEB4CB2B344FBAF /* InterTight-ExtraBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-ExtraBold.ttf"; path = "../src/assets/fonts/InterTight-ExtraBold.ttf"; sourceTree = "<group>"; };
-		A6510D324303D635A9F57BFF /* Pods-bitkit-bitkitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.debug.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.debug.xcconfig"; sourceTree = "<group>"; };
-		B36A867933B4B5BFDDE63376 /* Pods-bitkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit.debug.xcconfig"; path = "Target Support Files/Pods-bitkit/Pods-bitkit.debug.xcconfig"; sourceTree = "<group>"; };
 		CA37793F82F144678099A00D /* InterTight-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Bold.ttf"; path = "../src/assets/fonts/InterTight-Bold.ttf"; sourceTree = "<group>"; };
 		D67AECF5F543462F90EC89AD /* InterTight-Medium.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "InterTight-Medium.ttf"; path = "../src/assets/fonts/InterTight-Medium.ttf"; sourceTree = "<group>"; };
 		DEC74C5375A34FFCAEBA0781 /* Damion-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "Damion-Regular.ttf"; path = "../src/assets/fonts/Damion-Regular.ttf"; sourceTree = "<group>"; };
+		E61E5298EB4866D79818C702 /* Pods-bitkit-bitkitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-bitkit-bitkitTests.debug.xcconfig"; path = "Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		EA8F92DE89C468BB2C951F57 /* libPods-bitkit-bitkitTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-bitkit-bitkitTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -68,7 +68,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				14C7F078B9ECCF6D5CE4E4E0 /* libPods-bitkit-bitkitTests.a in Frameworks */,
+				E34B496ADC4F6C5B741EEAF0 /* libPods-bitkit-bitkitTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -76,7 +76,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C3D28AA3BD0927627BB234A5 /* libPods-bitkit.a in Frameworks */,
+				60997BC491E87E00BD548D53 /* libPods-bitkit.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -119,8 +119,8 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				31EFC5E3853CF2172202D5AF /* libPods-bitkit.a */,
-				82BD64DFFBDCF84B062DF0EC /* libPods-bitkit-bitkitTests.a */,
+				928E53689DAD68A69BBCB608 /* libPods-bitkit.a */,
+				EA8F92DE89C468BB2C951F57 /* libPods-bitkit-bitkitTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -183,10 +183,10 @@
 		BBD78D7AC51CEA395F1C20DB /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				B36A867933B4B5BFDDE63376 /* Pods-bitkit.debug.xcconfig */,
-				0D94393DE57BB1237C3FD9BE /* Pods-bitkit.release.xcconfig */,
-				A6510D324303D635A9F57BFF /* Pods-bitkit-bitkitTests.debug.xcconfig */,
-				3C7EE2A2C59CB47BD0CFDF03 /* Pods-bitkit-bitkitTests.release.xcconfig */,
+				099E9C7EAC08F36D9B473DEF /* Pods-bitkit.debug.xcconfig */,
+				574B6E043E5D2189612CCE8B /* Pods-bitkit.release.xcconfig */,
+				E61E5298EB4866D79818C702 /* Pods-bitkit-bitkitTests.debug.xcconfig */,
+				57AC9D3A9F933BCDCFD2FBCA /* Pods-bitkit-bitkitTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -198,12 +198,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 00E357021AD99517003FC87E /* Build configuration list for PBXNativeTarget "bitkitTests" */;
 			buildPhases = (
-				F76659A78AB8E8DAA61875BE /* [CP] Check Pods Manifest.lock */,
+				8167C001BDA408631FC4E5A8 /* [CP] Check Pods Manifest.lock */,
 				00E356EA1AD99517003FC87E /* Sources */,
 				00E356EB1AD99517003FC87E /* Frameworks */,
 				00E356EC1AD99517003FC87E /* Resources */,
-				31478B03316028D9FF020593 /* [CP] Embed Pods Frameworks */,
-				F9BB96CEF297605062F4B855 /* [CP] Copy Pods Resources */,
+				DF638271ADD7D8CB418625DD /* [CP] Embed Pods Frameworks */,
+				4CBC2FC5FBF74D86EDF81699 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -219,13 +219,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "bitkit" */;
 			buildPhases = (
-				B09B508614A1A13173DEE197 /* [CP] Check Pods Manifest.lock */,
+				0CF1EFC8DE7FFD9F0CC2B385 /* [CP] Check Pods Manifest.lock */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				1749EECDE3672B535836D668 /* [CP] Embed Pods Frameworks */,
-				A7512337D4002772672A9C9F /* [CP] Copy Pods Resources */,
+				FAB4399481A293FEE3929F96 /* [CP] Embed Pods Frameworks */,
+				F5E759C0B2E5907FAFFB6ACC /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -316,58 +316,7 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
 		};
-		1749EECDE3672B535836D668 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		31478B03316028D9FF020593 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		A7512337D4002772672A9C9F /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B09B508614A1A13173DEE197 /* [CP] Check Pods Manifest.lock */ = {
+		0CF1EFC8DE7FFD9F0CC2B385 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -389,7 +338,24 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F76659A78AB8E8DAA61875BE /* [CP] Check Pods Manifest.lock */ = {
+		4CBC2FC5FBF74D86EDF81699 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		8167C001BDA408631FC4E5A8 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -411,21 +377,55 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F9BB96CEF297605062F4B855 /* [CP] Copy Pods Resources */ = {
+		DF638271ADD7D8CB418625DD /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Copy Pods Resources";
+			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-resources.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit-bitkitTests/Pods-bitkit-bitkitTests-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		F5E759C0B2E5907FAFFB6ACC /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		FAB4399481A293FEE3929F96 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-bitkit/Pods-bitkit-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -461,7 +461,7 @@
 /* Begin XCBuildConfiguration section */
 		00E356F61AD99517003FC87E /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = A6510D324303D635A9F57BFF /* Pods-bitkit-bitkitTests.debug.xcconfig */;
+			baseConfigurationReference = E61E5298EB4866D79818C702 /* Pods-bitkit-bitkitTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -489,7 +489,7 @@
 		};
 		00E356F71AD99517003FC87E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3C7EE2A2C59CB47BD0CFDF03 /* Pods-bitkit-bitkitTests.release.xcconfig */;
+			baseConfigurationReference = 57AC9D3A9F933BCDCFD2FBCA /* Pods-bitkit-bitkitTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -514,7 +514,7 @@
 		};
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B36A867933B4B5BFDDE63376 /* Pods-bitkit.debug.xcconfig */;
+			baseConfigurationReference = 099E9C7EAC08F36D9B473DEF /* Pods-bitkit.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconOrange;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
@@ -546,7 +546,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0D94393DE57BB1237C3FD9BE /* Pods-bitkit.release.xcconfig */;
+			baseConfigurationReference = 574B6E043E5D2189612CCE8B /* Pods-bitkit.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIconOrange;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -14,9 +14,6 @@ jest.mock('react-native-permissions', () =>
 jest.mock('@react-native-community/netinfo', () => mockRNCNetInfo);
 jest.mock('react-native-localize', () => mockRNLocalize);
 jest.mock('@synonymdev/react-native-ldk', () => mockLDK);
-jest.mock('@react-native-async-storage/async-storage', () =>
-	require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
-);
 
 global.net = require('net'); // needed by Electrum client. For RN it is proviced in shim.js
 global.tls = require('tls'); // needed by Electrum client. For RN it is proviced in shim.js

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "@formatjs/intl-pluralrules": "5.2.12",
     "@formatjs/intl-relativetimeformat": "11.2.12",
     "@gorhom/bottom-sheet": "4.6.3",
-    "@react-native-async-storage/async-storage": "1.22.3",
     "@react-native-clipboard/clipboard": "1.14.1",
     "@react-native-community/blur": "4.4.0",
     "@react-native-community/netinfo": "11.3.1",
@@ -174,6 +173,7 @@
     "react-native-skia-stub": "0.0.1",
     "react-native-svg-transformer": "^1.3.0",
     "reactotron-react-native": "^5.1.6",
+    "reactotron-react-native-mmkv": "^0.2.6",
     "reactotron-redux": "^3.1.9",
     "typescript": "5.4.5"
   },

--- a/src/components/SlashtagsProvider.tsx
+++ b/src/components/SlashtagsProvider.tsx
@@ -3,91 +3,19 @@ import { createContext } from 'react';
 import b4a from 'b4a';
 import KeyChain from '@synonymdev/slashtags-keychain';
 import type { Client as IWebRelayClient } from '@synonymdev/web-relay';
-import Client from '@synonymdev/web-relay/lib/client';
+import { Client, Store } from '@synonymdev/web-relay/lib/client';
 import SlashtagsProfile from '@synonymdev/slashtags-profile';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { format, parse } from '@synonymdev/slashtags-url';
 
-import { getSlashtagsPrimaryKey } from '../utils/wallet';
-import { seedHashSelector } from '../store/reselect/wallet';
-import { showToast } from '../utils/notifications';
-import { useAppSelector } from '../hooks/redux';
-import { webRelaySelector } from '../store/reselect/settings';
 import i18n from '../utils/i18n';
+import { showToast } from '../utils/notifications';
+import { getSlashtagsPrimaryKey } from '../utils/wallet';
+import { WebRelayCache } from '../store/mmkv-storage';
+import { seedHashSelector } from '../store/reselect/wallet';
+import { webRelaySelector } from '../store/reselect/settings';
+import { useAppSelector } from '../hooks/redux';
 
-class Store {
-	location: string;
-
-	constructor(location: string) {
-		this.location = 'WEB-RELAY-CLIENT!' + location + '!';
-	}
-
-	async *iterator(
-		opts: Parameters<Client.Store['iterator']>[0],
-	): AsyncIterable<[string, Uint8Array | undefined]> {
-		const allKeys = await AsyncStorage.getAllKeys();
-		for (let key of allKeys) {
-			if (!key.startsWith(this.location)) {
-				continue;
-			}
-
-			const suffix = key.replace(this.location, '');
-
-			// @ts-ignore
-			if (opts.gt && suffix <= opts.gt) {
-				continue;
-			}
-			// @ts-ignore
-			if (opts.gte && suffix < opts.gte) {
-				continue;
-			}
-			// @ts-ignore
-			if (opts.lt && suffix >= opts.lt) {
-				continue;
-			}
-			// @ts-ignore
-			if (opts.lte && suffix > opts.lte) {
-				continue;
-			}
-
-			const value = await AsyncStorage.getItem(key);
-			const buffer = value ? b4a.from(value, 'hex') : undefined;
-
-			yield [key, buffer];
-		}
-	}
-
-	_storeKey(key: string): string {
-		return this.location + key;
-	}
-
-	async put(key: string, buffer: Uint8Array): Promise<void> {
-		const value = b4a.toString(buffer, 'hex');
-		return AsyncStorage.setItem(this._storeKey(key), value);
-	}
-
-	async del(key: string): Promise<void> {
-		return AsyncStorage.removeItem(this._storeKey(key));
-	}
-
-	async get(key: string): Promise<Uint8Array | undefined> {
-		const value = await AsyncStorage.getItem(this._storeKey(key));
-		const buffer = value ? b4a.from(value, 'hex') : undefined;
-		return buffer;
-	}
-
-	batch(): Store {
-		return this;
-	}
-
-	write(): Store {
-		return this;
-	}
-
-	async close(): Promise<void> {}
-}
-
-const store = new Store('slashtags.db') as unknown as Client.Store;
+const store: Store = new WebRelayCache('slashtags.db');
 
 export let webRelayClient: IWebRelayClient;
 let profile: SlashtagsProfile;

--- a/src/screens/Settings/DevSettings/index.tsx
+++ b/src/screens/Settings/DevSettings/index.tsx
@@ -1,6 +1,5 @@
 import React, { memo, ReactElement, useState } from 'react';
 import RNFS, { unlink, writeFile } from 'react-native-fs';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import Share from 'react-native-share';
 import { useTranslation } from 'react-i18next';
 
@@ -40,6 +39,7 @@ import { showToast } from '../../../utils/notifications';
 import { getFakeTransaction } from '../../../utils/wallet/testing';
 import Dialog from '../../../components/Dialog';
 import { resetBackupState } from '../../../store/slices/backup';
+import { storage } from '../../../store/mmkv-storage';
 import { __E2E__ } from '../../../constants/env';
 
 const DevSettings = ({
@@ -55,6 +55,15 @@ const DevSettings = ({
 	const warnings = useAppSelector((state) => {
 		return warningsSelector(state, selectedWallet, selectedNetwork);
 	});
+
+	const clearWebRelayCache = (): void => {
+		const keys = storage.getAllKeys();
+		keys.forEach((key) => {
+			if (key.includes('WEB-RELAY-CLIENT')) {
+				storage.delete(key);
+			}
+		});
+	};
 
 	const exportLdkLogs = async (): Promise<void> => {
 		const result = await zipLogs({
@@ -143,9 +152,9 @@ const DevSettings = ({
 			title: 'App Cache',
 			data: [
 				{
-					title: 'Clear AsyncStorage',
+					title: 'Clear WebRelay Cache',
 					type: EItemType.button,
-					onPress: AsyncStorage.clear,
+					onPress: clearWebRelayCache,
 				},
 				{
 					title: "Clear UTXO's",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -18,7 +18,7 @@ import {
 	__ENABLE_REDUX_LOGGER__,
 	__JEST__,
 } from '../constants/env';
-import mmkvStorage from './mmkv-storage';
+import { reduxStorage } from './mmkv-storage';
 import rootReducer, { RootReducer } from './reducers';
 import migrations from './migrations';
 
@@ -30,7 +30,7 @@ if (__ENABLE_REDUX_LOGGER__) {
 
 const persistConfig = {
 	key: 'root',
-	storage: mmkvStorage,
+	storage: reduxStorage,
 	// increase version after store shape changes
 	version: 43,
 	stateReconciler: autoMergeLevel2,

--- a/src/store/mmkv-storage.ts
+++ b/src/store/mmkv-storage.ts
@@ -1,9 +1,10 @@
-import { MMKV } from 'react-native-mmkv';
 import { Storage } from 'redux-persist';
+import { MMKV } from 'react-native-mmkv';
+import type { IteratorOptions } from 'level';
 
 export const storage = new MMKV();
 
-const mmkvStorage: Storage = {
+export const reduxStorage: Storage = {
 	setItem: (key, value) => {
 		storage.set(key, value);
 		return Promise.resolve(true);
@@ -18,4 +19,66 @@ const mmkvStorage: Storage = {
 	},
 };
 
-export default mmkvStorage;
+export class WebRelayCache {
+	location: string;
+
+	constructor(location: string) {
+		this.location = 'WEB-RELAY-CLIENT!' + location + '!';
+	}
+
+	private getKey(key: string): string {
+		return this.location + key;
+	}
+
+	async *iterator(
+		opts: IteratorOptions<string, Uint8Array>,
+	): AsyncIterable<[string, Uint8Array | undefined]> {
+		const allKeys = await storage.getAllKeys();
+		for (let key of allKeys) {
+			if (!key.startsWith(this.location)) {
+				continue;
+			}
+
+			const suffix = key.replace(this.location, '');
+
+			if (opts.gt && suffix <= opts.gt) {
+				continue;
+			}
+			if (opts.gte && suffix < opts.gte) {
+				continue;
+			}
+			if (opts.lt && suffix >= opts.lt) {
+				continue;
+			}
+			if (opts.lte && suffix > opts.lte) {
+				continue;
+			}
+
+			const buffer = await storage.getBuffer(key);
+
+			yield [key, buffer];
+		}
+	}
+
+	async get(key: string): Promise<Uint8Array | undefined> {
+		return storage.getBuffer(this.getKey(key));
+	}
+
+	async put(key: string, buffer: Uint8Array): Promise<void> {
+		return storage.set(this.getKey(key), buffer);
+	}
+
+	async del(key: string): Promise<void> {
+		return storage.delete(this.getKey(key));
+	}
+
+	batch(): WebRelayCache {
+		return this;
+	}
+
+	write(): WebRelayCache {
+		return this;
+	}
+
+	async close(): Promise<void> {}
+}

--- a/src/store/reducers/index.ts
+++ b/src/store/reducers/index.ts
@@ -1,5 +1,4 @@
 import { UnknownAction, combineReducers } from 'redux';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { storage } from '../mmkv-storage';
 import actions from '../actions/actions';
@@ -43,11 +42,8 @@ const rootReducer = (
 ): ReturnType<typeof appReducer> => {
 	if (action.type === actions.WIPE_APP) {
 		console.log('Wiping app data...');
-		// Clear mmkv persisted storage
+		// Clear MMKV persisted storage
 		storage.clearAll();
-		// Clear web relay client storage
-		AsyncStorage.clear().catch(() => {});
-
 		// Reset all stores
 		return appReducer(undefined, action);
 	}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3835,17 +3835,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-native-async-storage/async-storage@npm:1.22.3":
-  version: 1.22.3
-  resolution: "@react-native-async-storage/async-storage@npm:1.22.3"
-  dependencies:
-    merge-options: ^3.0.4
-  peerDependencies:
-    react-native: ^0.0.0-0 || >=0.60 <1.0
-  checksum: bbf0f49c4441361d24f5c7a236862757d1addb7332d4c11ed7238b7023e882d2280290059602d9099cee094f60aeb11aad3f2017652ab6e143544e61dccadb73
-  languageName: node
-  linkType: hard
-
 "@react-native-clipboard/clipboard@npm:1.14.1":
   version: 1.14.1
   resolution: "@react-native-clipboard/clipboard@npm:1.14.1"
@@ -6355,7 +6344,6 @@ __metadata:
     "@gorhom/bottom-sheet": 4.6.3
     "@ptsecurity/commitlint-config": ^2.0.0
     "@radar/lnrpc": ^0.11.1-beta.1
-    "@react-native-async-storage/async-storage": 1.22.3
     "@react-native-clipboard/clipboard": 1.14.1
     "@react-native-community/blur": 4.4.0
     "@react-native-community/netinfo": 11.3.1
@@ -6469,6 +6457,7 @@ __metadata:
     react-native-zip-archive: 6.1.0
     react-redux: 9.1.1
     reactotron-react-native: ^5.1.6
+    reactotron-react-native-mmkv: ^0.2.6
     reactotron-redux: ^3.1.9
     readable-stream: 4.5.2
     redux: 5.0.1
@@ -12072,15 +12061,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"merge-options@npm:^3.0.4":
-  version: 3.0.4
-  resolution: "merge-options@npm:3.0.4"
-  dependencies:
-    is-plain-obj: ^2.1.0
-  checksum: d86ddb3dd6e85d558dbf25dc944f3527b6bacb944db3fdda6e84a3f59c4e4b85231095f58b835758b9a57708342dee0f8de0dffa352974a48221487fe9f4584f
-  languageName: node
-  linkType: hard
-
 "merge-stream@npm:^2.0.0":
   version: 2.0.0
   resolution: "merge-stream@npm:2.0.0"
@@ -14573,6 +14553,16 @@ __metadata:
   version: 0.2.3
   resolution: "reactotron-core-contract@npm:0.2.3"
   checksum: 956a6bf3cf845ac52ff90533da9714f2766e84570a391069601ed7ec8795ec6051c40ba6788f91ef1c34da808f98415e06a1cbd47a755fb7d4e821c6eb0d2377
+  languageName: node
+  linkType: hard
+
+"reactotron-react-native-mmkv@npm:^0.2.6":
+  version: 0.2.6
+  resolution: "reactotron-react-native-mmkv@npm:0.2.6"
+  peerDependencies:
+    react-native-mmkv: "*"
+    reactotron-core-client: "*"
+  checksum: e96aa47608e4ed361893203b72d604fa527fccd0e4c8c90f91ea8347bb31d71a8b6ccd3a4f4c839b625df7d73bb8fa41238494399206359465ed2c96f95b70df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This replaces AsyncStorage with MMKV for the web relay cache. No need to have two key-value stores. Also adds Reactotron plugin for react-native-mmkv.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

