### PR TITLE
fix: do not run confetti animations if e2e or reduced motion

### DIFF
--- a/src/screens/TreasureHunt/Prize.tsx
+++ b/src/screens/TreasureHunt/Prize.tsx
@@ -9,6 +9,7 @@ import { StyleSheet, View } from 'react-native';
 import { SvgXml } from 'react-native-svg';
 import Lottie from 'lottie-react-native';
 import { ldk } from '@synonymdev/react-native-ldk';
+import { useReducedMotion } from 'react-native-reanimated';
 
 import { CaptionB, BodyMSB } from '../../styles/text';
 import GradientView from '../../components/GradientView';
@@ -24,7 +25,7 @@ import { useLightningMaxInboundCapacity } from '../../hooks/lightning';
 import { getNodeIdFromStorage, waitForLdk } from '../../utils/lightning';
 import { updateTreasureChest } from '../../store/slices/settings';
 import { createLightningInvoice } from '../../store/utils/lightning';
-import { __TREASURE_HUNT_HOST__ } from '../../constants/env';
+import { __E2E__, __TREASURE_HUNT_HOST__ } from '../../constants/env';
 import type { TreasureHuntScreenProps } from '../../navigation/types';
 
 const confettiSrc = require('../../assets/lottie/confetti-yellow.json');
@@ -54,6 +55,7 @@ const Prize = ({
 	const { chestId } = route.params;
 	const interval = useRef<NodeJS.Timer>();
 	const { isSmallScreen } = useScreenSize();
+	const reducedMotion = useReducedMotion();
 	const dispatch = useAppDispatch();
 	const { treasureChests } = useAppSelector((state) => state.settings);
 	const maxInboundCapacitySat = useLightningMaxInboundCapacity();
@@ -213,7 +215,7 @@ const Prize = ({
 						source={confettiSrc}
 						style={styles.lottie}
 						resizeMode="cover"
-						autoPlay
+						autoPlay={!(__E2E__ || reducedMotion)}
 						loop
 					/>
 				</View>

--- a/src/screens/Wallets/NewTxPrompt.tsx
+++ b/src/screens/Wallets/NewTxPrompt.tsx
@@ -2,6 +2,7 @@ import React, { memo, ReactElement } from 'react';
 import { Image, StyleSheet, View } from 'react-native';
 import Lottie from 'lottie-react-native';
 import { useTranslation } from 'react-i18next';
+import { useReducedMotion } from 'react-native-reanimated';
 
 import BottomSheetWrapper from '../../components/BottomSheetWrapper';
 import AmountToggle from '../../components/AmountToggle';
@@ -18,12 +19,14 @@ import {
 import { viewControllerSelector } from '../../store/reselect/ui';
 import { EActivityType } from '../../store/types/activity';
 import Button from '../../components/buttons/Button';
+import { __E2E__ } from '../../constants/env';
 
 const confettiOrangeSrc = require('../../assets/lottie/confetti-orange.json');
 const confettiPurpleSrc = require('../../assets/lottie/confetti-purple.json');
 const imageSrc = require('../../assets/illustrations/coin-stack-x.png');
 
 const NewTxPrompt = (): ReactElement => {
+	const reducedMotion = useReducedMotion();
 	const { t } = useTranslation('wallet');
 	const snapPoints = useSnapPoints('large');
 	const dispatch = useAppDispatch();
@@ -53,7 +56,7 @@ const NewTxPrompt = (): ReactElement => {
 							source={isOnchainItem ? confettiOrangeSrc : confettiPurpleSrc}
 							style={styles.lottie}
 							resizeMode="cover"
-							autoPlay
+							autoPlay={!(__E2E__ || reducedMotion)}
 							loop
 						/>
 					</View>

--- a/src/screens/Wallets/Send/Success.tsx
+++ b/src/screens/Wallets/Send/Success.tsx
@@ -2,6 +2,7 @@ import React, { memo, ReactElement } from 'react';
 import { StyleSheet, View, Image } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import Lottie from 'lottie-react-native';
+import { useReducedMotion } from 'react-native-reanimated';
 
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
 import SafeAreaInset from '../../../components/SafeAreaInset';
@@ -14,6 +15,7 @@ import { activityItemSelector } from '../../../store/reselect/activity';
 import { rootNavigation } from '../../../navigation/root/RootNavigator';
 import type { SendScreenProps } from '../../../navigation/types';
 import { EActivityType } from '../../../store/types/activity';
+import { __E2E__ } from '../../../constants/env';
 
 const confettiOrangeSrc = require('../../../assets/lottie/confetti-orange.json');
 const confettiPurpleSrc = require('../../../assets/lottie/confetti-purple.json');
@@ -22,6 +24,7 @@ const imageSrc = require('../../../assets/illustrations/check.png');
 const Success = ({ route }: SendScreenProps<'Success'>): ReactElement => {
 	const { t } = useTranslation('wallet');
 	const { type, amount, txId } = route.params;
+	const reducedMotion = useReducedMotion();
 	const dispatch = useAppDispatch();
 	const activityItem = useAppSelector((state) => {
 		return activityItemSelector(state, txId);
@@ -47,7 +50,7 @@ const Success = ({ route }: SendScreenProps<'Success'>): ReactElement => {
 					style={styles.lottie}
 					source={isOnchain ? confettiOrangeSrc : confettiPurpleSrc}
 					resizeMode="cover"
-					autoPlay
+					autoPlay={!(__E2E__ || reducedMotion)}
 					loop
 				/>
 			</View>


### PR DESCRIPTION
### Description

- help those who really need this accessibility feature
- reduce GPU usage during e2e tests

### Linked Issues/Tasks



### Type of change

Bug fix

### Tests

No test
