### PR TITLE
fix(backup): add boosts & transfers to backup

### DIFF
--- a/__tests__/helpers.ts
+++ b/__tests__/helpers.ts
@@ -3,6 +3,7 @@ import {
 	reduceValue,
 	timeAgo,
 	isObjPartialMatch,
+	deepCompareStructure,
 	ellipsis,
 	generateCalendar,
 	getDurationForBlocks,
@@ -157,6 +158,77 @@ describe('isObjPartialMatch', () => {
 		expect(f({ a: { c: 1 } }, { a: { b: 1 } })).toEqual(false);
 
 		expect(f({ a: 1 }, { a: [] })).toEqual(true);
+	});
+});
+
+describe('deepCompareStructure', () => {
+	it('can perform match', () => {
+		const f = deepCompareStructure;
+		expect(f({}, {})).toEqual(true);
+		expect(f({}, [])).toEqual(false);
+		expect(f({ a: 1 }, {})).toEqual(false);
+		expect(f({ a: 1 }, { a: 2 })).toEqual(true);
+		expect(f({ a: 1 }, { b: 1 })).toEqual(false);
+		expect(f({ a: { b: 1 } }, { a: { b: 2 } })).toEqual(true);
+		expect(f({ a: { b: 1 } }, { a: { c: 1 } })).toEqual(false);
+		expect(f({ a: 1 }, { a: [] })).toEqual(false);
+		expect(f({ a: { b: [] } }, { a: { b: [] } })).toEqual(true);
+		expect(f({ a: { b: 1 } }, { a: { b: [] } })).toEqual(false);
+
+		const received = {
+			boostedTransactions: {
+				bitcoin: {},
+				bitcoinTestnet: {},
+				bitcoinRegtest: {
+					fff9398e30329ab0d4ae227c017b9c11537d6fadede4df402d3ae9bb854816f5: {
+						parentTransactions: [
+							'fff9398e30329ab0d4ae227c017b9c11537d6fadede4df402d3ae9bb854816f5',
+						],
+						childTransaction:
+							'ee459c02101cad9dbab8d0fc2fe55026130e7db4d88ca8892b9003167c787fa1',
+						type: 'cpfp',
+						fee: 664,
+					},
+					'415098a69d7b1c93b31b14625c4b7663a4bdeee5f15c5982083ac1c4ec14717b': {
+						parentTransactions: [
+							'415098a69d7b1c93b31b14625c4b7663a4bdeee5f15c5982083ac1c4ec14717b',
+						],
+						childTransaction:
+							'f7f0d6184818a9588633be608dc4d8f3510708c5946bea330c663a0bf8c334a2',
+						type: 'cpfp',
+						fee: 664,
+					},
+				},
+			},
+			transfers: {
+				bitcoin: [],
+				bitcoinTestnet: [],
+				bitcoinRegtest: [
+					{
+						txId: '67a7108cd434d8580a0295517df0c740b59e84e875284ac139717e4dda4da0f8',
+						type: 'open',
+						status: 'pending',
+						orderId: '5f95e1f5-26f9-4fb2-82e6-9ae602764d3b',
+						amount: 17602,
+					},
+				],
+			},
+		};
+
+		const expected = {
+			boostedTransactions: {
+				bitcoin: {},
+				bitcoinTestnet: {},
+				bitcoinRegtest: {},
+			},
+			transfers: {
+				bitcoin: [],
+				bitcoinTestnet: [],
+				bitcoinRegtest: [],
+			},
+		};
+
+		expect(f(received, expected, 1)).toEqual(true);
 	});
 });
 

--- a/e2e/backup.e2e.js
+++ b/e2e/backup.e2e.js
@@ -9,6 +9,8 @@ import {
 	bitcoinURL,
 	electrumHost,
 	electrumPort,
+	getSeed,
+	restoreWallet,
 } from './helpers';
 import initWaitForElectrumToSync from '../__tests__/utils/wait-for-electrum';
 
@@ -103,54 +105,9 @@ d('Backup', () => {
 		await element(by.id('WidgetsEdit')).tap();
 		await expect(element(by.id('PriceWidget'))).toBeVisible();
 
-		// get seed
-		await element(by.id('Settings')).tap();
-		await element(by.id('BackupSettings')).tap();
-		await element(by.id('BackupWallet')).tap();
-		await sleep(200); // animation
-		await element(by.id('TapToReveal')).tap();
-
-		// get the seed from SeedContaider
-		const { label: seed } = await element(
-			by.id('SeedContaider'),
-		).getAttributes();
-
-		await element(by.id('SeedContaider')).swipe('down');
-		await sleep(200); // animation
-		await element(by.id('NavigationClose')).atIndex(0).tap();
-
-		await sleep(5000); // make sure everything is saved to cloud storage TODO: improve this
-
-		console.info('seed: ', seed);
-
 		// restore wallet
-		await device.launchApp({ delete: true });
-
-		await waitFor(element(by.id('Check1'))).toBeVisible();
-		await element(by.id('Check1')).tap();
-		await element(by.id('Check2')).tap();
-		await element(by.id('Continue')).tap();
-		await waitFor(element(by.id('SkipIntro'))).toBeVisible();
-		await element(by.id('SkipIntro')).tap();
-		await element(by.id('RestoreWallet')).tap();
-		await element(by.id('MultipleDevices-button')).tap();
-		await element(by.id('Word-0')).replaceText(seed);
-		await element(by.id('WordIndex-4')).swipe('up');
-		await element(by.id('RestoreButton')).tap();
-
-		await waitFor(element(by.id('GetStartedButton')))
-			.toBeVisible()
-			.withTimeout(300000); // 5 min
-		await element(by.id('GetStartedButton')).tap();
-
-		// wait for SuggestionsLabel to appear and be accessible
-		for (let i = 0; i < 60; i++) {
-			await sleep(200);
-			try {
-				await element(by.id('SuggestionsLabel')).tap();
-				break;
-			} catch (e) {}
-		}
+		const seed = await getSeed();
+		await restoreWallet(seed);
 
 		// check settings
 		await expect(

--- a/e2e/boost.e2e.js
+++ b/e2e/boost.e2e.js
@@ -11,6 +11,8 @@ import {
 	bitcoinURL,
 	electrumHost,
 	electrumPort,
+	getSeed,
+	restoreWallet,
 } from './helpers';
 import initWaitForElectrumToSync from '../__tests__/utils/wait-for-electrum';
 
@@ -267,10 +269,23 @@ d('Boost', () => {
 		assert(Number(oldFee.replace(' ', '')) < Number(newFee.replace(' ', '')));
 		assert(oldTxid !== newTxid);
 		await expect(element(by.id('RBFBoosted'))).toBeVisible();
+		await element(by.id('NavigationClose')).atIndex(0).tap();
+
+		// wipe & restore
+		const seed = await getSeed();
+		await restoreWallet(seed);
+
+		// check activity after restore
+		await element(by.id('WalletsScrollView')).scrollTo('bottom', NaN, 0.85);
+		await expect(element(by.id('BoostingIcon'))).toBeVisible();
+		await element(by.id('ActivityShort-1')).tap();
+		await expect(element(by.id('BoostedButton'))).toBeVisible();
+		await expect(element(by.id('StatusBoosting'))).toBeVisible();
 
 		// mine new block
-		await element(by.id('NavigationBack')).atIndex(0).tap();
 		await rpc.generateToAddress(1, await rpc.getNewAddress());
+
+		// check activity item after mine
 		await waitFor(element(by.id('StatusConfirmed')))
 			.toBeVisible()
 			.withTimeout(30000);

--- a/e2e/channels.e2e.js
+++ b/e2e/channels.e2e.js
@@ -16,6 +16,8 @@ import {
 	sleep,
 	waitForActiveChannel,
 	waitForPeerConnection,
+	getSeed,
+	restoreWallet,
 } from './helpers';
 
 d = checkComplete(['transfer-1', 'transfer-2']) ? describe.skip : describe;
@@ -186,6 +188,18 @@ d('Transfer', () => {
 		await expect(
 			element(by.id('MoneyText').withAncestor(by.id('TotalSize'))),
 		).toHaveText('250 000');
+		await element(by.id('NavigationClose')).tap();
+
+		const seed = await getSeed();
+		await restoreWallet(seed);
+
+		// check transfer card
+		await expect(element(by.id('Suggestion-lightningSettingUp'))).toBeVisible();
+
+		// check activity after restore
+		await element(by.id('WalletsScrollView')).scrollTo('bottom', NaN, 0.85);
+		await element(by.id('ActivityShort-1')).tap();
+		await expect(element(by.id('StatusTransfer'))).toBeVisible();
 
 		markComplete('transfer-1');
 	});

--- a/e2e/lightning.e2e.js
+++ b/e2e/lightning.e2e.js
@@ -15,6 +15,8 @@ import {
 	sleep,
 	waitForActiveChannel,
 	waitForPeerConnection,
+	restoreWallet,
+	getSeed,
 } from './helpers';
 
 d = checkComplete('lighting-1') ? describe.skip : describe;
@@ -311,52 +313,9 @@ d('Lightning', () => {
 			await element(by.id('Tag-stag-delete')).tap();
 			await element(by.id('NavigationClose')).tap();
 
-			// get seed
-			await element(by.id('Settings')).tap();
-			await element(by.id('BackupSettings')).tap();
-			await element(by.id('BackupWallet')).tap();
-			await sleep(1000); // animation
-			await element(by.id('TapToReveal')).tap();
-
-			// get the seed from SeedContaider
-			const { label: seed } = await element(
-				by.id('SeedContaider'),
-			).getAttributes();
-			await element(by.id('SeedContaider')).swipe('down');
-			await sleep(1000); // animation
-			await element(by.id('NavigationClose')).atIndex(0).tap();
-
-			await sleep(5000); // make sure everything is saved to cloud storage TODO: improve this
-			console.info('seed: ', seed);
-
-			// restore wallet
-			await device.launchApp({ delete: true });
-
-			await waitFor(element(by.id('Check1'))).toBeVisible();
-			await element(by.id('Check1')).tap();
-			await element(by.id('Check2')).tap();
-			await element(by.id('Continue')).tap();
-			await waitFor(element(by.id('SkipIntro'))).toBeVisible();
-			await element(by.id('SkipIntro')).tap();
-			await element(by.id('RestoreWallet')).tap();
-			await element(by.id('MultipleDevices-button')).tap();
-			await element(by.id('Word-0')).replaceText(seed);
-			await element(by.id('WordIndex-4')).swipe('up');
-			await element(by.id('RestoreButton')).tap();
-
-			await waitFor(element(by.id('GetStartedButton')))
-				.toBeVisible()
-				.withTimeout(300000); // 5 min
-			await element(by.id('GetStartedButton')).tap();
-
-			// wait for SuggestionsLabel to appear and be accessible
-			for (let i = 0; i < 60; i++) {
-				await sleep(1000);
-				try {
-					await element(by.id('SuggestionsLabel')).tap();
-					break;
-				} catch (e) {}
-			}
+			// wipe and restore wallet
+			const seed = await getSeed();
+			await restoreWallet(seed);
 
 			// check balance
 			await waitFor(

--- a/e2e/onboarding.e2e.js
+++ b/e2e/onboarding.e2e.js
@@ -1,6 +1,12 @@
 import jestExpect from 'expect';
 
-import { sleep, checkComplete, markComplete } from './helpers';
+import {
+	sleep,
+	checkComplete,
+	markComplete,
+	getSeed,
+	restoreWallet,
+} from './helpers';
 
 d = checkComplete('onboarding-1') ? describe.skip : describe;
 
@@ -31,8 +37,9 @@ d('Onboarding', () => {
 		await element(by.id('SkipButton')).tap();
 
 		// create new wallet with passphrase
+		const passphrase = 'supersecret';
 		await element(by.id('Passphrase')).tap();
-		await element(by.id('PassphraseInput')).typeText('supersecret');
+		await element(by.id('PassphraseInput')).typeText(passphrase);
 		await element(by.id('PassphraseInput')).tapReturnKey();
 		await element(by.id('CreateNewWallet')).tap();
 
@@ -54,20 +61,9 @@ d('Onboarding', () => {
 			}
 		}
 
-		// get seed
-		await element(by.id('Settings')).tap();
-		await element(by.id('BackupSettings')).tap();
-		await element(by.id('BackupWallet')).tap();
-		await element(by.id('TapToReveal')).tap();
-		// get the seed from SeedContaider
-		const { label: seed } = await element(
-			by.id('SeedContaider'),
-		).getAttributes();
-		await element(by.id('SeedContaider')).swipe('down');
-		await element(by.id('NavigationClose')).atIndex(0).tap();
-		console.info('seed: ', seed);
+		const seed = await getSeed();
 
-		// get receing address
+		// get receiving address
 		await element(by.id('Receive')).tap();
 		await waitFor(element(by.id('QRCode')))
 			.toBeVisible()
@@ -76,38 +72,9 @@ d('Onboarding', () => {
 		console.info('address', address1);
 
 		// wipe and restore wallet
-		await device.launchApp({ delete: true });
+		await restoreWallet(seed, passphrase);
 
-		await waitFor(element(by.id('Check1'))).toBeVisible();
-		await element(by.id('Check1')).tap();
-		await element(by.id('Check2')).tap();
-		await element(by.id('Continue')).tap();
-		await waitFor(element(by.id('SkipIntro'))).toBeVisible();
-		await element(by.id('SkipIntro')).tap();
-		await element(by.id('RestoreWallet')).tap();
-		await element(by.id('MultipleDevices-button')).tap();
-		await element(by.id('Word-0')).replaceText(seed);
-		await element(by.id('WordIndex-4')).swipe('up');
-		await element(by.id('AdvancedButton')).tap();
-		await element(by.id('PassphraseInput')).typeText('supersecret');
-		await element(by.id('PassphraseInput')).tapReturnKey();
-		await element(by.id('RestoreButton')).tap();
-
-		await waitFor(element(by.id('GetStartedButton')))
-			.toBeVisible()
-			.withTimeout(300000); // 5 min
-		await element(by.id('GetStartedButton')).tap();
-
-		// wait for SuggestionsLabel to appear and be accessible
-		for (let i = 0; i < 60; i++) {
-			await sleep(1000);
-			try {
-				await element(by.id('SuggestionsLabel')).tap();
-				break;
-			} catch (e) {}
-		}
-
-		// get receing address
+		// get receiving address
 		await element(by.id('Receive')).tap();
 		await waitFor(element(by.id('QRCode')))
 			.toBeVisible()

--- a/src/screens/Activity/ActivityDetail.tsx
+++ b/src/screens/Activity/ActivityDetail.tsx
@@ -335,7 +335,7 @@ const OnchainActivityDetail = ({
 		if (transfer.status !== ETransferStatus.done) {
 			const duration = getDurationForBlocks(transfer.confirmsIn);
 			status = (
-				<View style={styles.row}>
+				<View style={styles.row} testID="StatusTransfer">
 					<HourglassIcon style={styles.rowIcon} color="brand" width={16} />
 					<BodySSB color="brand">
 						{t('activity_transfer_pending', { duration })}

--- a/src/screens/Settings/AppStatus/index.tsx
+++ b/src/screens/Settings/AppStatus/index.tsx
@@ -17,7 +17,7 @@ import {
 	isOnlineSelector,
 } from '../../../store/reselect/ui';
 import { TBackupItem } from '../../../store/types/backup';
-import { EBackupCategories } from '../../../store/utils/backup';
+import { EBackupCategory } from '../../../store/utils/backup';
 import { IColors } from '../../../styles/colors';
 import { ScrollView, View as ThemedView } from '../../../styles/components';
 import {
@@ -147,7 +147,7 @@ const AppStatus = ({}: SettingsScreenProps<'AppStatus'>): ReactElement => {
 			);
 		};
 
-		return Object.values(EBackupCategories).every((key) => {
+		return Object.values(EBackupCategory).every((key) => {
 			return isSyncOk(backup[key]);
 		});
 	}, [backup, now]);
@@ -157,7 +157,7 @@ const AppStatus = ({}: SettingsScreenProps<'AppStatus'>): ReactElement => {
 			if (!isBackupSyncOk) {
 				return { state: 'error' };
 			}
-			const syncTimes = Object.values(EBackupCategories).map((key) => {
+			const syncTimes = Object.values(EBackupCategory).map((key) => {
 				return backup[key].synced;
 			});
 			const max = Math.max(...syncTimes);

--- a/src/screens/Settings/Backup/Metadata.tsx
+++ b/src/screens/Settings/Backup/Metadata.tsx
@@ -11,7 +11,7 @@ import { useAppDispatch, useAppSelector } from '../../../hooks/redux';
 import { closeSheet } from '../../../store/slices/ui';
 import { backupSelector } from '../../../store/reselect/backup';
 import { i18nTime } from '../../../utils/i18n';
-import { EBackupCategories } from '../../../store/utils/backup';
+import { EBackupCategory } from '../../../store/utils/backup';
 
 const imageSrc = require('../../../assets/illustrations/card.png');
 
@@ -22,7 +22,7 @@ const Metadata = (): ReactElement => {
 	const backup = useAppSelector(backupSelector);
 
 	const max = Math.max(
-		...Object.values(EBackupCategories).map((key) => {
+		...Object.values(EBackupCategory).map((key) => {
 			return backup[key].synced;
 		}),
 	);

--- a/src/screens/Settings/BackupSettings/index.tsx
+++ b/src/screens/Settings/BackupSettings/index.tsx
@@ -12,7 +12,7 @@ import { backupSelector } from '../../../store/reselect/backup';
 import { lightningBackupSelector } from '../../../store/reselect/lightning';
 import { forceBackup } from '../../../store/slices/backup';
 import { TBackupItem } from '../../../store/types/backup';
-import { EBackupCategories } from '../../../store/utils/backup';
+import { EBackupCategory } from '../../../store/utils/backup';
 import { toggleBottomSheet } from '../../../store/utils/ui';
 import {
 	ArrowClockwise,
@@ -21,6 +21,7 @@ import {
 	RectanglesTwo,
 	SettingsIcon,
 	TagIcon,
+	TimerIconAlt,
 	TransferIcon,
 	UsersIcon,
 } from '../../../styles/icons';
@@ -38,7 +39,7 @@ const Status = ({
 	Icon: React.FunctionComponent<any>;
 	title: ReactNode;
 	status: TBackupItem;
-	category?: EBackupCategories;
+	category?: EBackupCategory;
 	disableRetry?: boolean;
 }): ReactElement => {
 	const { t } = useTranslation('settings');
@@ -124,7 +125,7 @@ const Status = ({
 type TBackupCategory = {
 	Icon: React.FunctionComponent<any>;
 	title: string;
-	category?: EBackupCategories;
+	category?: EBackupCategory;
 	status: TBackupItem;
 	disableRetry?: boolean;
 };
@@ -154,32 +155,38 @@ const BackupSettings = ({
 		{
 			Icon: NoteIcon,
 			title: t('backup.category_connection_receipts'),
-			category: EBackupCategories.blocktank,
-			status: backup[EBackupCategories.blocktank],
+			category: EBackupCategory.blocktank,
+			status: backup[EBackupCategory.blocktank],
 		},
 		{
 			Icon: TransferIcon,
 			title: t('backup.category_transaction_log'),
-			category: EBackupCategories.ldkActivity,
-			status: backup[EBackupCategories.ldkActivity],
+			category: EBackupCategory.ldkActivity,
+			status: backup[EBackupCategory.ldkActivity],
+		},
+		{
+			Icon: TimerIconAlt,
+			title: t('backup.category_wallet'),
+			category: EBackupCategory.wallet,
+			status: backup[EBackupCategory.wallet],
 		},
 		{
 			Icon: SettingsIcon,
 			title: t('backup.category_settings'),
-			category: EBackupCategories.settings,
-			status: backup[EBackupCategories.settings],
+			category: EBackupCategory.settings,
+			status: backup[EBackupCategory.settings],
 		},
 		{
 			Icon: RectanglesTwo,
 			title: t('backup.category_widgets'),
-			category: EBackupCategories.widgets,
-			status: backup[EBackupCategories.widgets],
+			category: EBackupCategory.widgets,
+			status: backup[EBackupCategory.widgets],
 		},
 		{
 			Icon: TagIcon,
 			title: t('backup.category_tags'),
-			category: EBackupCategories.metadata,
-			status: backup[EBackupCategories.metadata],
+			category: EBackupCategory.metadata,
+			status: backup[EBackupCategory.metadata],
 		},
 		// {
 		// 	Icon: UserRectangleIcon,
@@ -190,8 +197,8 @@ const BackupSettings = ({
 		{
 			Icon: UsersIcon,
 			title: t('backup.category_contacts'),
-			category: EBackupCategories.slashtags,
-			status: backup[EBackupCategories.slashtags],
+			category: EBackupCategory.slashtags,
+			status: backup[EBackupCategory.slashtags],
 		},
 	];
 

--- a/src/store/shapes/backup.ts
+++ b/src/store/shapes/backup.ts
@@ -1,5 +1,5 @@
 import { TBackupItem, TBackupState } from '../types/backup';
-import { EBackupCategories } from '../utils/backup';
+import { EBackupCategory } from '../utils/backup';
 
 const item: TBackupItem = {
 	required: Date.now() - 1000,
@@ -8,10 +8,11 @@ const item: TBackupItem = {
 };
 
 export const initialBackupState: TBackupState = {
-	[EBackupCategories.widgets]: { ...item },
-	[EBackupCategories.settings]: { ...item },
-	[EBackupCategories.metadata]: { ...item },
-	[EBackupCategories.blocktank]: { ...item },
-	[EBackupCategories.slashtags]: { ...item },
-	[EBackupCategories.ldkActivity]: { ...item },
+	[EBackupCategory.wallet]: { ...item },
+	[EBackupCategory.widgets]: { ...item },
+	[EBackupCategory.settings]: { ...item },
+	[EBackupCategory.metadata]: { ...item },
+	[EBackupCategory.blocktank]: { ...item },
+	[EBackupCategory.slashtags]: { ...item },
+	[EBackupCategory.ldkActivity]: { ...item },
 };

--- a/src/store/slices/wallet.ts
+++ b/src/store/slices/wallet.ts
@@ -2,6 +2,7 @@ import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import {
 	IAddress,
 	IAddresses,
+	IBoostedTransactions,
 	IFormattedTransactions,
 	IHeader,
 	IWalletData,
@@ -14,6 +15,7 @@ import {
 } from '../shapes/wallet';
 import {
 	ETransferStatus,
+	IWalletItem,
 	IWallets,
 	IWalletStore,
 	TTransfer,
@@ -123,6 +125,13 @@ export const walletSlice = createSlice({
 
 			state.wallets[selectedWallet].transfers[selectedNetwork] = updated;
 		},
+		restoreTransfers: (
+			state,
+			action: PayloadAction<IWalletItem<TTransfer[]>>,
+		) => {
+			const { selectedWallet } = state;
+			state.wallets[selectedWallet].transfers = action.payload;
+		},
 		removeTransfer: (state, action: PayloadAction<string>) => {
 			const { selectedWallet, selectedNetwork } = state;
 			const current = state.wallets[selectedWallet].transfers[selectedNetwork];
@@ -152,6 +161,13 @@ export const walletSlice = createSlice({
 				],
 				...action.payload,
 			};
+		},
+		restoreBoostedTransactions: (
+			state,
+			action: PayloadAction<IWalletItem<IBoostedTransactions>>,
+		) => {
+			const { selectedWallet } = state;
+			state.wallets[selectedWallet].boostedTransactions = action.payload;
 		},
 		replaceImpactedAddresses: (
 			state,
@@ -194,9 +210,11 @@ export const {
 	updateHeader,
 	addTransfer,
 	updateTransfer,
+	restoreTransfers,
 	removeTransfer,
 	updateTransactions,
 	addUnconfirmedTransactions,
+	restoreBoostedTransactions,
 	replaceImpactedAddresses,
 	resetSelectedWallet,
 	resetExchangeRates,

--- a/src/store/types/backup.ts
+++ b/src/store/types/backup.ts
@@ -1,5 +1,5 @@
 import { ENetworks, TAccount } from '@synonymdev/react-native-ldk';
-import { EBackupCategories } from '../utils/backup';
+import { EBackupCategory } from '../utils/backup';
 
 export type TBackupItem = {
 	running: boolean;
@@ -8,7 +8,7 @@ export type TBackupItem = {
 };
 
 export type TBackupState = {
-	[key in EBackupCategories]: TBackupItem;
+	[key in EBackupCategory]: TBackupItem;
 };
 
 export declare type TAccountBackup<T> = {
@@ -19,7 +19,7 @@ export declare type TAccountBackup<T> = {
 };
 
 export type TBackupMetadata = {
-	category: EBackupCategories;
+	category: EBackupCategory;
 	timestamp: number;
 	version: number;
 };

--- a/src/utils/backup/backups-subscriber.tsx
+++ b/src/utils/backup/backups-subscriber.tsx
@@ -5,7 +5,7 @@ import { __E2E__ } from '../../constants/env';
 import { useDebouncedEffect } from '../../hooks/helpers';
 import { useAppSelector } from '../../hooks/redux';
 import { backupSelector } from '../../store/reselect/backup';
-import { EBackupCategories, performBackup } from '../../store/utils/backup';
+import { EBackupCategory, performBackup } from '../../store/utils/backup';
 import { showToast } from '../notifications';
 
 const BACKUP_DEBOUNCE = 5000; // 5 seconds
@@ -13,24 +13,35 @@ const BACKUP_CHECK_INTERVAL = 60 * 1000; // 1 minute
 export const FAILED_BACKUP_CHECK_TIME = 30 * 60 * 1000; // 30 minutes
 const FAILED_BACKUP_NOTIFICATION_INTERVAL = 10 * 60 * 1000; // 10 minutes
 
-const EnabledSlashtag = (): ReactElement => {
+const BackupSubscriber = (): ReactElement => {
 	const { t } = useTranslation('settings');
 	const backup = useAppSelector(backupSelector);
 	const [now, setNow] = useState<number>(new Date().getTime());
 
-	const backupSettings = backup[EBackupCategories.settings];
-	const backupWidgets = backup[EBackupCategories.widgets];
-	const backupMetadata = backup[EBackupCategories.metadata];
-	const backupBlocktank = backup[EBackupCategories.blocktank];
-	const backupSlashtags = backup[EBackupCategories.slashtags];
-	const backupLDKActivity = backup[EBackupCategories.ldkActivity];
+	const backupWallet = backup[EBackupCategory.wallet];
+	const backupSettings = backup[EBackupCategory.settings];
+	const backupWidgets = backup[EBackupCategory.widgets];
+	const backupMetadata = backup[EBackupCategory.metadata];
+	const backupBlocktank = backup[EBackupCategory.blocktank];
+	const backupSlashtags = backup[EBackupCategory.slashtags];
+	const backupLDKActivity = backup[EBackupCategory.ldkActivity];
 
+	useDebouncedEffect(
+		() => {
+			if (backupWallet.synced > backupWallet.required) {
+				return;
+			}
+			performBackup(EBackupCategory.wallet);
+		},
+		[backupWallet.synced, backupWallet.required],
+		BACKUP_DEBOUNCE,
+	);
 	useDebouncedEffect(
 		() => {
 			if (backupSettings.synced > backupSettings.required) {
 				return;
 			}
-			performBackup(EBackupCategories.settings);
+			performBackup(EBackupCategory.settings);
 		},
 		[backupSettings.synced, backupSettings.required],
 		BACKUP_DEBOUNCE,
@@ -40,7 +51,7 @@ const EnabledSlashtag = (): ReactElement => {
 			if (backupWidgets.synced > backupWidgets.required) {
 				return;
 			}
-			performBackup(EBackupCategories.widgets);
+			performBackup(EBackupCategory.widgets);
 		},
 		[backupWidgets.synced, backupWidgets.required],
 		BACKUP_DEBOUNCE,
@@ -50,7 +61,7 @@ const EnabledSlashtag = (): ReactElement => {
 			if (backupMetadata.synced > backupMetadata.required) {
 				return;
 			}
-			performBackup(EBackupCategories.metadata);
+			performBackup(EBackupCategory.metadata);
 		},
 		[backupMetadata.synced, backupMetadata.required],
 		BACKUP_DEBOUNCE,
@@ -60,7 +71,7 @@ const EnabledSlashtag = (): ReactElement => {
 			if (backupBlocktank.synced > backupBlocktank.required) {
 				return;
 			}
-			performBackup(EBackupCategories.blocktank);
+			performBackup(EBackupCategory.blocktank);
 		},
 		[backupBlocktank.synced, backupBlocktank.required],
 		BACKUP_DEBOUNCE,
@@ -70,7 +81,7 @@ const EnabledSlashtag = (): ReactElement => {
 			if (backupSlashtags.synced > backupSlashtags.required) {
 				return;
 			}
-			performBackup(EBackupCategories.slashtags);
+			performBackup(EBackupCategory.slashtags);
 		},
 		[backupSlashtags.synced, backupSlashtags.required],
 		BACKUP_DEBOUNCE,
@@ -80,7 +91,7 @@ const EnabledSlashtag = (): ReactElement => {
 			if (backupLDKActivity.synced > backupLDKActivity.required) {
 				return;
 			}
-			performBackup(EBackupCategories.ldkActivity);
+			performBackup(EBackupCategory.ldkActivity);
 		},
 		[backupLDKActivity.synced, backupLDKActivity.required],
 		BACKUP_DEBOUNCE,
@@ -92,7 +103,7 @@ const EnabledSlashtag = (): ReactElement => {
 		}
 
 		// find if there are any backup categories that have been failing for more than 30 minutes
-		return Object.values(EBackupCategories).some((key) => {
+		return Object.values(EBackupCategory).some((key) => {
 			return (
 				backup[key].synced < backup[key].required &&
 				now - backup[key].required > FAILED_BACKUP_CHECK_TIME
@@ -131,10 +142,6 @@ const EnabledSlashtag = (): ReactElement => {
 	}, [t, shouldShowBackupWarning]);
 
 	return <></>;
-};
-
-const BackupSubscriber = (): ReactElement => {
-	return <EnabledSlashtag />;
 };
 
 export default BackupSubscriber;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -2,6 +2,9 @@ import { Linking, Vibration } from 'react-native';
 import NetInfo from '@react-native-community/netinfo';
 import { err, ok, Result } from '@synonymdev/result';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
+import has from 'lodash/has';
+import keys from 'lodash/keys';
+import isPlainObject from 'lodash/isPlainObject';
 
 import { i18nTime } from '../utils/i18n';
 
@@ -240,6 +243,61 @@ export const isObjPartialMatch = (
 		}
 		return false;
 	});
+};
+
+export const deepCompareStructure = (
+	obj1: any,
+	obj2: any,
+	maxDepth: number = Infinity,
+	currentDepth: number = 0,
+): boolean => {
+	// Ensure both objects are plain objects
+	if (!isPlainObject(obj1) || !isPlainObject(obj2)) {
+		return false;
+	}
+
+	// Stop further comparison if max depth is exceeded
+	if (currentDepth > maxDepth) {
+		return true;
+	}
+
+	// Get keys from both objects
+	const keys1 = keys(obj1);
+	const keys2 = keys(obj2);
+
+	// Check if the number of keys is the same
+	if (keys1.length !== keys2.length) {
+		return false;
+	}
+
+	// Check if all keys from obj1 exist in obj2 and recursively compare their nested objects
+	for (const key of keys1) {
+		if (!has(obj2, key)) {
+			return false;
+		}
+
+		const value1 = obj1[key];
+		const value2 = obj2[key];
+
+		// If types are different, return false
+		if (typeof value1 !== typeof value2) {
+			return false;
+		}
+
+		// Skip arrays for deep comparison
+		if (Array.isArray(value1) && Array.isArray(value2)) {
+			continue;
+		}
+
+		// If both are plain objects, recurse; otherwise, continue
+		if (isPlainObject(value1) && isPlainObject(value2)) {
+			if (!deepCompareStructure(value1, value2, maxDepth, currentDepth + 1)) {
+				return false;
+			}
+		}
+	}
+
+	return true; // All keys and types match
 };
 
 /**

--- a/src/utils/i18n/locales/en/settings.json
+++ b/src/utils/i18n/locales/en/settings.json
@@ -239,6 +239,9 @@
 		"category_transaction_log": {
 			"string": "Transaction Log"
 		},
+		"category_wallet": {
+			"string": "Boosts & Transfers"
+		},
 		"category_settings": {
 			"string": "Settings"
 		},

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -137,6 +137,20 @@ let onChannelClose: EmitterSubscription | undefined;
 // let onSpendableOutputsSubscription: EmitterSubscription | undefined;
 let onBackupStateUpdate: EmitterSubscription | undefined;
 
+export const getNetwork = (selectedNetwork: EAvailableNetwork): ENetworks => {
+	switch (selectedNetwork) {
+		case EAvailableNetwork.bitcoin: {
+			return ENetworks.mainnet;
+		}
+		case EAvailableNetwork.bitcoinTestnet: {
+			return ENetworks.testnet;
+		}
+		case EAvailableNetwork.bitcoinRegtest: {
+			return ENetworks.regtest;
+		}
+	}
+};
+
 /**
  * Checks if a string is a plain LN URI.
  * @param {string} uri

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -51,6 +51,7 @@ import {
 	IWallet,
 	IWallets,
 	TKeyDerivationAccountType,
+	TTransfer,
 	TWalletName,
 } from '../../store/types/wallet';
 import { IGetAddress, IGenerateAddresses } from '../types';
@@ -700,6 +701,15 @@ export const getOnChainTransactions = ({
 		getWalletStore().wallets[selectedWallet]?.transactions[selectedNetwork] ??
 		{}
 	);
+};
+
+export const getTransfers = (): TTransfer[] => {
+	const selectedWallet = getSelectedWallet();
+	const selectedNetwork = getSelectedNetwork();
+	const currentWallet = getWalletStore().wallets[selectedWallet];
+	const transfers = currentWallet.transfers[selectedNetwork];
+
+	return transfers;
 };
 
 /**


### PR DESCRIPTION
### Description

Adds `boostedTransactions` and `transfers` from wallet state to backup & restore.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/1844 https://github.com/synonymdev/bitkit/issues/1868

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [x] Detox test
- [x] Unit test
- [ ] No test

### Screenshots

![Simulator Screenshot - iPhone 16 - 2024-11-26 at 17 10 08](https://github.com/user-attachments/assets/50a8ddd0-b4df-4c3d-b48c-b61dfd9a7397)

Screenshot shows activity after restore:
- 1 received tx
- 1 sent tx not boosted (1000 sats)
- 1 sent tx boosted (1000 sats)
- 2 transfers to spending