### PR TITLE
fix: prevent wallet from beeing initalized twice

### DIFF
--- a/e2e/boost.e2e.js
+++ b/e2e/boost.e2e.js
@@ -52,6 +52,15 @@ d('Boost', () => {
 			return;
 		}
 
+		// switch off RBF mode
+		await element(by.id('Settings')).tap();
+		if (!__DEV__) {
+			await element(by.id('DevOptions')).multiTap(5); // enable dev mode
+		}
+		await element(by.id('DevSettings')).tap();
+		await element(by.id('RBF')).tap();
+		await launchAndWait();
+
 		// fund the wallet
 		await element(by.id('Receive')).tap();
 		let { label: wAddress } = await element(by.id('QRCode')).getAttributes();
@@ -76,11 +85,10 @@ d('Boost', () => {
 		await sleep(500); // wait for keyboard to hide
 		await element(by.id('AddressContinue')).tap();
 		await element(by.id('N1').withAncestor(by.id('SendAmountNumberPad'))).tap();
-		for (let i = 0; i < 4; i++) {
-			await element(
-				by.id('N0').withAncestor(by.id('SendAmountNumberPad')),
-			).tap();
-		}
+		await element(by.id('N0').withAncestor(by.id('SendAmountNumberPad'))).tap();
+		await element(
+			by.id('N000').withAncestor(by.id('SendAmountNumberPad')),
+		).tap();
 		await expect(element(by.text('10 000'))).toBeVisible();
 		await element(by.id('ContinueAmount')).tap();
 		await element(by.id('GRAB')).swipe('right', 'slow', 0.95, 0.5, 0.5); // Swipe to confirm
@@ -164,15 +172,6 @@ d('Boost', () => {
 			return;
 		}
 
-		// switch to RBF mode
-		await element(by.id('Settings')).tap();
-		if (!__DEV__) {
-			await element(by.id('DevOptions')).multiTap(5); // enable dev mode
-		}
-		await element(by.id('DevSettings')).tap();
-		await element(by.id('RBF')).tap();
-		await launchAndWait();
-
 		// fund the wallet
 		await element(by.id('Receive')).tap();
 		let { label: wAddress } = await element(by.id('QRCode')).getAttributes();
@@ -197,11 +196,10 @@ d('Boost', () => {
 		await sleep(500); // wait for keyboard to hide
 		await element(by.id('AddressContinue')).tap();
 		await element(by.id('N1').withAncestor(by.id('SendAmountNumberPad'))).tap();
-		for (let i = 0; i < 4; i++) {
-			await element(
-				by.id('N0').withAncestor(by.id('SendAmountNumberPad')),
-			).tap();
-		}
+		await element(by.id('N0').withAncestor(by.id('SendAmountNumberPad'))).tap();
+		await element(
+			by.id('N000').withAncestor(by.id('SendAmountNumberPad')),
+		).tap();
 		await expect(element(by.text('10 000'))).toBeVisible();
 		await element(by.id('ContinueAmount')).tap();
 		await element(by.id('GRAB')).swipe('right', 'slow', 0.95, 0.5, 0.5); // Swipe to confirm

--- a/src/store/actions/wallet.ts
+++ b/src/store/actions/wallet.ts
@@ -50,6 +50,7 @@ import {
 	addUnconfirmedTransactions,
 	createWallet,
 	replaceImpactedAddresses,
+	setWalletExits,
 	updateHeader,
 	updateTransactions,
 	updateTransfer,
@@ -95,6 +96,7 @@ export const createWalletThunk = async ({
 			return err(response.error.message);
 		}
 		dispatch(createWallet(response.value));
+		dispatch(setWalletExits());
 		return ok('');
 	} catch (e) {
 		return err(e);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -32,7 +32,7 @@ const persistConfig = {
 	key: 'root',
 	storage: reduxStorage,
 	// increase version after store shape changes
-	version: 43,
+	version: 44,
 	stateReconciler: autoMergeLevel2,
 	blacklist: ['receive', 'ui'],
 	migrate: createMigrate(migrations, { debug: __ENABLE_MIGRATION_DEBUG__ }),

--- a/src/store/migrations/index.ts
+++ b/src/store/migrations/index.ts
@@ -16,6 +16,15 @@ const migrations = {
 			},
 		};
 	},
+	44: (state): PersistedState => {
+		return {
+			...state,
+			settings: {
+				...state.settings,
+				rbf: true,
+			},
+		};
+	},
 };
 
 export default migrations;

--- a/src/store/shapes/settings.ts
+++ b/src/store/shapes/settings.ts
@@ -82,7 +82,7 @@ export const initialSettingsState: TSettings = {
 	pinOnIdle: false,
 	pinForPayments: false,
 	biometrics: false,
-	rbf: false,
+	rbf: true,
 	theme: 'dark',
 	unit: EUnit.BTC,
 	denomination: EDenomination.modern,

--- a/src/store/slices/wallet.ts
+++ b/src/store/slices/wallet.ts
@@ -32,7 +32,6 @@ export const walletSlice = createSlice({
 	initialState: defaultWalletStoreShape,
 	reducers: {
 		createWallet: (state, action: PayloadAction<IWallets>) => {
-			state.walletExists = true;
 			state.wallets = {
 				...state.wallets,
 				...action.payload,
@@ -186,6 +185,9 @@ export const walletSlice = createSlice({
 		resetExchangeRates: (state) => {
 			state.exchangeRates = defaultWalletStoreShape.exchangeRates;
 		},
+		setWalletExits: (state) => {
+			state.walletExists = true;
+		},
 	},
 });
 
@@ -204,6 +206,7 @@ export const {
 	replaceImpactedAddresses,
 	resetSelectedWallet,
 	resetExchangeRates,
+	setWalletExits,
 } = actions;
 
 export default reducer;


### PR DESCRIPTION
### Description

After new wallet creation `setupOnChainWallet` was called twice resulting in 2 instances of Beignet competing against each other. 
I'm fixing it by `walletExists: true` setter to be executed later, after the `createDefaultWallet` function is completed

### Linked Issues/Tasks

closes #2177

### Type of change

Bug fix

### Tests

No test

### QA Notes

- make sure RBF is enabled by default
- create new wallet, do not restart the app
- create 2-3 onchain transactions
- make sure you don't have any error messages
