### PR TITLE
fix: various e2e fixes

### DIFF
--- a/.github/workflows/e2e-android.yml
+++ b/.github/workflows/e2e-android.yml
@@ -124,7 +124,7 @@ jobs:
         timeout-minutes: 10
         run: |
           while ! nc -z '127.0.0.1' 60001; do sleep 1; done
-          while ! nc -z '127.0.0.1' 10009; do sleep 1; done
+          sudo bash -c "while [ ! -f docker/lnd/data/chain/bitcoin/regtest/admin.macaroon ]; do sleep 1; done"
           sudo chmod -R 777 docker/lnd
 
       - name: Test attempt 1
@@ -173,9 +173,12 @@ jobs:
 
       - name: Restart docker before last attempt
         if: steps.test1.outcome != 'success' && steps.test2.outcome != 'success' && steps.test3.outcome != 'success'
+        timeout-minutes: 10
         run: |
           cd docker && docker compose down -t 60 && docker compose up --quiet-pull -d && cd ..
           while ! nc -z '127.0.0.1' 60001; do sleep 1; done
+          sudo bash -c "while [ ! -f docker/lnd/data/chain/bitcoin/regtest/admin.macaroon ]; do sleep 1; done"
+          sudo chmod -R 777 docker/lnd
 
       - name: Test attempt 4
         if: steps.test1.outcome != 'success' && steps.test2.outcome != 'success' && steps.test3.outcome != 'success'

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -61,7 +61,7 @@ jobs:
           echo '    npmAuthToken: "${{ secrets.NPMJS_READ_RN_PUBKY }}"' >> .yarnrc.yml
 
       - name: Yarn Install
-        run: yarn --no-audit --prefer-offline || yarn --no-audit --prefer-offline || yarn
+        run: yarn || yarn
         env:
           HUSKY: 0
 
@@ -91,7 +91,10 @@ jobs:
       - name: Restart docker before last attempt
         if: steps.test1.outcome != 'success' && steps.test2.outcome != 'success' && steps.test3.outcome != 'success'
         run: |
-          cd docker && docker compose down -t 60 && docker compose up --force-recreate --quiet-pull -d && cd ..
+          cd docker
+          docker compose down -t 60
+          rm -rf lnd
+          docker compose up --force-recreate --quiet-pull -d
           while ! nc -z '127.0.0.1' 60001; do sleep 1; done
 
       - name: Test attempt 4

--- a/e2e/channels.e2e.js
+++ b/e2e/channels.e2e.js
@@ -276,7 +276,7 @@ d('Transfer', () => {
 		// TODO: mine single blocks and check updated transfer time
 
 		// Sometimes the channel is only opened after restart
-		await device.launchApp();
+		await launchAndWait();
 
 		// wait for channel to be opened
 		await waitForActiveChannel(lnd, ldkNodeId);


### PR DESCRIPTION
### Description

- instead of waiting for the port to be open, wait for admin.macaroon to appear to determine that LND has started. This works better for the Android tests
- remove depricated yarn arguments
- `device.launchApp()` does not actually restart the app, you need to pass `newInstance: true`. But I'm using `launchAndWait()`. Looks like the channel.e2e.js test is now more stable

### Linked Issues/Tasks



### Type of change

Bug fix

### Tests

Detox test
