### PR TITLE
fix: always use iphone 15 for detox iOS tests

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -1,6 +1,3 @@
-// run iPhone 14 on local machine, iPhone 15 Pro on mac mini
-const iOSDevice = process.env.MACMINI ? 'iPhone 15 Pro' : 'iPhone 14';
-
 const reversePorts = [3003, 8080, 8081, 9735, 10009, 28334, 28335, 28336, 30001, 39388, 43782, 60001];
 
 /** @type {Detox.DetoxConfig} */
@@ -47,7 +44,7 @@ module.exports = {
 		simulator: {
 			type: 'ios.simulator',
 			device: {
-				type: iOSDevice,
+				type: 'iPhone 15',
 			},
 		},
 		emulator: {

--- a/.github/workflows/e2e-ios.yml
+++ b/.github/workflows/e2e-ios.yml
@@ -11,7 +11,6 @@ concurrency:
 env:
   E2E_TESTS: 1 # build without transform-remove-console babel plugin
   DEBUG: 'lnurl* lnurl server'
-  MACMINI: 1 # use iPhone 15 in .detoxrc
 
 jobs:
   e2e:


### PR DESCRIPTION
### Description

- always use iPhone 15 for e2e tests

### Linked Issues/Tasks



### Type of change

Bug fix

### Tests

Detox test


