### PR TITLE
fix: expose rescan error to the user

### DIFF
--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -241,7 +241,7 @@ const handleRefreshError = (msg: string): void => {
 		showToast({
 			type: 'warning',
 			title: i18n.t('wallet:refresh_error_title'),
-			description: i18n.t('wallet:refresh_error_msg'),
+			description: msg,
 		});
 	}
 };


### PR DESCRIPTION
### Description

Orignal error message is overwritten, we need to expose it to the user

### Linked Issues/Tasks

https://app.asana.com/0/1201997517565379/1207677258911336/f

### Type of change

Bug fix

### Tests

No test
