### PR TITLE
feat(ui): add Save Log button in debug settings for use in E2E tests

### DIFF
--- a/src/screens/Settings/DevSettings/LdkDebug.tsx
+++ b/src/screens/Settings/DevSettings/LdkDebug.tsx
@@ -4,6 +4,7 @@ import Share from 'react-native-share';
 import { useTranslation } from 'react-i18next';
 import Clipboard from '@react-native-clipboard/clipboard';
 import lm from '@synonymdev/react-native-ldk';
+import RNFS from 'react-native-fs';
 
 import { Caption13Up } from '../../../styles/text';
 import { View as ThemedView, TextInput } from '../../../styles/components';
@@ -176,6 +177,30 @@ const LdkDebug = (): ReactElement => {
 			type: 'application/zip',
 			url: `file://${result.value}`,
 			title: t('export_logs'),
+		});
+	};
+
+	const onSaveLogs = async (): Promise<void> => {
+		const result = await zipLogs();
+		if (result.isErr()) {
+			showToast({
+				type: 'warning',
+				title: t('error_logs'),
+				description: t('error_logs_description'),
+			});
+			return;
+		}
+
+		// Define the destination path in the Downloads folder
+		const downloadsDir = RNFS.DownloadDirectoryPath;
+		const destinationPath = `${downloadsDir}/bitkit_ldk_logs.zip`;
+
+		await RNFS.copyFile(result.value, destinationPath);
+
+		showToast({
+			type: 'success',
+			title: 'Logs saved', // todo: locale
+			description: `${destinationPath}`,
 		});
 	};
 
@@ -370,6 +395,12 @@ const LdkDebug = (): ReactElement => {
 					style={styles.button}
 					text="Export Logs"
 					onPress={onExportLogs}
+				/>
+				<Button
+					style={styles.button}
+					text="Save Logs"
+					onPress={onSaveLogs}
+					testID="SaveLogs"
 				/>
 
 				{openChannels.length > 0 && (


### PR DESCRIPTION
### Description

Added 'Save Log' button in LDK debug settings so logs can be saved in UI-driven E2E tests without needing to use the export share menu that depends on a 3rd-party app.

### Linked Issues/Tasks

Add any links to GitHub issues or Asana tasks that are relevant to this pull request.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

Insert relevant screenshot / recording

### QA Notes

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce during the Bitkit testing session. You can also leave a video of the PR in action.
