### PR TITLE
fix: yarn - do not update checksum by default

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,3 @@
 nodeLinker: node-modules
 
-checksumBehavior: 'update'
-
 yarnPath: .yarn/releases/yarn-3.6.4.cjs

--- a/yarn.lock
+++ b/yarn.lock
@@ -14118,7 +14118,7 @@ __metadata:
 "react-native-keychain@synonymdev/react-native-keychain#refactor/android-data-store":
   version: 8.2.0
   resolution: "react-native-keychain@https://github.com/synonymdev/react-native-keychain.git#commit=7378c469afe81195487a3163295be425af79fa7a"
-  checksum: 94297964de510a7a47f27e4175cdc85a977f36092afa0749648ad102c0f818f3fc41a9a92cf5e3e70d52c93e1e922ce4247860017ec4cee72f331f6410cbe02a
+  checksum: 96008e384e055b2c812a8271e758fac6f50e7018cd43644adbe2a0902fe5a3fa64698bc1056e507a5b4612da4a6ecc79144d52de4e01b8ee7e017ad550c83662
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This PR disables Yarn's automatic checksum updates to enhance security and maintain consistency. It ensures that dependencies remain unchanged unless explicitly intended, preventing potential unauthorized or accidental modifications. This is crucial for a stable and secure build process.

### Linked Issues/Tasks



### Type of change

Bug fix

### Tests

No test
