### PR TITLE
Set trusted peers list from env and Blocktank API

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1028,7 +1028,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-ldk (0.0.147):
+  - react-native-ldk (0.0.148):
     - React
   - react-native-mmkv (2.12.2):
     - DoubleConversion
@@ -1806,7 +1806,7 @@ SPEC CHECKSUMS:
   react-native-biometrics: 352e5a794bfffc46a0c86725ea7dc62deb085bdc
   react-native-blur: a2acf22fd7bd13621df5e0b1c130b81adea7009c
   react-native-image-picker: c3afe5472ef870d98a4b28415fc0b928161ee5f7
-  react-native-ldk: 71275a0c18172fa1646bc2a38a62560ded090da5
+  react-native-ldk: fda4d4381d40401bdc5c3a9965937d19b232ed08
   react-native-mmkv: 8c9a677e64a1ac89b0c6cf240feea528318b3074
   react-native-netinfo: bdb108d340cdb41875c9ced535977cac6d2ff321
   react-native-quick-base64: a74c4b2607b9de016877a8edb776b6ac59785809

--- a/ios/bitkit.xcodeproj/project.pbxproj
+++ b/ios/bitkit.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CC = "";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -606,6 +607,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				CXX = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
@@ -626,6 +628,8 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD = "";
+				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",
@@ -657,6 +661,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				CC = "";
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -684,6 +689,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				CXX = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
@@ -700,6 +706,8 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				LD = "";
+				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					/usr/lib/swift,
 					"$(inherited)",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@synonymdev/blocktank-lsp-http-client": "1.1.2",
     "@synonymdev/feeds": "2.1.1",
     "@synonymdev/ledger": "0.0.5",
-    "@synonymdev/react-native-ldk": "0.0.147",
+    "@synonymdev/react-native-ldk": "0.0.148",
     "@synonymdev/react-native-lnurl": "0.0.10",
     "@synonymdev/result": "0.0.2",
     "@synonymdev/slashtags-keychain": "1.0.0",

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -1523,8 +1523,16 @@ export const getPeersFromStorage = ({
 	return getLightningStore().nodes[selectedWallet].peers[selectedNetwork];
 };
 
+/**
+ * Adds trusted peers from env file as well as directly from Blocktank API
+ */
 export const addTrustedPeers = async (): Promise<Result<string>> => {
-	await lm.setTrustedZeroConfPeerNodeIds(__TRUSTED_ZERO_CONF_PEERS__);
+	const btInfo = await getBlocktankInfo(true);
+	const btNodeIds = btInfo.nodes.map((n) => n.pubkey);
+
+	await lm.setTrustedZeroConfPeerNodeIds(
+		Array.from(new Set([...btNodeIds, ...__TRUSTED_ZERO_CONF_PEERS__])),
+	);
 	return ok('Trusted peers added.');
 };
 

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -321,7 +321,6 @@ export const setupLdk = async ({
 				},
 				manually_accept_inbound_channels: true,
 			},
-			trustedZeroConfPeers: __TRUSTED_ZERO_CONF_PEERS__,
 			rapidGossipSyncUrl,
 			skipParamCheck: true, //Switch off for debugging LDK networking issues
 			lspLogEvent: async (payload) => {
@@ -337,6 +336,7 @@ export const setupLdk = async ({
 			updateLightningNodeIdThunk(),
 			updateLightningNodeVersionThunk(),
 			removeUnusedPeers({ selectedWallet, selectedNetwork }),
+			addTrustedPeers(),
 		]);
 		if (shouldRefreshLdk) {
 			const refreshRes = await refreshLdk({ selectedWallet, selectedNetwork });
@@ -1521,6 +1521,11 @@ export const getPeersFromStorage = ({
 	selectedNetwork?: EAvailableNetwork;
 }): string[] => {
 	return getLightningStore().nodes[selectedWallet].peers[selectedNetwork];
+};
+
+export const addTrustedPeers = async (): Promise<Result<string>> => {
+	await lm.setTrustedZeroConfPeerNodeIds(__TRUSTED_ZERO_CONF_PEERS__);
+	return ok('Trusted peers added.');
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4663,16 +4663,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@synonymdev/react-native-ldk@npm:0.0.147":
-  version: 0.0.147
-  resolution: "@synonymdev/react-native-ldk@npm:0.0.147"
+"@synonymdev/react-native-ldk@npm:0.0.148":
+  version: 0.0.148
+  resolution: "@synonymdev/react-native-ldk@npm:0.0.148"
   dependencies:
     "@synonymdev/raw-transaction-decoder": 1.1.0
     bech32: ^2.0.0
     bitcoinjs-lib: ^6.0.2
   peerDependencies:
     react-native: "*"
-  checksum: fa999832a99c56cda62dd46a2e9c3d4b2ab53725cfd6a4474beff318090b27dcbb11e3276a945416f95ce7efc4d78aac781c65ef53d5c18be8f75a90e40fe9fb
+  checksum: 79f990e6b2e63bcf18680c4ec9583a91e5571cb1c71c408363e0e6be8248cb12a49e097f7106cce5832c465e347d5e8385d7ef8a5be7dfd9d13eb8cc62e3f05a
   languageName: node
   linkType: hard
 
@@ -6314,7 +6314,7 @@ __metadata:
     "@synonymdev/blocktank-lsp-http-client": 1.1.2
     "@synonymdev/feeds": 2.1.1
     "@synonymdev/ledger": 0.0.5
-    "@synonymdev/react-native-ldk": 0.0.147
+    "@synonymdev/react-native-ldk": 0.0.148
     "@synonymdev/react-native-lnurl": 0.0.10
     "@synonymdev/result": 0.0.2
     "@synonymdev/slashtags-keychain": 1.0.0


### PR DESCRIPTION
### Description

Sets trusted zero conf channel peers from env and Blocktank API so we can add new LSP nodes without doing a full release

### Linked Issues/Tasks

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes
