### PR TITLE
fix(receive): force refresh LDK on channel open

### DIFF
--- a/src/store/utils/blocktank.ts
+++ b/src/store/utils/blocktank.ts
@@ -76,7 +76,7 @@ export const refreshOrdersList = async (): Promise<Result<string>> => {
  * Updates the status of pending CJIT entries that may have changed.
  * @returns {Promise<Result<string>>}
  */
-export const checkPendingCJitEntries = async (): Promise<Result<string>> => {
+export const updatePendingCJitEntries = async (): Promise<Result<string>> => {
 	const pendingCJitEntries = blocktank.getPendingCJitEntries();
 	try {
 		const promises = pendingCJitEntries.map((order) => {


### PR DESCRIPTION
### Description

Updating to force `refreshLdk()` when a channel is opened. Also makes the code around CJIT more readable and adds logs. Removing `InteractionManager.runAfterInteractions` lines since it doesn't do anything.

### Linked Issues/Tasks

https://github.com/synonymdev/bitkit/issues/1780

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
