### PR TITLE
fix(transfer): fix force transfer bottom sheet

### DIFF
--- a/e2e/channels.e2e.js
+++ b/e2e/channels.e2e.js
@@ -275,6 +275,9 @@ d('Transfer', () => {
 
 		// TODO: mine single blocks and check updated transfer time
 
+		// Sometimes the channel is only opened after restart 
+		await device.launchApp();
+
 		// wait for channel to be opened
 		await waitForActiveChannel(lnd, ldkNodeId);
 

--- a/src/navigation/bottom-sheet/BottomSheets.tsx
+++ b/src/navigation/bottom-sheet/BottomSheets.tsx
@@ -6,7 +6,6 @@ import { viewControllersSelector } from '../../store/reselect/ui';
 import BackupNavigation from './BackupNavigation';
 import BoostPrompt from '../../screens/Wallets/BoostPrompt';
 import ConnectionClosed from './ConnectionClosed';
-import ForceTransfer from './ForceTransfer';
 import LNURLWithdrawNavigation from './LNURLWithdrawNavigation';
 import NewTxPrompt from '../../screens/Wallets/NewTxPrompt';
 import OrangeTicketNavigation from './OrangeTicketNavigation';
@@ -24,7 +23,6 @@ const BottomSheets = (): JSX.Element => {
 			{views.backupNavigation.isMounted && <BackupNavigation />}
 			{views.boostPrompt.isMounted && <BoostPrompt />}
 			{views.connectionClosed.isMounted && <ConnectionClosed />}
-			{views.forceTransfer.isMounted && <ForceTransfer />}
 			{views.lnurlWithdraw.isMounted && <LNURLWithdrawNavigation />}
 			{views.newTxPrompt.isMounted && <NewTxPrompt />}
 			{views.orangeTicket.isMounted && <OrangeTicketNavigation />}

--- a/src/navigation/bottom-sheet/ForceTransfer.tsx
+++ b/src/navigation/bottom-sheet/ForceTransfer.tsx
@@ -1,5 +1,4 @@
 import React, { memo, ReactElement, useEffect, useState } from 'react';
-import { useAppDispatch, useAppSelector } from '../../hooks/redux';
 import { Trans, useTranslation } from 'react-i18next';
 
 import { Display } from '../../styles/text';
@@ -7,6 +6,7 @@ import BottomSheetWrapper from '../../components/BottomSheetWrapper';
 import BottomSheetScreen from '../../components/BottomSheetScreen';
 import { closeAllChannels } from '../../utils/lightning';
 import { showToast } from '../../utils/notifications';
+import { useAppDispatch, useAppSelector } from '../../hooks/redux';
 import {
 	useBottomSheetBackPress,
 	useSnapPoints,

--- a/src/navigation/root/RootNavigator.tsx
+++ b/src/navigation/root/RootNavigator.tsx
@@ -45,11 +45,12 @@ import Widget from '../../screens/Widgets/Widget';
 import WidgetEdit from '../../screens/Widgets/WidgetEdit';
 import WidgetsSuggestions from '../../screens/Widgets/WidgetsSuggestions';
 import WidgetsOnboarding from '../../screens/Widgets/WidgetsOnboarding';
+import ForgotPIN from '../../screens/Settings/PIN/ForgotPIN';
 import BackupSubscriber from '../../utils/backup/backups-subscriber';
+import ForceTransfer from '../bottom-sheet/ForceTransfer';
+import BottomSheetsLazy from '../bottom-sheet/BottomSheetsLazy';
 import { __E2E__ } from '../../constants/env';
 import type { RootStackParamList } from '../types';
-import BottomSheetsLazy from '../bottom-sheet/BottomSheetsLazy';
-import ForgotPIN from '../../screens/Settings/PIN/ForgotPIN';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
@@ -228,6 +229,7 @@ const RootNavigator = (): ReactElement => {
 
 			<BottomSheetsLazy />
 			<BackupSubscriber />
+			<ForceTransfer />
 
 			<Dialog
 				visible={showDialog && isAuthenticated}


### PR DESCRIPTION
### Description

Keep `<ForceTransfer />` mounted so the interval can run.

This card is for when a channel couldn't be cooperatively closed after a transfer to savings. It will keep trying for 30m and then offer to force close. For example if the channel peer is offline. If the user wants Bitkit to keep retrying the coop close they need to keep Bitkit open, otherwise on next start it should offer to force close.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/2190

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Recording

https://github.com/user-attachments/assets/15a11248-dc1d-47c0-90a5-2fb43d88fe2a



