### PR TITLE
fix: Headlines Widget in offline mode

### DIFF
--- a/src/components/HeadlinesWidget.tsx
+++ b/src/components/HeadlinesWidget.tsx
@@ -65,7 +65,7 @@ const HeadlinesWidget = ({
 
 				const allArticles = await reader.getAllArticles();
 				const _article = allArticles
-					.sort((a, b) => b.published - a.published)
+					?.sort((a, b) => b.published - a.published)
 					.slice(0, 10)[Math.floor(Math.random() * 10)];
 
 				if (!unmounted && _article) {


### PR DESCRIPTION
### Description

If device is offline, `reader.getAllArticles()` will return null

### Linked Issues/Tasks


### Type of change

Bug fix

### Tests

No test

### QA Notes

Go offline, make sure app doesn't crash
