### PR TITLE
fix: use docker compose instead of docker-compose

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           cd docker
           mkdir lnd && chmod 777 lnd
-          docker-compose pull --quiet
+          docker compose pull --quiet
           docker compose up -d
 
       - name: Wait for electrum server and LND

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           cd docker
           mkdir lnd && chmod 777 lnd
-          docker-compose pull --quiet
+          docker compose pull --quiet
           docker compose up --force-recreate -d
 
       - name: Wait for electrum server


### PR DESCRIPTION
### Description

Fixes android e2e tests
For example:
```
home/runner/work/_temp/a931c985-e504-4828-a8d8-095de5d37e66.sh: line 3: docker-compose: command not found
```

### Linked Issues/Tasks



### Type of change

Bug fix

### Tests

Detox test
