### PR TITLE
fix: stop auto removing peers

### DIFF
--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -45,6 +45,7 @@ import {
 	recoverOutputsFromForceClose,
 	refreshLdk,
 	setupLdk,
+	removeUnusedPeers,
 } from '../../../utils/lightning';
 import { showToast } from '../../../utils/notifications';
 import {
@@ -349,6 +350,23 @@ const Channels = ({
 		});
 	}, [peer, selectedNetwork, selectedWallet, t]);
 
+	const onRemoveUnusedPeers = useCallback(async () => {
+		const res = await removeUnusedPeers({ selectedWallet, selectedNetwork });
+		if (res.isErr()) {
+			showToast({
+				type: 'warning',
+				title: 'No unused peers removed',
+				description: res.error.message,
+			});
+		} else {
+			showToast({
+				type: 'info',
+				title: 'Removed unused peers',
+				description: res.value,
+			});
+		}
+	}, [selectedNetwork, selectedWallet]);
+
 	return (
 		<ThemedView style={styles.root}>
 			<SafeAreaInset type="top" />
@@ -485,6 +503,12 @@ const Channels = ({
 									: 'Paste Lightning Peer From Clipboard'
 							}
 							onPress={onAddPeer}
+							testID="AddPeerButton"
+						/>
+						<Button
+							style={styles.devButton}
+							text={'Remove unused peers'}
+							onPress={onRemoveUnusedPeers}
 							testID="AddPeerButton"
 						/>
 						<Button

--- a/src/screens/Settings/Lightning/Channels.tsx
+++ b/src/screens/Settings/Lightning/Channels.tsx
@@ -507,9 +507,8 @@ const Channels = ({
 						/>
 						<Button
 							style={styles.devButton}
-							text={'Remove unused peers'}
+							text="Remove unused peers"
 							onPress={onRemoveUnusedPeers}
-							testID="AddPeerButton"
 						/>
 						<Button
 							style={styles.devButton}

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -335,7 +335,6 @@ export const setupLdk = async ({
 		await Promise.all([
 			updateLightningNodeIdThunk(),
 			updateLightningNodeVersionThunk(),
-			removeUnusedPeers({ selectedWallet, selectedNetwork }),
 			addTrustedPeers(),
 		]);
 		if (shouldRefreshLdk) {
@@ -1575,6 +1574,8 @@ export const removeUnusedPeers = async ({
 	const blocktankPubKeys = blocktankInfo.nodes.map((n) => n.pubkey);
 	const peers = await lm.getPeers();
 
+	let removedCount = 0;
+
 	await Promise.all(
 		peers.map((peer) => {
 			if (
@@ -1591,10 +1592,14 @@ export const removeUnusedPeers = async ({
 					address: peer.address,
 					port: peer.port,
 				}).then();
+
+				removedCount++;
+
+				console.error(`Removed unused peer: ${peerStr}`);
 			}
 		}),
 	);
-	return ok('Unused peers removed.');
+	return ok(`${removedCount} unused peers removed.`);
 };
 
 /**


### PR DESCRIPTION
### Description

removeUnusedPeers was added a few years back to avoid connecting to peers that wallet did not have a channel with or was not a Blocktank node. On restore this was being triggered before syncing channels with redux state so it was removing peers before realising there was actually an active channel. 

I think auto dropping peers might be a bit premature of an optimisation so I moved it to a manual button for now. A user might have the intention of adding a peer and opening a channel with that peer at a later stage and with this method the peer would be removed on each start up.

### Linked Issues/Tasks

https://github.com/orgs/synonymdev/projects/12/views/1?pane=issue&itemId=69388158

https://github.com/synonymdev/react-native-ldk/issues/259

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

Insert relevant screenshot / recording

### QA Notes

After adding an external peer, restore from remote backup and peer should still be there. Or if there was a channel from another LSP it should still be usable.