### PR TITLE
 fix: async beignet wallet 

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@synonymdev/slashtags-widget-price-feed": "1.1.0",
     "@synonymdev/web-relay": "1.0.7",
     "bech32": "2.0.0",
-    "beignet": "0.0.46",
+    "beignet": "0.0.48",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
     "bip39": "3.1.0",

--- a/src/AppOnboarded.tsx
+++ b/src/AppOnboarded.tsx
@@ -7,7 +7,7 @@ import RootNavigator from './navigation/root/RootNavigator';
 import InactivityTracker from './components/InactivityTracker';
 import { showToast } from './utils/notifications';
 import { startWalletServices } from './utils/startup';
-import { getOnChainWalletElectrum } from './utils/wallet';
+import { getOnChainWalletElectrumAsync } from './utils/wallet';
 import { unsubscribeFromLightningSubscriptions } from './utils/lightning';
 import { useAppSelector } from './hooks/redux';
 import { dispatch } from './store/helpers';
@@ -24,8 +24,6 @@ import {
 } from './store/reselect/wallet';
 import { updateSettings } from './store/slices/settings';
 // import { updateExchangeRates } from './store/actions/wallet';
-
-const electrum = getOnChainWalletElectrum();
 
 const AppOnboarded = (): ReactElement => {
 	const { t } = useTranslation('other');
@@ -59,16 +57,16 @@ const AppOnboarded = (): ReactElement => {
 		// on AppState change
 		const appStateSubscription = AppState.addEventListener(
 			'change',
-			(nextAppState) => {
+			async (nextAppState) => {
 				dispatch(updateUi({ appState: nextAppState }));
-
+				const electrum = await getOnChainWalletElectrumAsync();
 				// on App to foreground
 				if (
 					appState.current.match(/inactive|background/) &&
 					nextAppState === 'active'
 				) {
 					// resubscribe to electrum connection changes
-					electrum?.startConnectionPolling();
+					electrum.startConnectionPolling();
 				}
 
 				// on App to background
@@ -76,7 +74,7 @@ const AppOnboarded = (): ReactElement => {
 					appState.current.match(/active|inactive/) &&
 					nextAppState === 'background'
 				) {
-					electrum?.stopConnectionPolling();
+					electrum.stopConnectionPolling();
 				}
 
 				appState.current = nextAppState;

--- a/src/hooks/wallet.ts
+++ b/src/hooks/wallet.ts
@@ -1,3 +1,5 @@
+import { Wallet as TWallet } from 'beignet';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAppDispatch, useAppSelector } from '../hooks/redux';
@@ -9,6 +11,7 @@ import { ignoreSwitchUnitToast } from '../store/slices/user';
 import { EUnit } from '../store/types/wallet';
 import i18n from '../utils/i18n';
 import { showToast } from '../utils/notifications';
+import { getOnChainWalletAsync } from '../utils/wallet';
 import { useCurrency } from './displayValues';
 
 /**
@@ -62,4 +65,24 @@ export const useSwitchUnitAnnounced = (): (() => void) => {
 	};
 
 	return switchUnitAnnounced;
+};
+
+/**
+ * Wait for the onchain wallet to be loaded.
+ */
+export const useOnchainWallet = (): { wallet: TWallet | null } => {
+	const [wallet, setWallet] = useState<TWallet | null>(null);
+
+	useEffect(() => {
+		const getWallet = async (): Promise<void> => {
+			const w = await getOnChainWalletAsync();
+			setWallet(w);
+		};
+
+		getWallet();
+	}, []);
+
+	return {
+		wallet,
+	};
 };

--- a/src/screens/Activity/ActivityDetail.tsx
+++ b/src/screens/Activity/ActivityDetail.tsx
@@ -95,7 +95,7 @@ import type {
 	RootStackScreenProps,
 } from '../../navigation/types';
 import { i18nTime } from '../../utils/i18n';
-import { useSwitchUnit } from '../../hooks/wallet';
+import { useOnchainWallet, useSwitchUnit } from '../../hooks/wallet';
 import { contactsSelector } from '../../store/reselect/slashtags';
 import { ETransferStatus } from '../../store/types/wallet';
 
@@ -157,6 +157,7 @@ const OnchainActivityDetail = ({
 	const isSend = txType === EPaymentType.sent;
 	const total = isSend ? fee + value : value;
 
+	const { wallet } = useOnchainWallet();
 	const { t } = useTranslation('wallet');
 	const { t: tTime } = useTranslation('intl', { i18n: i18nTime });
 	const switchUnit = useSwitchUnit();
@@ -210,17 +211,21 @@ const OnchainActivityDetail = ({
 	}, [confirmed, isBoosted, txId]);
 
 	const boostedParents = useMemo(() => {
+		if (!wallet) {
+			return [];
+		}
 		return getBoostedTransactionParents({
+			wallet,
 			txId,
 			boostedTransactions,
 		});
-	}, [boostedTransactions, txId]);
+	}, [boostedTransactions, txId, wallet]);
 
 	const hasBoostedParents = useMemo(() => {
 		return boostedParents.length > 0;
 	}, [boostedParents.length]);
 
-	const handleBoostParentPress = (parentTxId): void => {
+	const handleBoostParentPress = (parentTxId: string): void => {
 		const activityItem = activityItems.find((i) => {
 			return i.activityType === EActivityType.onchain && i.txId === parentTxId;
 		});
@@ -300,6 +305,10 @@ const OnchainActivityDetail = ({
 		}
 		return <View />;
 	}, [txDetails]);
+
+	if (!wallet) {
+		return <ActivityIndicator />;
+	}
 
 	let fees = fee;
 	let paymentAmount = value;

--- a/src/screens/Settings/GapLimit/index.tsx
+++ b/src/screens/Settings/GapLimit/index.tsx
@@ -12,7 +12,7 @@ import { gapLimitOptionsSelector } from '../../../store/reselect/wallet';
 import { ScrollView, TextInput, View } from '../../../styles/components';
 import { Caption13Up } from '../../../styles/text';
 import { showToast } from '../../../utils/notifications';
-import { getOnChainWallet, refreshWallet } from '../../../utils/wallet';
+import { getOnChainWalletAsync, refreshWallet } from '../../../utils/wallet';
 
 const GapLimit = ({}: SettingsScreenProps<'GapLimit'>): ReactElement => {
 	const { t } = useTranslation('settings');
@@ -68,7 +68,7 @@ const GapLimit = ({}: SettingsScreenProps<'GapLimit'>): ReactElement => {
 
 	const saveGapLimit = async (): Promise<void> => {
 		setLoading(true);
-		const wallet = getOnChainWallet();
+		const wallet = await getOnChainWalletAsync();
 		const res = wallet.updateGapLimit({
 			lookAhead: Number(lookAhead),
 			lookBehind: Number(lookBehind),

--- a/src/store/utils/activity.ts
+++ b/src/store/utils/activity.ts
@@ -101,7 +101,7 @@ export const updateOnChainActivityList = async (): Promise<Result<string>> => {
 	});
 	const activityItems = await Promise.all(promises);
 
-	const boostFormattedItems = formatBoostedActivityItems({
+	const boostFormattedItems = await formatBoostedActivityItems({
 		items: activityItems,
 		boostedTransactions,
 		selectedWallet,

--- a/src/store/utils/fees.ts
+++ b/src/store/utils/fees.ts
@@ -4,7 +4,7 @@ import { dispatch, getFeesStore } from '../helpers';
 import { updateOnchainFees } from '../slices/fees';
 import { getFeeEstimates } from '../../utils/wallet/transactions';
 import { EAvailableNetwork } from '../../utils/networks';
-import { getOnChainWallet, getSelectedNetwork } from '../../utils/wallet';
+import { getOnChainWalletAsync, getSelectedNetwork } from '../../utils/wallet';
 import { IOnchainFees } from 'beignet';
 
 export const REFRESH_INTERVAL = 60 * 30; // in seconds, 30 minutes
@@ -46,6 +46,6 @@ export const refreshOnchainFeeEstimates = async ({
 }: {
 	forceUpdate?: boolean;
 }): Promise<Result<IOnchainFees>> => {
-	const wallet = getOnChainWallet();
+	const wallet = await getOnChainWalletAsync();
 	return await wallet.updateFeeEstimates(forceUpdate);
 };

--- a/src/utils/ledger.ts
+++ b/src/utils/ledger.ts
@@ -16,7 +16,7 @@ import {
 } from './lightning';
 import { EAvailableNetwork } from './networks';
 import {
-	getOnChainWalletElectrum,
+	getOnChainWalletElectrumAsync,
 	getScriptHash,
 	getSelectedNetwork,
 	getSelectedWallet,
@@ -59,7 +59,7 @@ export const getChannelCloseTime = async (
 
 	// we have to construct IAddress to get the history
 	const scriptHash = await getScriptHash(address, selectedNetwork);
-	const el = getOnChainWalletElectrum();
+	const el = await getOnChainWalletElectrumAsync();
 	const scriptHashes: IAddress[] = [
 		{
 			index: 0,

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -42,8 +42,8 @@ import {
 	getBip39Passphrase,
 	getCurrentAddressIndex,
 	getMnemonicPhrase,
-	getOnChainWalletData,
-	getOnChainWalletElectrum,
+	getOnChainWalletDataAsync,
+	getOnChainWalletElectrumAsync,
 	getSelectedNetwork,
 	getSelectedWallet,
 	ldkSeed,
@@ -214,7 +214,7 @@ export const setLdkStoragePath = (): Promise<Result<string>> =>
 const broadcastTransaction: TBroadcastTransaction = async (
 	rawTx: string,
 ): Promise<Result<string>> => {
-	const electrum = getOnChainWalletElectrum();
+	const electrum = await getOnChainWalletElectrumAsync();
 	const res = await electrum.broadcastTransaction({
 		rawTx,
 		subscribeToOutputAddress: false,
@@ -229,7 +229,7 @@ const broadcastTransaction: TBroadcastTransaction = async (
 const getScriptPubKeyHistory = async (
 	scriptPubKey: string,
 ): Promise<TGetAddressHistory[]> => {
-	const electrum = getOnChainWalletElectrum();
+	const electrum = await getOnChainWalletElectrumAsync();
 	return await electrum.getScriptPubKeyHistory(scriptPubKey);
 };
 
@@ -913,7 +913,7 @@ export const getBestBlock = async (
 	selectedNetwork: EAvailableNetwork = getSelectedNetwork(),
 ): Promise<THeader> => {
 	try {
-		const beignetHeader = getOnChainWalletData().header;
+		const beignetHeader = (await getOnChainWalletDataAsync()).header;
 		const storageHeader = getWalletStore().header[selectedNetwork];
 		const header =
 			beignetHeader.height > storageHeader.height
@@ -937,7 +937,7 @@ export const getTransactionData = async (
 	let transactionData = DefaultTransactionDataShape;
 	try {
 		const data = [{ tx_hash: txId }];
-		const electrum = getOnChainWalletElectrum();
+		const electrum = await getOnChainWalletElectrumAsync();
 		const response = await electrum.getTransactions({
 			txHashes: data,
 		});

--- a/src/utils/wallet/electrum.ts
+++ b/src/utils/wallet/electrum.ts
@@ -2,11 +2,12 @@ import { err, ok, Result } from '@synonymdev/result';
 
 import { EAvailableNetwork } from '../networks';
 import {
-	getCustomElectrumPeers,
-	getOnChainWallet,
-	getOnChainWalletElectrum,
-	getSelectedNetwork,
 	ITransaction,
+	getCustomElectrumPeers,
+	getOnChainWalletAsync,
+	getOnChainWalletElectrum,
+	getOnChainWalletElectrumAsync,
+	getSelectedNetwork,
 	refreshWallet,
 } from './index';
 import {
@@ -35,7 +36,7 @@ export type TUnspentAddressScriptHashData = {
  * @returns {Promise<boolean>}
  */
 export const isConnectedElectrum = async (): Promise<boolean> => {
-	const electrum = getOnChainWalletElectrum();
+	const electrum = await getOnChainWalletElectrumAsync();
 	return electrum.isConnected();
 };
 
@@ -65,7 +66,7 @@ export const listUnspentAddressScriptHashes = async ({
 }: {
 	addresses: TUnspentAddressScriptHashData;
 }): Promise<Result<IGetUtxosResponse>> => {
-	const electrum = getOnChainWalletElectrum();
+	const electrum = await getOnChainWalletElectrumAsync();
 	const unspentAddressResult = await electrum.listUnspentAddressScriptHashes({
 		addresses,
 	});
@@ -89,7 +90,7 @@ export const subscribeToAddresses = async ({
 	scriptHashes?: string[];
 	onReceive?: () => void;
 } = {}): Promise<Result<string>> => {
-	const electrum = getOnChainWalletElectrum();
+	const electrum = await getOnChainWalletElectrumAsync();
 	return electrum.subscribeToAddresses({ scriptHashes, onReceive });
 };
 
@@ -132,7 +133,7 @@ export const getTransactions = async ({
 }: {
 	txHashes: ITxHash[];
 }): Promise<Result<IGetTransactions>> => {
-	const electrum = getOnChainWalletElectrum();
+	const electrum = await getOnChainWalletElectrumAsync();
 	return await electrum.getTransactions({ txHashes });
 };
 
@@ -147,7 +148,7 @@ export interface IPeerData {
  * @return {Promise<Result<IPeerData>>}
  */
 export const getConnectedPeer = async (): Promise<Result<IPeerData>> => {
-	const electrum = getOnChainWalletElectrum();
+	const electrum = await getOnChainWalletElectrumAsync();
 	const peerData = await electrum.getConnectedPeer();
 	return peerData as Result<IPeerData>;
 };
@@ -173,7 +174,7 @@ export const getTransactionsFromInputs = async ({
 }: {
 	txHashes: ITxHash[];
 }): Promise<Result<IGetTransactionsFromInputs>> => {
-	const electrum = getOnChainWalletElectrum();
+	const electrum = await getOnChainWalletElectrumAsync();
 	return await electrum.getTransactionsFromInputs({ txHashes });
 };
 
@@ -197,7 +198,7 @@ export const getAddressHistory = async ({
 	scriptHashes?: IAddress[];
 	scanAllAddresses?: boolean;
 }): Promise<Result<IGetAddressHistoryResponse[]>> => {
-	const electrum = getOnChainWalletElectrum();
+	const electrum = await getOnChainWalletElectrumAsync();
 	return await electrum.getAddressHistory({ scriptHashes, scanAllAddresses });
 };
 
@@ -217,7 +218,7 @@ export const connectToElectrum = async ({
 	showNotification?: boolean;
 	selectedNetwork?: EAvailableNetwork;
 } = {}): Promise<Result<string>> => {
-	const electrum = getOnChainWalletElectrum();
+	const electrum = await getOnChainWalletElectrumAsync();
 
 	// Attempt to disconnect from any old/lingering connections
 	await electrum?.disconnect();
@@ -254,7 +255,7 @@ export const getAddressBalance = async ({
 }: {
 	addresses: string[];
 }): Promise<Result<number>> => {
-	const wallet = getOnChainWallet();
+	const wallet = await getOnChainWalletAsync();
 	return await wallet.getAddressesBalance(addresses);
 };
 
@@ -269,24 +270,8 @@ export const getBlockHex = async ({
 }: {
 	height?: number;
 }): Promise<Result<string>> => {
-	const electrum = getOnChainWalletElectrum();
+	const electrum = await getOnChainWalletElectrumAsync();
 	return await electrum.getBlockHex({ height });
-};
-
-/**
- * Returns the block hash given a block hex.
- * Leaving blockHex empty will return the last known block hash from storage.
- * @param {string} [blockHex]
- * @param {EAvailableNetwork} [selectedNetwork]
- * @returns {string}
- */
-export const getBlockHashFromHex = ({
-	blockHex,
-}: {
-	blockHex?: string;
-}): string => {
-	const electrum = getOnChainWalletElectrum();
-	return electrum.getBlockHashFromHex({ blockHex });
 };
 
 /**

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -40,8 +40,10 @@ import { TRANSACTION_DEFAULTS } from './constants';
 import {
 	getBalance,
 	getOnChainWallet,
+	getOnChainWalletAsync,
 	getOnChainWalletElectrum,
 	getOnChainWalletTransaction,
+	getOnChainWalletTransactionAsync,
 	getSelectedNetwork,
 	getSelectedWallet,
 	refreshWallet,
@@ -103,7 +105,7 @@ export const createTransaction = async (
 	transactionData?: ISendTransaction,
 ): Promise<Result<{ id: string; hex: string }>> => {
 	try {
-		const transaction = getOnChainWalletTransaction();
+		const transaction = await getOnChainWalletTransactionAsync();
 		const createTxRes = await transaction.createTransaction({
 			transactionData,
 		});
@@ -495,7 +497,7 @@ export const sendMax = async ({
 	const { paymentMethod } = getUiStore();
 
 	try {
-		const tx = getOnChainWalletTransaction();
+		const tx = await getOnChainWalletTransactionAsync();
 		const transaction = tx.data;
 
 		// TODO: Re-work lightning transaction invoices once beignet migration is complete.
@@ -813,7 +815,7 @@ export const setupCpfp = async ({
 }: {
 	txid: string;
 }): Promise<Result<ISendTransaction>> => {
-	const transaction = getOnChainWalletTransaction();
+	const transaction = await getOnChainWalletTransactionAsync();
 	return await transaction.setupCpfp({ txid });
 };
 
@@ -826,7 +828,7 @@ export const setupRbf = async ({
 }: {
 	txid: string;
 }): Promise<Result<ISendTransaction>> => {
-	const transaction = getOnChainWalletTransaction();
+	const transaction = await getOnChainWalletTransactionAsync();
 	return await transaction.setupRbf({ txid });
 };
 
@@ -901,7 +903,7 @@ export const getFeeEstimates = async (
 			});
 		}
 
-		const wallet = getOnChainWallet();
+		const wallet = await getOnChainWalletAsync();
 		const feeRes = await wallet.getFeeEstimates();
 		if (!feeRes) {
 			return err('Unable to get fee estimates.');

--- a/src/utils/wallet/transfer.ts
+++ b/src/utils/wallet/transfer.ts
@@ -7,9 +7,13 @@ import {
 import { err, ok } from '@synonymdev/result';
 import lm, { ldk } from '@synonymdev/react-native-ldk';
 
-import { getCurrentWallet, getSelectedNetwork, refreshWallet } from '.';
+import {
+	getCurrentWallet,
+	getOnChainWalletAsync,
+	getSelectedNetwork,
+	refreshWallet,
+} from '.';
 import { btcToSats } from '../conversion';
-import { getBoostedTransactionParents } from '../boost';
 import { getTransactions } from './electrum';
 import {
 	ETransferStatus,
@@ -33,6 +37,7 @@ export const getTransferForTx = async (
 ): Promise<TTransfer | undefined> => {
 	const { currentWallet, selectedNetwork } = getCurrentWallet();
 	const transfers = currentWallet.transfers[selectedNetwork];
+	const wallet = await getOnChainWalletAsync();
 
 	if (tx.type === EPaymentType.sent) {
 		const transfersToSpending = transfers.filter((t) => {
@@ -46,7 +51,9 @@ export const getTransferForTx = async (
 
 		// check if the tx is a transfer that was boosted
 		if (!transferToSpending) {
-			const boostedParents = getBoostedTransactionParents({ txId: tx.txid });
+			const boostedParents = wallet.getBoostedTransactionParents({
+				txid: tx.txid,
+			});
 			const isBoosted = boostedParents.length > 0;
 			if (isBoosted) {
 				transferToSpending = transfersToSpending.find((t) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6368,9 +6368,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"beignet@npm:0.0.46":
-  version: 0.0.46
-  resolution: "beignet@npm:0.0.46"
+"beignet@npm:0.0.48":
+  version: 0.0.48
+  resolution: "beignet@npm:0.0.48"
   dependencies:
     "@bitcoinerlab/secp256k1": 1.0.5
     bech32: 2.0.0
@@ -6384,7 +6384,7 @@ __metadata:
     lodash.clonedeep: 4.5.0
     net: 1.0.2
     rn-electrum-client: 0.0.18
-  checksum: aee2f6d7b852287b33950bd0a1f784db9fa2db0549218eb314ce34409f611b0cd6ddc9bb7b4c4ed2ee46694080b92a1d4a755198c658bf477d435ec8b3e3457f
+  checksum: 4aab9ec50b339bde6ef291fc9e9a2e6845f6f7bac9a07be292cfc0eaac5bcd387ed08d5a54e416f476a40d332cf6a1946c028387eba76a0e81890e33b5e73615
   languageName: node
   linkType: hard
 
@@ -6631,7 +6631,7 @@ __metadata:
     babel-jest: ^29.7.0
     babel-plugin-transform-remove-console: ^6.9.4
     bech32: 2.0.0
-    beignet: 0.0.46
+    beignet: 0.0.48
     bip21: 2.0.3
     bip32: 4.0.0
     bip39: 3.1.0


### PR DESCRIPTION
### Description

- use getOnchainWalletAsync where possible
- throw an error in sync methods 
- useOnchainWallet hook to use in react components and wait for the wallet to be loaded
- new beignet with [this patch](https://github.com/synonymdev/beignet/pull/82). Now wallet creation is much faster, because it doesn't wait for sync to be complete

This is still not perfect, and we still use sync methods sometimes. I think we can elliminate the remaining issues later

### Linked Issues/Tasks

closes #2254 #2202

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video

Insert relevant screenshot / recording

### QA Notes

- start the app
- try to tap somewhere fast
