### PR TITLE
chore: upgrade detox

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "babel-jest": "^29.7.0",
     "babel-plugin-transform-remove-console": "^6.9.4",
     "bitcoin-json-rpc": "^1.3.3",
-    "detox": "20.20.2",
+    "detox": "20.23.1",
     "electrum-client": "BlueWallet/rn-electrum-client#47acb51149e97fab249c3f8a314f708dbee4fb6e",
     "eslint": "^8.57.0",
     "eslint-plugin-ft-flow": "^3.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6640,7 +6640,7 @@ __metadata:
     bitcoin-units: 0.3.0
     bitcoinjs-lib: 6.1.5
     color: 4.2.3
-    detox: 20.20.2
+    detox: 20.23.1
     electrum-client: "BlueWallet/rn-electrum-client#47acb51149e97fab249c3f8a314f708dbee4fb6e"
     eslint: ^8.57.0
     eslint-plugin-ft-flow: ^3.0.7
@@ -7007,9 +7007,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bunyamin@npm:^1.5.0":
-  version: 1.5.1
-  resolution: "bunyamin@npm:1.5.1"
+"bunyamin@npm:^1.5.2":
+  version: 1.6.3
+  resolution: "bunyamin@npm:1.6.3"
   dependencies:
     "@flatten-js/interval-tree": ^1.1.2
     multi-sort-stream: ^1.0.4
@@ -7023,7 +7023,7 @@ __metadata:
       optional: true
     bunyan:
       optional: true
-  checksum: 3b7b2f6e58f54017a66c246580e885a016af11b178aa021bc41fa690e885fd1f4adca4d5a5c6e1eca9b8f549fdffc515329bf791ab096d04294eb256d5f9e195
+  checksum: 3422db179c2f1d9581740b18de79c925e2ab25ee49ea5e66a5b66db16372d6f641927de55010c997050049d9e9569f4b720d409ffa0a573ded86aef5d49768eb
   languageName: node
   linkType: hard
 
@@ -8195,9 +8195,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detox@npm:20.20.2":
-  version: 20.20.2
-  resolution: "detox@npm:20.20.2"
+"detox@npm:20.23.1":
+  version: 20.23.1
+  resolution: "detox@npm:20.23.1"
   dependencies:
     ajv: ^8.6.3
     bunyan: ^1.8.12
@@ -8211,7 +8211,7 @@ __metadata:
     funpermaproxy: ^1.1.0
     glob: ^8.0.3
     ini: ^1.3.4
-    jest-environment-emit: ^1.0.5
+    jest-environment-emit: ^1.0.8
     json-cycle: ^1.3.0
     lodash: ^4.17.11
     multi-sort-stream: ^1.0.3
@@ -8241,7 +8241,7 @@ __metadata:
       optional: true
   bin:
     detox: local-cli/cli.js
-  checksum: 29983078bc1de1abb017d01fa3d30ad452f47e9026e23ec45d3ff6c191cb7bb57ce5e910283f0ee4057e618c926c3d880cf9314c4c24efe71f35205ca3fd1246
+  checksum: b383dcf852754854e48a496970ebecb0bbfb84c4381aa62064ba0c719be8552429f57f2f1cce0bad43b168cc3e21a000ae609f14a612d72c7b0e168054c5f2bb
   languageName: node
   linkType: hard
 
@@ -11092,11 +11092,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-environment-emit@npm:^1.0.5":
-  version: 1.0.5
-  resolution: "jest-environment-emit@npm:1.0.5"
+"jest-environment-emit@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "jest-environment-emit@npm:1.0.8"
   dependencies:
-    bunyamin: ^1.5.0
+    bunyamin: ^1.5.2
     bunyan: ^2.0.5
     bunyan-debug-stream: ^3.1.0
     funpermaproxy: ^1.1.0
@@ -11121,7 +11121,7 @@ __metadata:
       optional: true
     jest-environment-node:
       optional: true
-  checksum: 116cb697b4464061f22d22f6741c2e3685af64685c8ec4652f247706c08fe55b559bb6822a8cf6c05c8071e68c2a048b0eaf340400db5a0bcbac58751c132f49
+  checksum: 0c7bafbd3a6e5952f6abb45958f0d2997371d29b29f3876afda48d1d734ccd703577aaac0d5afec2e19dc33a9db0e9458721fe73dbe797f0ced21481d908acfd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Upgrade detox dependency to fix e2e tests for Xcode 16 / iOS 18
