### PR TITLE
fix: stop beignet wallet before replace/wipe it

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@synonymdev/slashtags-widget-price-feed": "1.1.0",
     "@synonymdev/web-relay": "1.0.7",
     "bech32": "2.0.0",
-    "beignet": "0.0.48",
+    "beignet": "0.0.49",
     "bip21": "2.0.3",
     "bip32": "4.0.0",
     "bitcoin-address-validation": "2.2.3",

--- a/src/screens/Settings/AddressViewer/index.tsx
+++ b/src/screens/Settings/AddressViewer/index.tsx
@@ -628,7 +628,7 @@ const AddressViewer = ({
 			if (utxosLength <= 0) {
 				return;
 			}
-			resetSendTransaction();
+			await resetSendTransaction();
 			const transactionRes = await setupOnChainTransaction({
 				utxos: selectedUtxosLength > 0 ? selectedUtxos : utxos,
 				rbf: true,

--- a/src/store/utils/settings.ts
+++ b/src/store/utils/settings.ts
@@ -9,7 +9,7 @@ import { removePin } from '../../utils/settings';
 import { wipeKeychain } from '../../utils/keychain';
 import { showToast } from '../../utils/notifications';
 import { wipeLdkStorage } from '../../utils/lightning';
-import { getSelectedWallet } from '../../utils/wallet';
+import { getOnChainWallet, getSelectedWallet } from '../../utils/wallet';
 import { TWalletName } from '../types/wallet';
 import { __E2E__ } from '../../constants/env';
 
@@ -31,6 +31,12 @@ export const wipeApp = async ({
 	restartApp?: boolean;
 } = {}): Promise<Result<string>> => {
 	try {
+		// stop onchain wallet if it exists
+		try {
+			const wallet = getOnChainWallet();
+			await wallet.stop();
+		} catch (e) {}
+
 		// Reset Redux stores & persisted storage
 		dispatch({ type: actions.WIPE_APP });
 

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -1108,14 +1108,8 @@ export const setupOnChainWallet = async ({
 	addressTypesToMonitor?: EAddressType[];
 	gapLimitOptions?: TGapLimitOptions;
 }): Promise<Result<Wallet>> => {
-	// Disconnect from Electrum before setting up a new wallet
-	if (globalWallet) {
-		// If wallet refresh is in progress, wait for it to complete
-		if (globalWallet.isRefreshing) {
-			await globalWallet.refreshWallet();
-		}
-		await globalWallet.electrum?.disconnect();
-	}
+	// if wallet alrady exists, prepare it to be re-created
+	await globalWallet?.stop();
 
 	if (!mnemonic) {
 		const mnemonicRes = await getMnemonicPhrase(name);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6351,9 +6351,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"beignet@npm:0.0.48":
-  version: 0.0.48
-  resolution: "beignet@npm:0.0.48"
+"beignet@npm:0.0.49":
+  version: 0.0.49
+  resolution: "beignet@npm:0.0.49"
   dependencies:
     "@bitcoinerlab/secp256k1": 1.0.5
     bech32: 2.0.0
@@ -6367,7 +6367,7 @@ __metadata:
     lodash.clonedeep: 4.5.0
     net: 1.0.2
     rn-electrum-client: 0.0.18
-  checksum: 4aab9ec50b339bde6ef291fc9e9a2e6845f6f7bac9a07be292cfc0eaac5bcd387ed08d5a54e416f476a40d332cf6a1946c028387eba76a0e81890e33b5e73615
+  checksum: fef6246edf066cb1dad9a3969d10e7a5497524aa9220fab24b3a11cb0644d04b23bddab48912b9485e67b7b58c58e3da951fa5e349c92a5121a042663def0280
   languageName: node
   linkType: hard
 
@@ -6612,7 +6612,7 @@ __metadata:
     babel-jest: ^29.7.0
     babel-plugin-transform-remove-console: ^6.9.4
     bech32: 2.0.0
-    beignet: 0.0.48
+    beignet: 0.0.49
     bip21: 2.0.3
     bip32: 4.0.0
     bitcoin-address-validation: 2.2.3


### PR DESCRIPTION
### Description

This should prevent wallet instance to write any data to the redux or call any onMessage callback after it has been stoped.
Maybe we can stop restarting RN after this

### Linked Issues/Tasks



### Type of change

Bug fix

### Tests

No test
