### PR TITLE
fix: use emulator build 12325540 for e2e tests

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -138,6 +138,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 2047
           arch: x86_64
+          emulator-build: 12325540
           script: yarn e2e:test:android-release  --record-videos all --record-logs all --take-screenshots all --headless -d 200000 --artifacts-location /mnt/artifacts
 
       - name: Test attempt 2
@@ -152,6 +153,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 2047
           arch: x86_64
+          emulator-build: 12325540
           script: yarn e2e:test:android-release  --record-videos all --record-logs all --take-screenshots all --headless -d 200000 --artifacts-location /mnt/artifacts
 
       - name: Test attempt 3
@@ -166,6 +168,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 2047
           arch: x86_64
+          emulator-build: 12325540
           script: yarn e2e:test:android-release  --record-videos all --record-logs all --take-screenshots all --headless -d 200000 --artifacts-location /mnt/artifacts
 
       - name: Restart docker before last attempt
@@ -184,6 +187,7 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim -camera-back none -camera-front none -partition-size 2047
           arch: x86_64
+          emulator-build: 12325540
           script: yarn e2e:test:android-release  --record-videos all --record-logs all --take-screenshots all --headless -d 200000 --artifacts-location /mnt/artifacts
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request updates the `.github/workflows/e2e-android.yml` file to specify a particular emulator build for the Android end-to-end tests.

### Linked Issues/Tasks



### Type of change

Bug fix

### Tests

Detox test
