### PR TITLE
fix: show proper error if slashpay.json is empty

### DIFF
--- a/src/screens/Contacts/Contact.tsx
+++ b/src/screens/Contacts/Contact.tsx
@@ -94,7 +94,7 @@ const Contact = ({
 			showToast({
 				type: 'warning',
 				title: t('contact_pay_error'),
-				description: t('other:try_again'),
+				description: res.error.message,
 			});
 		}
 	};

--- a/src/utils/i18n/locales/en/slashtags.json
+++ b/src/utils/i18n/locales/en/slashtags.json
@@ -240,7 +240,7 @@
     "string": "Unable To Pay Contact"
   },
   "error_pay_empty_msg": {
-    "string": "This contact has no payment data."
+    "string": "The contact you’re trying to send to hasn’t enabled payments."
   },
   "auth_depricated_title": {
     "string": "Deprecated"


### PR DESCRIPTION
### Description

- Show original error message, insted of "try again" - it makes to sence
- Change error message to "The contact you’re trying to send to hasn’t enabled payments"

### Linked Issues/Tasks

#2256

### Type of change

Bug fix

### Tests

No test
