### PR TITLE
feat: e2e test for lnurl payment manual entry

### DIFF
--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -59,6 +59,29 @@ export const isButtonEnabled = async (element) => {
 	}
 };
 
+export async function waitForElementAttribute(
+	elementId,
+	attribute,
+	expectedValue = true,
+	timeout = 10,
+) {
+	while (timeout >= 0) {
+		const attributes = await element(by.id(elementId)).getAttributes();
+		if (attributes[attribute] === expectedValue) {
+			console.log(`${elementId} has attribute ${attribute}=${expectedValue}`);
+			break;
+		} else {
+			console.log(
+				`Waiting for ${elementId} to have attribute ${attribute}=${expectedValue}...`,
+			);
+			await new Promise((resolve) => {
+				setTimeout(resolve, 1000);
+			});
+			timeout--;
+		}
+	}
+}
+
 export const completeOnboarding = async () => {
 	await device.launchApp();
 

--- a/e2e/lightning.e2e.js
+++ b/e2e/lightning.e2e.js
@@ -228,8 +228,9 @@ d('Lightning', () => {
 				.withTimeout(10000);
 
 			// send funds to LND, 10000 invoice
+			const value = 1000;
 			const { paymentRequest: invoice4 } = await lnd.addInvoice({
-				value: '1000',
+				value: value,
 			});
 			await element(by.id('Send')).tap();
 			await element(by.id('RecipientManual')).tap();
@@ -239,6 +240,9 @@ d('Lightning', () => {
 			await element(by.id('AddressContinue')).tap();
 
 			// Review & Send
+			await waitFor(
+				element(by.id('MoneyText').withAncestor(by.id('ReviewAmount-primary'))),
+			).toHaveText(value.toString());
 			await expect(element(by.id('TagsAddSend'))).toBeVisible();
 			await element(by.id('TagsAddSend')).tap(); // add tag
 			await element(by.id('TagInputSend')).typeText('stag');

--- a/e2e/lnurl.e2e.js
+++ b/e2e/lnurl.e2e.js
@@ -11,6 +11,7 @@ import {
 	bitcoinURL,
 	electrumHost,
 	electrumPort,
+	waitForElementAttribute,
 } from './helpers';
 import initWaitForElectrumToSync from '../__tests__/utils/wait-for-electrum';
 
@@ -205,6 +206,31 @@ d('LNURL', () => {
 		await element(by.id('QRInput')).replaceText(payRequest2.encoded);
 		await element(by.id('DialogConfirm')).tap();
 		await waitFor(element(by.id('CommentInput'))).not.toBeVisible();
+		await element(by.id('GRAB')).swipe('right', 'slow', 0.95, 0.5, 0.5); // Swipe to confirm
+		await waitFor(element(by.id('SendSuccess')))
+			.toBeVisible()
+			.withTimeout(10000);
+		await element(by.id('Close')).tap();
+
+		// test lnurl-pay, using manual entry
+		const minSendable = 321000;
+		const minSendableSats = minSendable / 1000;
+		const payRequest3 = await lnurl.generateNewUrl('payRequest', {
+			minSendable: minSendable, // msats
+			maxSendable: 350000, // msats
+			metadata: '[["text/plain", "lnurl-node2"]]',
+		});
+		await element(by.id('Send')).tap();
+		await element(by.id('RecipientManual')).tap();
+		await element(by.id('RecipientInput')).replaceText(payRequest3.encoded);
+		await element(by.id('RecipientInput')).tapReturnKey();
+		await waitForElementAttribute('AddressContinue', 'enabled');
+		await element(by.id('AddressContinue')).tap();
+		await waitFor(
+			element(by.id('MoneyText').withAncestor(by.id('ReviewAmount-primary'))),
+		).toHaveText(minSendableSats.toString());
+		await waitFor(element(by.id('ContinueAmount'))).toBeVisible();
+		await element(by.id('ContinueAmount')).tap();
 		await element(by.id('GRAB')).swipe('right', 'slow', 0.95, 0.5, 0.5); // Swipe to confirm
 		await waitFor(element(by.id('SendSuccess')))
 			.toBeVisible()

--- a/src/components/AmountToggle.tsx
+++ b/src/components/AmountToggle.tsx
@@ -34,12 +34,14 @@ const AmountToggle = ({
 				decimalLength={decimalLength}
 				unitType="secondary"
 				symbol={true}
+				testID={testID + '-secondary'}
 			/>
 			<Money
 				sats={amount}
 				decimalLength={decimalLength}
 				unitType="primary"
 				symbol={true}
+				testID={testID + '-primary'}
 			/>
 		</Pressable>
 	);

--- a/src/screens/Wallets/Send/ReviewAndSend.tsx
+++ b/src/screens/Wallets/Send/ReviewAndSend.tsx
@@ -582,6 +582,7 @@ const ReviewAndSend = ({
 						style={styles.amountToggle}
 						amount={amount}
 						onPress={goBackToAmount}
+						testID="ReviewAmount"
 					/>
 
 					<View style={styles.sectionContainer}>


### PR DESCRIPTION
### Description

Add check in existing lnurl test that enters invoice in via the Manual Entry path. We had a problem with this recently that prevented button being pressed.

### Linked Issues/Tasks

Add any links to GitHub issues or Asana tasks that are relevant to this pull request.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [x] Detox test
- [ ] Unit test
- [ ] No test

### Screenshot / Video

none

### QA Notes

none
