### PR TITLE
feat: Add readme and local run bash script for E2E tests

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,43 @@
+# End-to-End (E2E) Tests
+
+## Purpose
+
+This directory contains end-to-end (E2E) tests for Bitkit. These tests are designed to verify the functionality of the application, ensuring that it behaves as expected from the user's perspective. Using a local regtest environment, greater control and reproducibility is achieved compared to the mainnet for reliable and consistent testing outcomes.
+
+## Triggering Tests on Pull Requests
+
+E2E tests are automatically triggered on pull requests for this repository. When a new pull request is created or updated, the E2E tests run to ensure that the changes do not introduce any regressions. The results of these tests are displayed in the pull request checks, and merging is prevented if any test failures occur. This ensures that only code that passes all tests is integrated into the main codebase.
+
+## Running E2E Tests
+
+You can run the end-to-end (E2E) tests locally if the correct environment is set up:
+
+- For iOS Tests:
+  - The host must be running macOS.
+  - iOS Simulator must be installed, which comes with Xcode.
+- For Android Tests:
+  - An Android Virtual Device (AVD) must be set up.
+  - The Android Debug Bridge (ADB) must be installed.
+
+Additionally, you may need to update the `devices.emulator.device.avdName` and/or `devices.simulator.device.type` settings in the .detoxrc.js configuration file to match your environment.
+
+### Using `act`
+
+You can run the E2E tests using the [`act`](https://github.com/nektos/act) tool, which allows you to run GitHub Actions locally. Here's an example of how to run the iOS tests:
+
+```sh
+act -W .github/workflows/e2e-ios.yml -j e2e -P self-hosted=-self-hosted
+```
+
+### Bash script
+
+Alternatively, you can run the E2E tests directly with the `e2e/run.sh` script.
+
+    Usage: run.sh <platform> <build|skip-build> [debug|release]
+    Where <platform> is either 'android' or 'ios'
+          <build|skip-build> specifies whether to build or skip the build step
+          [debug|release] is an optional argument for the build type, defaulting to 'release'
+
+## Contributing
+
+We welcome contributions to improve our E2E tests. If you have any suggestions or find any issues, please open an issue or submit a pull request.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -12,6 +12,7 @@ E2E tests are automatically triggered on pull requests for this repository. When
 
 You can run the end-to-end (E2E) tests locally if the correct environment is set up:
 
+- Docker must be installed.
 - For iOS Tests:
   - The host must be running macOS.
   - iOS Simulator must be installed, which comes with Xcode.
@@ -19,24 +20,26 @@ You can run the end-to-end (E2E) tests locally if the correct environment is set
   - An Android Virtual Device (AVD) must be set up.
   - The Android Debug Bridge (ADB) must be installed.
 
-Additionally, you may need to update the `devices.emulator.device.avdName` and/or `devices.simulator.device.type` settings in the .detoxrc.js configuration file to match your environment.
-
-### Using `act`
-
-You can run the E2E tests using the [`act`](https://github.com/nektos/act) tool, which allows you to run GitHub Actions locally. Here's an example of how to run the iOS tests:
-
-```sh
-act -W .github/workflows/e2e-ios.yml -j e2e -P self-hosted=-self-hosted
-```
+Additionally, you may need to update the `devices.emulator.device.avdName` and/or `devices.simulator.device.type` values in the .detoxrc.js configuration file to match your environment.
 
 ### Bash script
 
-Alternatively, you can run the E2E tests directly with the `e2e/run.sh` script.
+You can run the E2E tests locally with the `e2e/run.sh` script.
 
     Usage: run.sh <platform> <build|skip-build> [debug|release]
     Where <platform> is either 'android' or 'ios'
           <build|skip-build> specifies whether to build or skip the build step
           [debug|release] is an optional argument for the build type, defaulting to 'release'
+
+### Using `act`
+
+Alternatively, you can run the E2E tests using the [`act`](https://github.com/nektos/act) tool. This allows you to run the GitHub Actions workflows locally.
+
+```sh
+act -W .github/workflows/e2e-ios.yml -j e2e -P self-hosted=-self-hosted
+
+act -W .github/workflows/e2e-android.yml -j e2e -P self-hosted=-self-hosted
+```
 
 ## Contributing
 

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -48,18 +48,24 @@ fi
 echo "Using platform: $PLATFORM"
 echo "Using build type: $BUILD_TYPE"
 
-# Set up the environment variables
-cp .env.test.template .env
-
 # Prepare the LND state dir
 rm -rf docker/lnd/
 mkdir -p docker/lnd
 chmod 777 docker/lnd
 
-# Build the release unless skip-build option is provided
+# Build the app unless skip-build option is provided
 if [ "$BUILD_OPTION" == "build" ]; then
   echo "Building the app..."
+  # Preserve the existing .env file if it exists
+  if [ -f .env ]; then
+    cp .env .env.bak
+  fi
+  cp .env.test.template .env
   yarn e2e:build:$PLATFORM-$BUILD_TYPE
+  # Restore the original .env file if it was backed up
+  if [ -f .env.bak ]; then
+    mv .env.bak .env
+  fi
 else
   echo "Skipping build..."
 fi

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# Navigate up a level if currently in 'e2e'
+if [ "$(basename "$PWD")" == "e2e" ]; then
+  cd ..
+fi
+
+# Check current directory is 'bitkit' project root
+if [ "$(basename "$PWD")" != "bitkit" ]; then
+  echo "Not at bitkit project root. Exiting."
+  exit 1
+fi
+
+# Check if the necessary arguments are provided
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 <platform> <build|skip-build> [debug|release]"
+  echo "Where <platform> is either 'android' or 'ios'"
+  echo "      <build|skip-build> specifies whether to build or skip the build step"
+  echo "      [debug|release] is an optional argument for the build type, defaulting to 'release'"
+  exit 1
+fi
+
+PLATFORM=$1
+BUILD_OPTION=$2
+BUILD_TYPE=${3:-release}
+
+# Check if the platform is valid
+if [[ "$PLATFORM" != "android" && "$PLATFORM" != "ios" ]]; then
+  echo "Invalid platform: $PLATFORM"
+  echo "Please specify either 'android' or 'ios'"
+  exit 1
+fi
+
+# Check if the build option is valid
+if [[ "$BUILD_OPTION" != "build" && "$BUILD_OPTION" != "skip-build" ]]; then
+  echo "Invalid build option: $BUILD_OPTION"
+  echo "Please specify either 'build' or 'skip-build'"
+  exit 1
+fi
+
+# Check if the build type is valid
+if [[ "$BUILD_TYPE" != "debug" && "$BUILD_TYPE" != "release" ]]; then
+  echo "Invalid build type: $BUILD_TYPE"
+  echo "Please specify either 'debug' or 'release'"
+  exit 1
+fi
+
+echo "Using platform: $PLATFORM"
+echo "Using build type: $BUILD_TYPE"
+
+# Set up the environment variables
+cp .env.test.template .env
+
+# Prepare the LND state dir
+rm -rf docker/lnd/
+mkdir -p docker/lnd
+chmod 777 docker/lnd
+
+# Build the release unless skip-build option is provided
+if [ "$BUILD_OPTION" == "build" ]; then
+  echo "Building the app..."
+  yarn e2e:build:$PLATFORM-$BUILD_TYPE
+else
+  echo "Skipping build..."
+fi
+
+# Start the Docker Compose environment
+docker compose -f docker/docker-compose.yml up -d
+sleep 2 # short wait for Electrum and LND
+
+# Run the E2E tests
+yarn e2e:test:$PLATFORM-$BUILD_TYPE --cleanup
+
+# Tear down the Docker environment
+docker compose -f docker/docker-compose.yml down -v

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -66,7 +66,18 @@ fi
 
 # Start the Docker Compose environment
 docker compose -f docker/docker-compose.yml up -d
-sleep 2 # short wait for Electrum and LND
+
+# Wait for Electrum and LND
+T=60
+while ! (nc -z '127.0.0.1' 60001 && nc -z '127.0.0.1' 10009); do
+  if [ $T -le 0 ]; then
+    echo "Timeout reached waiting for Electrum and LND. Exiting."
+    exit 1
+  else
+    sleep 1
+    (( T-- ))
+  fi
+done
 
 # Run the E2E tests
 yarn e2e:test:$PLATFORM-$BUILD_TYPE --cleanup


### PR DESCRIPTION
### Description

Add readme to E2E directory to explain the purpose, how to run locally, and how they are run in the CI pipeline.
Add a bash script for running E2E tests locally.

### Linked Issues/Tasks

Add any links to GitHub issues or Asana tasks that are relevant to this pull request.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [x] Detox test
- [ ] Unit test
- [ ] No test

### Screenshot / Video

None

### QA Notes

None
