### PR TITLE
fix(send): show confetti for pending payment success

### DIFF
--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -102,6 +102,7 @@ import {
 import { showToast } from '../notifications';
 import i18n from '../i18n';
 import { bitkitLedger, syncLedger } from '../ledger';
+import { sendNavigation } from '../../navigation/bottom-sheet/SendNavigation';
 
 const PAYMENT_TIMEOUT = 8 * 1000; // 8 seconds
 
@@ -492,6 +493,14 @@ export const subscribeToLightningPayments = ({
 						title: i18n.t('wallet:toast_payment_success_title'),
 						description: i18n.t('wallet:toast_payment_success_description'),
 					});
+
+					// If the send sheet is open, navigate to the success screen
+					sendNavigation.navigate('Success', {
+						type: EActivityType.lightning,
+						txId: found.payment_hash,
+						amount: found.amount,
+					});
+
 					await refreshLdk();
 					bitkitLedger?.handleLNTx({ ...res, amount_sat: found.amount });
 				} else {
@@ -508,7 +517,7 @@ export const subscribeToLightningPayments = ({
 				const found = pending.find((p) => p.payment_hash === res.payment_hash);
 
 				if (found) {
-					await refreshLdk({ selectedWallet, selectedNetwork });
+					await refreshLdk();
 					showToast({
 						type: 'error',
 						title: i18n.t('wallet:toast_payment_failed_title'),


### PR DESCRIPTION
### Description

If a payment is pending (fe. hold invoice) but still resolves while the send sheet is open, show confetti.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/2248

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/user-attachments/assets/7cbedf10-daa5-44f7-aaf3-3c36ef8c2b7c

