### PR TITLE
fix: hide LightningSyncing properly

### DIFF
--- a/src/components/LightningSyncing.tsx
+++ b/src/components/LightningSyncing.tsx
@@ -48,7 +48,7 @@ const LightningSyncing = ({
 		if (isLDKReady && !hidden) {
 			rootOpacity.value = withTiming(0, { duration: 200 }, () => {
 				cancelAnimation(glowOpacity);
-				runOnJS(() => setHidden(true));
+				runOnJS(setHidden)(true);
 			});
 		}
 


### PR DESCRIPTION
### Description

runOnJs returns a callback, that needs to be executed. Otherwise LightningSyncing remains and blocks the UI

### Linked Issues/Tasks

closes #1334 #2220

### Type of change

Bug fix

### Tests

No test
