### PR TITLE
fix: Show Info notification for LNURL-withdraw success

### DIFF
--- a/src/screens/Wallets/LNURLWithdraw/Confirm.tsx
+++ b/src/screens/Wallets/LNURLWithdraw/Confirm.tsx
@@ -44,9 +44,9 @@ const Confirm = ({ route }: LNURLWithdrawProps<'Confirm'>): ReactElement => {
 		}
 		dispatch(closeSheet('lnurlWithdraw'));
 		showToast({
-			type: 'success',
-			title: t('lnurl_w_success_title'),
-			description: t('lnurl_w_success_description'),
+			type: 'info',
+			title: t('other:lnurl_withdr_success_title'),
+			description: t('other:lnurl_withdr_success_msg'),
 		});
 	};
 

--- a/src/utils/i18n/locales/en/other.json
+++ b/src/utils/i18n/locales/en/other.json
@@ -224,7 +224,7 @@
 		"string": "Withdraw Requested"
 	},
 	"lnurl_withdr_success_msg": {
-		"string": "Your withdraw was successfully requested."
+		"string": "Your withdraw was successfully requested. Waiting for payment."
 	},
 	"phone_settings": {
 		"string": "Open Phone Settings"

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -644,12 +644,6 @@
 	"lnurl_w_button": {
 		"string": "Withdraw"
 	},
-	"lnurl_w_success_title": {
-		"string": "Success"
-	},
-	"lnurl_w_success_description": {
-		"string": "Withdraw Requested Successful"
-	},
 	"lnurl_p_title": {
 		"string": "Pay Bitcoin"
 	},

--- a/src/utils/lnurl.ts
+++ b/src/utils/lnurl.ts
@@ -334,13 +334,6 @@ export const handleLnurlWithdraw = async ({
 			});
 			return err(jsonRes.reason);
 		}
-
-		showToast({
-			type: 'success',
-			title: i18n.t('other:lnurl_withdr_success_title'),
-			description: i18n.t('other:lnurl_withdr_success_msg'),
-		});
-
 		return ok('');
 	} catch (e) {
 		console.log(e.message);


### PR DESCRIPTION
### Description

Instead of Success show Info, because payment is still not received yet.
Also alter text

### Linked Issues/Tasks

closes #2326

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video


### QA Notes


