### PR TITLE
fix: transfer UI fixes

### DIFF
--- a/__tests__/reselect.ts
+++ b/__tests__/reselect.ts
@@ -5,7 +5,11 @@ import '../src/utils/i18n';
 import store, { RootState } from '../src/store';
 import { dispatch } from '../src/store/helpers';
 import { updateWallet } from '../src/store/slices/wallet';
-import { TBalance, balanceSelector } from '../src/store/reselect/aggregations';
+import {
+	TBalance,
+	balanceSelector,
+	transferLimitsSelector,
+} from '../src/store/reselect/aggregations';
 import {
 	EChannelClosureReason,
 	EChannelStatus,
@@ -115,6 +119,78 @@ describe('Reselect', () => {
 			};
 
 			assert.deepEqual(balanceSelector(state), balance);
+		});
+	});
+
+	describe('transferLimitsSelector', () => {
+		it('should calculate limits without LN channels', () => {
+			// max value is limited by maxChannelSize / 2
+			const s1 = cloneDeep(s);
+			s1.wallet.wallets.wallet0.balance.bitcoinRegtest = 1000;
+			s1.blocktank.info.options = {
+				...s1.blocktank.info.options,
+				minChannelSizeSat: 10,
+				maxChannelSizeSat: 200,
+				maxClientBalanceSat: 100,
+			};
+
+			const received1 = transferLimitsSelector(s1);
+			const expected1 = {
+				minChannelSize: 11,
+				maxChannelSize: 180,
+				maxClientBalance: 90,
+			};
+
+			expect(received1).toMatchObject(expected1);
+
+			// max value is limited by onchain balance
+			const s2 = cloneDeep(s);
+			s2.wallet.wallets.wallet0.balance.bitcoinRegtest = 50;
+			s2.blocktank.info.options = {
+				...s2.blocktank.info.options,
+				minChannelSizeSat: 10,
+				maxChannelSizeSat: 200,
+				maxClientBalanceSat: 100,
+			};
+
+			const received2 = transferLimitsSelector(s2);
+			const expected2 = {
+				minChannelSize: 11,
+				maxChannelSize: 180,
+				maxClientBalance: 40,
+			};
+
+			expect(received2).toMatchObject(expected2);
+		});
+
+		it('should calculate limits with existing LN channels', () => {
+			// max value is limited by leftover node capacity
+			const s1 = cloneDeep(s);
+			s1.wallet.wallets.wallet0.balance.bitcoinRegtest = 1000;
+			s1.blocktank.info.options = {
+				...s1.blocktank.info.options,
+				minChannelSizeSat: 10,
+				maxChannelSizeSat: 200,
+			};
+			const channel1 = {
+				channel_id: 'channel1',
+				status: EChannelStatus.open,
+				is_channel_ready: true,
+				outbound_capacity_sat: 1,
+				balance_sat: 2,
+				channel_value_satoshis: 100,
+			} as TChannel;
+			const lnWallet = s1.lightning.nodes.wallet0;
+			lnWallet.channels.bitcoinRegtest = { channel1 };
+
+			const received1 = transferLimitsSelector(s1);
+			const expected1 = {
+				minChannelSize: 11,
+				maxChannelSize: 100,
+				maxClientBalance: 50,
+			};
+
+			expect(received1).toMatchObject(expected1);
 		});
 	});
 });

--- a/e2e/channels.e2e.js
+++ b/e2e/channels.e2e.js
@@ -53,7 +53,7 @@ d('LN Channel Onboarding', () => {
 		// Advanced
 		// - can change amount
 
-		it('Can buy a channel via the SpendingAmount and CustomSetup', async () => {
+		it('Can buy a channel with default and custom receive capacity', async () => {
 			if (checkComplete('channels-1')) {
 				return;
 			}
@@ -99,7 +99,7 @@ d('LN Channel Onboarding', () => {
 			await element(by.id('NavigationBack')).tap();
 			await element(by.id('SpendingIntro-button')).tap();
 
-			// NumberPad
+			// can change amount
 			await element(by.id('N2').withAncestor(by.id('SpendingAmount'))).tap();
 			await element(by.id('N0').withAncestor(by.id('SpendingAmount'))).multiTap(
 				5,
@@ -116,7 +116,7 @@ d('LN Channel Onboarding', () => {
 				.toBeVisible()
 				.withTimeout(10000);
 
-			// Advanced
+			// Get another channel with custom receiving capacity
 			await element(by.id('NavigationClose')).tap();
 			await element(by.id('ActivitySavings')).tap();
 			await element(by.id('TransferToSpending')).tap();
@@ -130,13 +130,26 @@ d('LN Channel Onboarding', () => {
 			await element(by.id('SpendingConfirmAdvanced')).tap();
 
 			// Receiving Capacity
-			await element(by.id('SpendingAdvancedDefault')).tap();
-			await expect(element(by.text('100 000'))).toBeVisible();
+			// can continue with min amount
 			await element(by.id('SpendingAdvancedMin')).tap();
-			await expect(element(by.text('2 000'))).toBeVisible();
-			await element(
-				by.id('NRemove').withAncestor(by.id('SpendingAdvanced')),
-			).multiTap(5);
+			await expect(element(by.text('110 000'))).toBeVisible();
+			await element(by.id('SpendingAdvancedContinue')).tap();
+			await element(by.id('SpendingConfirmDefault')).tap();
+			await element(by.id('SpendingConfirmAdvanced')).tap();
+
+			// can continue with default amount
+			await element(by.id('SpendingAdvancedDefault')).tap();
+			await element(by.id('SpendingAdvancedContinue')).tap();
+			await element(by.id('SpendingConfirmDefault')).tap();
+			await element(by.id('SpendingConfirmAdvanced')).tap();
+
+			// can continue with max amount
+			await element(by.id('SpendingAdvancedMax')).tap();
+			await element(by.id('SpendingAdvancedContinue')).tap();
+			await element(by.id('SpendingConfirmDefault')).tap();
+			await element(by.id('SpendingConfirmAdvanced')).tap();
+
+			// can set custom amount
 			await element(by.id('N1').withAncestor(by.id('SpendingAdvanced'))).tap();
 			await element(by.id('N5').withAncestor(by.id('SpendingAdvanced'))).tap();
 			await element(

--- a/src/components/OnboardingScreen.tsx
+++ b/src/components/OnboardingScreen.tsx
@@ -16,6 +16,7 @@ const OnboardingScreen = ({
 	buttonText,
 	displayBackButton = true,
 	disableNav = false,
+	mirrorImage = false,
 	testID,
 	onClosePress,
 	onButtonPress,
@@ -28,6 +29,7 @@ const OnboardingScreen = ({
 	buttonText: string;
 	displayBackButton?: boolean;
 	disableNav?: boolean;
+	mirrorImage?: boolean;
 	testID?: string;
 	onClosePress?: () => void;
 	onButtonPress: () => void;
@@ -51,6 +53,7 @@ const OnboardingScreen = ({
 						styles.imageContainer,
 						// eslint-disable-next-line react-native/no-inline-styles
 						{ marginBottom: imagePosition === 'center' ? 'auto' : 48 },
+						mirrorImage ? { transform: [{ rotateY: '180deg' }] } : {},
 					]}>
 					<Image style={styles.image} source={image} />
 				</View>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -14,8 +14,8 @@ import { receiveIcon, sendIcon } from '../assets/icons/tabs';
 import { toggleBottomSheet } from '../store/utils/ui';
 import { resetSendTransaction } from '../store/actions/wallet';
 import { viewControllersSelector } from '../store/reselect/ui';
+import { spendingOnboardingSelector } from '../store/reselect/aggregations';
 import useColors from '../hooks/colors';
-import { useBalance } from '../hooks/wallet';
 import { useAppSelector } from '../hooks/redux';
 import { ScanIcon } from '../styles/icons';
 import { AnimatedView } from '../styles/components';
@@ -30,9 +30,9 @@ const TabBar = ({
 }): ReactElement => {
 	const { white10 } = useColors();
 	const insets = useSafeAreaInsets();
-	const { lightningBalance } = useBalance();
 	const { t } = useTranslation('wallet');
 	const viewControllers = useAppSelector(viewControllersSelector);
+	const isSpendingOnboarding = useAppSelector(spendingOnboardingSelector);
 
 	const shouldHide = useMemo(() => {
 		const activityFilterSheets = ['timeRangePrompt', 'tagsPrompt'];
@@ -42,7 +42,8 @@ const TabBar = ({
 	const onReceivePress = (): void => {
 		const currentRoute = rootNavigation.getCurrenRoute();
 
-		if (currentRoute === 'ActivitySpending' && lightningBalance === 0) {
+		// if we are on the spending screen and the user has not yet received funds
+		if (currentRoute === 'ActivitySpending' && isSpendingOnboarding) {
 			toggleBottomSheet('receiveNavigation', {
 				receiveScreen: 'ReceiveAmount',
 			});

--- a/src/screens/Activity/ActivitySpending.tsx
+++ b/src/screens/Activity/ActivitySpending.tsx
@@ -15,7 +15,7 @@ import ActivityList from './ActivityList';
 import { useBalance } from '../../hooks/wallet';
 import { useAppSelector } from '../../hooks/redux';
 import { EActivityType } from '../../store/types/activity';
-import { activityItemsSelector } from '../../store/reselect/activity';
+import { spendingOnboardingSelector } from '../../store/reselect/aggregations';
 import { WalletScreenProps } from '../../navigation/types';
 
 const imageSrc = require('../../assets/illustrations/coin-stack-x-2.png');
@@ -25,13 +25,7 @@ const ActivitySpending = ({
 }: WalletScreenProps<'ActivitySpending'>): ReactElement => {
 	const { t } = useTranslation('wallet');
 	const { lightningBalance, balanceInTransferToSpending } = useBalance();
-	const items = useAppSelector(activityItemsSelector);
-
-	const spendingItems = useMemo(() => {
-		return items.filter((item) => {
-			return item.activityType === EActivityType.lightning;
-		});
-	}, [items]);
+	const isSpendingOnboarding = useAppSelector(spendingOnboardingSelector);
 
 	const filter = useMemo(() => {
 		return {
@@ -39,11 +33,6 @@ const ActivitySpending = ({
 			includeTransfers: true,
 		};
 	}, []);
-
-	const showOnboarding =
-		lightningBalance === 0 &&
-		spendingItems.length === 0 &&
-		!balanceInTransferToSpending;
 
 	const onTransfer = (): void => {
 		navigation.navigate('TransferRoot', { screen: 'SavingsIntro' });
@@ -87,7 +76,7 @@ const ActivitySpending = ({
 
 				<View style={styles.divider} />
 
-				{showOnboarding ? (
+				{isSpendingOnboarding ? (
 					<WalletOnboarding
 						text={
 							<Trans

--- a/src/screens/Transfer/SavingsConfirm.tsx
+++ b/src/screens/Transfer/SavingsConfirm.tsx
@@ -136,6 +136,7 @@ const styles = StyleSheet.create({
 		flex: 1,
 		resizeMode: 'contain',
 		width: 256,
+		transform: [{ rotateY: '180deg' }],
 	},
 	buttonContainer: {
 		marginTop: 'auto',

--- a/src/screens/Transfer/SavingsIntro.tsx
+++ b/src/screens/Transfer/SavingsIntro.tsx
@@ -33,6 +33,7 @@ const SavingsIntro = ({
 			description={t('savings_intro.text')}
 			image={imageSrc}
 			buttonText={t('savings_intro.button')}
+			mirrorImage={true}
 			testID="SavingsIntro"
 			onClosePress={onClose}
 			onButtonPress={onContinue}

--- a/src/store/reselect/aggregations.ts
+++ b/src/store/reselect/aggregations.ts
@@ -1,10 +1,16 @@
 import { ETransferType } from '../types/wallet';
-import { lightningBalanceSelector, pendingPaymentsSelector } from './lightning';
+import {
+	channelsSizeSelector,
+	lightningBalanceSelector,
+	pendingPaymentsSelector,
+} from './lightning';
 import { newChannelsNotificationsSelector } from './todos';
 import { onChainBalanceSelector, pendingTransfersSelector } from './wallet';
 import { createShallowEqualSelector } from './utils';
 import { activityItemsSelector } from './activity';
 import { EActivityType } from '../types/activity';
+import { blocktankInfoSelector } from './blocktank';
+import { MAX_SPENDING_PERCENTAGE } from '../../utils/wallet/constants';
 
 export type TBalance = {
 	/** Total onchain funds */
@@ -86,6 +92,50 @@ export const balanceSelector = createShallowEqualSelector(
 		};
 	},
 );
+
+/**
+ * Returns limits for channel orders with the LSP
+ */
+export const transferLimitsSelector = createShallowEqualSelector(
+	[blocktankInfoSelector, onChainBalanceSelector, channelsSizeSelector],
+	(
+		blocktankInfo,
+		onchainBalance,
+		channelsSize,
+	): {
+		minChannelSize: number;
+		maxChannelSize: number;
+		maxClientBalance: number;
+	} => {
+		const { minChannelSizeSat, maxChannelSizeSat } = blocktankInfo.options;
+		// Because LSP limits constantly change depending on network fees
+		// add a 10% buffer to avoid fluctuations while making the order
+		const minChannelSize = Math.round(minChannelSizeSat * 1.1);
+		const maxChannelSize1 = Math.round(maxChannelSizeSat * 0.9);
+		// The maximum channel size the user can open including existing channels
+		const maxChannelSize2 = Math.max(0, maxChannelSizeSat - channelsSize);
+		const maxChannelSize = Math.min(maxChannelSize1, maxChannelSize2);
+
+		// 80% cap to leave buffer for fees
+		const localLimit = Math.round(onchainBalance * MAX_SPENDING_PERCENTAGE);
+		// LSP balance must be at least 1.5% of the client balance
+		// const minLspBalance1 = Math.round(clientBalance * 0.02);
+		// const minLspBalance2 = Math.round(minChannelSize - clientBalance);
+		// const minLspBalance = Math.max(minLspBalance1, minLspBalance2);
+		// LSP balance must be at least half of the channel size
+		// The actual requirement is much lower, but we want to give the user a balanced channel.
+		// TODO: get exact requirements from LSP
+		const lspLimit = Math.round(maxChannelSize / 2);
+		const maxClientBalance = Math.min(localLimit, lspLimit);
+
+		return {
+			minChannelSize,
+			maxChannelSize,
+			maxClientBalance,
+		};
+	},
+);
+
 // Determine if the onboarding text is shown on the ActivitySpending screen
 export const spendingOnboardingSelector = createShallowEqualSelector(
 	[lightningBalanceSelector, pendingTransfersSelector, activityItemsSelector],

--- a/src/store/utils/blocktank.ts
+++ b/src/store/utils/blocktank.ts
@@ -485,7 +485,7 @@ export const scheduleNotifications = async (): Promise<void> => {
 
 		const options = {
 			title: i18n.t('other:transfer_notification.title'),
-			body: i18n.t('other:transfer_notification.title'),
+			body: i18n.t('other:transfer_notification.description'),
 			android: {
 				channelId,
 				smallIcon: 'ic_launcher_transparent',


### PR DESCRIPTION
### Description

Updates transfer to spending default values for receiving capacity. It now uses the same default (~500€) for receiving capacity as CJIT instead of a 1:1 balanced channel. Also fixes other smaller issues.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [x] Detox test
- [ ] Unit test
- [ ] No test
