### PR TITLE
fix: Slow RegExp when validating electrum server URL

### DIFF
--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -1075,7 +1075,7 @@ export const addPeer = async ({
 	}
 
 	if (!isValidLightningNodePublicKey(parsedUri.value.publicKey)) {
-		return err(i18n.t('lightning:error_add_msg'));
+		return err(i18n.t('lightning:error_add'));
 	}
 
 	const res = await lm.addPeer({
@@ -1086,7 +1086,7 @@ export const addPeer = async ({
 	});
 
 	if (res.isErr()) {
-		res.error.message = i18n.t('lightning:error_add_msg', {
+		res.error.message = i18n.t('lightning:error_add', {
 			raw: res.error.message,
 		});
 	}


### PR DESCRIPTION
### Description

Update `isValidURL` to use URL parser for performance.

### Linked Issues/Tasks

Closes #2288

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

Tested with the following URLs, the last one will also be considered valid now but I think this is acceptable.

http://umbrel.local:50001
http://0.0.0.0:60002
umbrel.local:50001:t
http://localhost:60001
http://35.233.47.252:18483
35.233.47.252:18483
031e30fda75f317ba5fe3264e9f9deb0797c1d5b17c21ed07354f92d244afcaa19@127.0.0.1:9735