### PR TITLE
fix(send): do not auto fill minimum amount for LNURL Pay

### DIFF
--- a/e2e/lnurl.e2e.js
+++ b/e2e/lnurl.e2e.js
@@ -186,6 +186,10 @@ d('LNURL', () => {
 		await element(by.id('ScanPrompt')).tap();
 		await element(by.id('QRInput')).replaceText(payRequest1.encoded);
 		await element(by.id('DialogConfirm')).tap();
+		await element(by.id('N1').withAncestor(by.id('SendAmountNumberPad'))).tap();
+		await element(
+			by.id('N0').withAncestor(by.id('SendAmountNumberPad')),
+		).multiTap(5);
 
 		await element(by.id('ContinueAmount')).tap();
 		await element(by.id('CommentInput')).typeText('test comment');
@@ -230,6 +234,12 @@ d('LNURL', () => {
 		await waitFor(
 			element(by.id('MoneyText').withAncestor(by.id('ReviewAmount-primary'))),
 		).toHaveText(minSendableSats.toString());
+		await element(by.id('N3').withAncestor(by.id('SendAmountNumberPad'))).tap();
+		await element(by.id('N2').withAncestor(by.id('SendAmountNumberPad'))).tap();
+		await element(by.id('N1').withAncestor(by.id('SendAmountNumberPad'))).tap();
+		await element(
+			by.id('N0').withAncestor(by.id('SendAmountNumberPad')),
+		).multiTap(3);
 		await waitFor(element(by.id('ContinueAmount'))).toBeVisible();
 		await element(by.id('ContinueAmount')).tap();
 		await element(by.id('GRAB')).swipe('right', 'slow', 0.95, 0.5, 0.5); // Swipe to confirm

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -637,6 +637,16 @@
 	"lnurl_p_title": {
 		"string": "Pay Bitcoin"
 	},
+	"lnurl_pay": {
+		"error_min": {
+			"title": {
+				"string": "Amount Too Low"
+			},
+			"description": {
+				"string": "The minimum amount for this invoice is ₿ {amount}."
+			}
+		}
+	},
 	"lnurl_p_max": {
 		"string": "Maximum amount"
 	},


### PR DESCRIPTION
### Description

Do not set the `minSpendable` from LNURL Pay url as default. With a low minimum like 1 ₿ the dollar converted amount can be $0.00 which result in confusing UX. Add a toast for minimum amount validation.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/2239

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/user-attachments/assets/8e435d96-569d-4b55-ad6d-591cbcfe9d19

