### PR TITLE
feat: new backdoor for qrcode scanner

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -1,7 +1,7 @@
 // run iPhone 14 on local machine, iPhone 15 Pro on mac mini
 const iOSDevice = process.env.MACMINI ? 'iPhone 15 Pro' : 'iPhone 14';
 
-const reversePorts = [3003, 8080, 8081, 9735, 10009, 28334, 28335, 28336, 39388, 43782, 60001];
+const reversePorts = [3003, 8080, 8081, 9735, 10009, 28334, 28335, 28336, 30001, 39388, 43782, 60001];
 
 /** @type {Detox.DetoxConfig} */
 module.exports = {

--- a/e2e/lnurl.e2e.js
+++ b/e2e/lnurl.e2e.js
@@ -1,7 +1,6 @@
 import BitcoinJsonRpc from 'bitcoin-json-rpc';
 import createLndRpc from '@radar/lnrpc';
 import LNURL from 'lnurl';
-import { device } from 'detox';
 
 import {
 	sleep,
@@ -20,11 +19,7 @@ const __DEV__ = process.env.DEV === 'true';
 const tls = `${__dirname}/../docker/lnd/tls.cert`;
 const macaroon = `${__dirname}/../docker/lnd/data/chain/bitcoin/regtest/admin.macaroon`;
 
-// disable lnurl tests on android since we don't have alert with input
-const d =
-	checkComplete('lnurl-1') || device.getPlatform() === 'android'
-		? describe.skip
-		: describe;
+const d = checkComplete('lnurl-1') ? describe.skip : describe;
 
 const waitForEvent = (lnurl, name) => {
 	let timer;
@@ -132,12 +127,8 @@ d('LNURL', () => {
 
 		await element(by.id('Scan')).tap();
 		await element(by.id('ScanPrompt')).tap();
-		await element(by.type('_UIAlertControllerTextField')).replaceText(
-			channelReq.encoded,
-		);
-		await element(
-			by.label('OK').and(by.type('_UIAlertControllerActionView')),
-		).tap();
+		await element(by.id('QRInput')).replaceText(channelReq.encoded);
+		await element(by.id('DialogConfirm')).tap();
 		const channelRequestPromise = waitForEvent(lnurl, 'channelRequest:action'); // init event listener
 		await waitFor(element(by.id('ConnectButton')))
 			.toBeVisible()
@@ -190,12 +181,8 @@ d('LNURL', () => {
 		});
 		await element(by.id('Scan')).tap();
 		await element(by.id('ScanPrompt')).tap();
-		await element(by.type('_UIAlertControllerTextField')).replaceText(
-			payRequest1.encoded,
-		);
-		await element(
-			by.label('OK').and(by.type('_UIAlertControllerActionView')),
-		).tap();
+		await element(by.id('QRInput')).replaceText(payRequest1.encoded);
+		await element(by.id('DialogConfirm')).tap();
 
 		await element(by.id('ContinueAmount')).tap();
 		await element(by.id('GRAB')).swipe('right', 'slow', 0.95, 0.5, 0.5); // Swipe to confirm
@@ -212,12 +199,8 @@ d('LNURL', () => {
 		});
 		await element(by.id('Scan')).tap();
 		await element(by.id('ScanPrompt')).tap();
-		await element(by.type('_UIAlertControllerTextField')).replaceText(
-			payRequest2.encoded,
-		);
-		await element(
-			by.label('OK').and(by.type('_UIAlertControllerActionView')),
-		).tap();
+		await element(by.id('QRInput')).replaceText(payRequest2.encoded);
+		await element(by.id('DialogConfirm')).tap();
 		await element(by.id('GRAB')).swipe('right', 'slow', 0.95, 0.5, 0.5); // Swipe to confirm
 		await waitFor(element(by.id('SendSuccess')))
 			.toBeVisible()
@@ -232,12 +215,8 @@ d('LNURL', () => {
 		});
 		await element(by.id('Scan')).tap();
 		await element(by.id('ScanPrompt')).tap();
-		await element(by.type('_UIAlertControllerTextField')).replaceText(
-			withdrawRequest1.encoded,
-		);
-		await element(
-			by.label('OK').and(by.type('_UIAlertControllerActionView')),
-		).tap();
+		await element(by.id('QRInput')).replaceText(withdrawRequest1.encoded);
+		await element(by.id('DialogConfirm')).tap();
 		await element(by.id('ContinueAmount')).tap();
 		await element(by.id('WithdrawConfirmButton')).tap();
 		await waitFor(element(by.id('NewTxPrompt')))
@@ -253,12 +232,8 @@ d('LNURL', () => {
 		});
 		await element(by.id('Scan')).tap();
 		await element(by.id('ScanPrompt')).tap();
-		await element(by.type('_UIAlertControllerTextField')).replaceText(
-			withdrawRequest2.encoded,
-		);
-		await element(
-			by.label('OK').and(by.type('_UIAlertControllerActionView')),
-		).tap();
+		await element(by.id('QRInput')).replaceText(withdrawRequest2.encoded);
+		await element(by.id('DialogConfirm')).tap();
 		await element(by.id('WithdrawConfirmButton')).tap();
 		await waitFor(element(by.id('NewTxPrompt')))
 			.toBeVisible()
@@ -269,16 +244,11 @@ d('LNURL', () => {
 		const loginRequest1 = await lnurl.generateNewUrl('login');
 		await element(by.id('Scan')).tap();
 		await element(by.id('ScanPrompt')).tap();
-		await element(by.type('_UIAlertControllerTextField')).replaceText(
-			loginRequest1.encoded,
-		);
-
+		await element(by.id('QRInput')).replaceText(loginRequest1.encoded);
 		const loginRequestPromise1 = new Promise((resolve) => {
 			lnurl.once('login', resolve);
 		});
-		await element(
-			by.label('OK').and(by.type('_UIAlertControllerActionView')),
-		).tap();
+		await element(by.id('DialogConfirm')).tap();
 		await loginRequestPromise1;
 
 		markComplete('lnurl-1');

--- a/e2e/settings.e2e.js
+++ b/e2e/settings.e2e.js
@@ -437,11 +437,6 @@ d('Settings', () => {
 				return;
 			}
 
-			// skip test on Android since we don't have alert with input
-			if (device.getPlatform() === 'android') {
-				return;
-			}
-
 			await element(by.id('Settings')).tap();
 			await element(by.id('AdvancedSettings')).tap();
 			await element(by.id('ElectrumConfig')).tap();
@@ -504,12 +499,8 @@ d('Settings', () => {
 			for (const conn of conns) {
 				await element(by.id('NavigationAction')).tap();
 				await element(by.id('ScanPrompt')).tap();
-				await element(by.type('_UIAlertControllerTextField')).replaceText(
-					conn.url,
-				);
-				await element(
-					by.label('OK').and(by.type('_UIAlertControllerActionView')),
-				).tap();
+				await element(by.id('QRInput')).replaceText(conn.url);
+				await element(by.id('DialogConfirm')).tap();
 				await expect(element(by.id('HostInput'))).toHaveText(conn.expectedHost);
 				await expect(element(by.id('PortInput'))).toHaveText(conn.expectedPort);
 				const attrs = await element(by.id('ElectrumProtocol')).getAttributes();

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -16,6 +16,7 @@ type DialogProps = {
 	visible: boolean;
 	title: string;
 	description: string;
+	children?: ReactElement;
 	buttonColor?: keyof IThemeColors;
 	cancelText?: string;
 	confirmText?: string;
@@ -29,6 +30,7 @@ const Dialog = ({
 	visible,
 	title,
 	description,
+	children,
 	buttonColor,
 	cancelText,
 	confirmText,
@@ -63,6 +65,9 @@ const Dialog = ({
 					<Text style={styles.title}>{title}</Text>
 					<Text style={styles.description}>{description}</Text>
 				</View>
+
+				{children && <View style={styles.children}>{children}</View>}
+
 				<View
 					style={styles.buttons}
 					testID={visible ? visibleTestID : undefined}>
@@ -181,6 +186,11 @@ const styles = StyleSheet.create({
 		textAlign: 'center',
 		letterSpacing: -0.41,
 		color: colors.brand,
+	},
+	children: {
+		padding: 16,
+		marginBottom: 8,
+		width: '100%',
 	},
 });
 

--- a/src/screens/Scanner/ScannerComponent.tsx
+++ b/src/screens/Scanner/ScannerComponent.tsx
@@ -1,12 +1,12 @@
 import React, { ReactElement, ReactNode, useMemo, useState } from 'react';
-import { Alert, View, StyleSheet, useWindowDimensions } from 'react-native';
+import { View, StyleSheet, useWindowDimensions } from 'react-native';
 import Clipboard from '@react-native-clipboard/clipboard';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
 import { launchImageLibrary } from 'react-native-image-picker';
 import RNQRGenerator from 'rn-qr-generator';
 import { useTranslation } from 'react-i18next';
 
-import { AnimatedView } from '../../styles/components';
+import { AnimatedView, TextInput } from '../../styles/components';
 import { BodySSB } from '../../styles/text';
 import {
 	ClipboardTextIcon,
@@ -18,6 +18,7 @@ import GradientView from '../../components/CameraGradientView';
 import BlurView from '../../components/BlurView';
 import Button from '../../components/buttons/Button';
 import { __E2E__ } from '../../constants/env';
+import Dialog from '../../components/Dialog';
 
 type ScannerComponentProps = {
 	children: ReactNode;
@@ -35,6 +36,8 @@ const ScannerComponent = ({
 	const [torchMode, setTorchMode] = useState(false);
 	const [isChooingFile, setIsChoosingFile] = useState(false);
 	const [error, setError] = useState('');
+	const [showDebug, setShowDebug] = useState(false);
+	const [textDebug, setTextDebug] = useState('');
 
 	const backgroundStyles = useMemo(() => {
 		if (!bottomSheet) {
@@ -103,9 +106,7 @@ const ScannerComponent = ({
 	};
 
 	const onReadDebug = (): void => {
-		Alert.prompt('Enter QRCode string', undefined, (text) => {
-			onRead(text);
-		});
+		setShowDebug(true);
 	};
 
 	const TopBackground = bottomSheet ? GradientView : BlurView;
@@ -178,6 +179,19 @@ const ScannerComponent = ({
 						)}
 					</Background>
 				</View>
+				<Dialog
+					visible={showDebug}
+					visibleTestID="QRDialog"
+					title="Debug"
+					description="Enter QRCode string"
+					onConfirm={(): void => onRead(textDebug)}
+					onCancel={(): void => setShowDebug(false)}>
+					<TextInput
+						value={textDebug}
+						testID="QRInput"
+						onChangeText={setTextDebug}
+					/>
+				</Dialog>
 			</>
 		</Camera>
 	);


### PR DESCRIPTION
### Description

- we can't use QRCODE scanner in e2e tests. So we use backdoor to just enter the text.
- Now instead of Alert with input field, which is working only on iOS, we use Dialog + Input and it now also works on android 

### Linked Issues/Tasks



### Type of change

New feature

### Tests

Detox test

