### PR TITLE
fix(transfer): update liquidity policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@react-navigation/native-stack": "6.10.1",
     "@reduxjs/toolkit": "2.2.6",
     "@shopify/react-native-skia": "1.3.11",
-    "@synonymdev/blocktank-lsp-http-client": "2.0.0",
+    "@synonymdev/blocktank-lsp-http-client": "2.2.0",
     "@synonymdev/feeds": "3.0.0",
     "@synonymdev/react-native-ldk": "0.0.154",
     "@synonymdev/react-native-lnurl": "0.0.10",

--- a/src/components/ActivityIndicator.tsx
+++ b/src/components/ActivityIndicator.tsx
@@ -16,7 +16,11 @@ import Animated, {
 	withTiming,
 } from 'react-native-reanimated';
 
-export const ActivityIndicator = ({ size }: { size: number }): ReactElement => {
+export const ActivityIndicator = ({
+	size = 32,
+}: {
+	size?: number;
+}): ReactElement => {
 	const strokeWidth = size / 12;
 	const radius = (size - strokeWidth) / 2;
 	const canvasSize = size + 30;

--- a/src/components/NumberPadTextField.tsx
+++ b/src/components/NumberPadTextField.tsx
@@ -93,7 +93,11 @@ const NumberPadTextField = ({
 	}
 
 	return (
-		<Pressable style={style} testID={testID} onPress={onPress}>
+		<Pressable
+			style={style}
+			accessibilityLabel={value}
+			testID={testID}
+			onPress={onPress}>
 			{showConversion && !reverse && (
 				<Money
 					style={styles.secondary}

--- a/src/hooks/transfer.ts
+++ b/src/hooks/transfer.ts
@@ -1,0 +1,90 @@
+import { useAppSelector } from './redux';
+import { onChainBalanceSelector } from '../store/reselect/wallet';
+import { blocktankInfoSelector } from '../store/reselect/blocktank';
+import { blocktankChannelsSizeSelector } from '../store/reselect/lightning';
+import { fiatToBitcoinUnit } from '../utils/conversion';
+
+type TTransferValues = {
+	maxClientBalance: number;
+	defaultLspBalance: number;
+	minLspBalance: number;
+	maxLspBalance: number;
+};
+
+const getDefaultLspBalance = (
+	clientBalance: number,
+	maxLspBalance: number,
+): number => {
+	const threshold1 = fiatToBitcoinUnit({ amount: 225, currency: 'EUR' });
+	const threshold2 = fiatToBitcoinUnit({ amount: 495, currency: 'EUR' });
+	const defaultLspBalance = fiatToBitcoinUnit({ amount: 450, currency: 'EUR' });
+
+	let lspBalance = defaultLspBalance - clientBalance;
+
+	if (clientBalance > threshold1) {
+		lspBalance = clientBalance;
+	}
+
+	if (clientBalance > threshold2) {
+		lspBalance = maxLspBalance;
+	}
+
+	return Math.min(lspBalance, maxLspBalance);
+};
+
+const getMinLspBalance = (
+	clientBalance: number,
+	minChannelSize: number,
+): number => {
+	// LSP balance must be at least 2% of the channel size for LDK to accept (reserve balance)
+	const ldkMinimum = Math.round(clientBalance * 0.02);
+	// Channel size must be at least minChannelSize
+	const lspMinimum = Math.max(minChannelSize - clientBalance, 0);
+
+	return Math.max(ldkMinimum, lspMinimum);
+};
+
+const getMaxClientBalance = (
+	onchainBalance: number,
+	maxChannelSize: number,
+): number => {
+	// Remote balance must be at least 2% of the channel size for LDK to accept (reserve balance)
+	const minRemoteBalance = Math.round(maxChannelSize * 0.02);
+	// Cap client balance to 80% to leave buffer for fees
+	const feeMaximum = Math.round(onchainBalance * 0.8);
+	const ldkMaximum = maxChannelSize - minRemoteBalance;
+
+	return Math.min(feeMaximum, ldkMaximum);
+};
+
+/**
+ * Returns limits and default values for channel orders with the LSP
+ * @param {number} clientBalance
+ * @returns {TTransferValues}
+ */
+export const useTransfer = (clientBalance: number): TTransferValues => {
+	const blocktankInfo = useAppSelector(blocktankInfoSelector);
+	const onchainBalance = useAppSelector(onChainBalanceSelector);
+	const channelsSize = useAppSelector(blocktankChannelsSizeSelector);
+
+	const { minChannelSizeSat, maxChannelSizeSat } = blocktankInfo.options;
+
+	// Because LSP limits constantly change depending on network fees
+	// add a 2% buffer to avoid fluctuations while making the order
+	const maxChannelSize1 = Math.round(maxChannelSizeSat * 0.98);
+	// The maximum channel size the user can open including existing channels
+	const maxChannelSize2 = Math.max(0, maxChannelSize1 - channelsSize);
+	const maxChannelSize = Math.min(maxChannelSize1, maxChannelSize2);
+
+	const minLspBalance = getMinLspBalance(clientBalance, minChannelSizeSat);
+	const maxLspBalance = maxChannelSize - clientBalance;
+	const defaultLspBalance = getDefaultLspBalance(clientBalance, maxLspBalance);
+	const maxClientBalance = getMaxClientBalance(onchainBalance, maxChannelSize);
+
+	return {
+		defaultLspBalance,
+		minLspBalance,
+		maxLspBalance,
+		maxClientBalance,
+	};
+};

--- a/src/screens/Transfer/SpendingConfirm.tsx
+++ b/src/screens/Transfer/SpendingConfirm.tsx
@@ -13,10 +13,10 @@ import Money from '../../components/Money';
 import LightningChannel from '../../components/LightningChannel';
 import { sleep } from '../../utils/helpers';
 import { showToast } from '../../utils/notifications';
+import { useTransfer } from '../../hooks/transfer';
 import { useAppSelector } from '../../hooks/redux';
 import { TransferScreenProps } from '../../navigation/types';
 import { transactionFeeSelector } from '../../store/reselect/wallet';
-import { transferLimitsSelector } from '../../store/reselect/aggregations';
 import {
 	confirmChannelPurchase,
 	startChannelPurchase,
@@ -32,7 +32,7 @@ const SpendingConfirm = ({
 	const { t } = useTranslation('lightning');
 	const [loading, setLoading] = useState(false);
 	const transactionFee = useAppSelector(transactionFeeSelector);
-	const limits = useAppSelector(transferLimitsSelector);
+	const { defaultLspBalance } = useTransfer(order.clientBalanceSat);
 
 	const clientBalance = order.clientBalanceSat;
 	const lspBalance = order.lspBalanceSat;
@@ -51,9 +51,6 @@ const SpendingConfirm = ({
 	};
 
 	const onDefault = async (): Promise<void> => {
-		const { maxChannelSize } = limits;
-		const defaultLspBalance = Math.round(maxChannelSize / 2);
-
 		const response = await startChannelPurchase({
 			clientBalance,
 			lspBalance: defaultLspBalance,

--- a/src/screens/Wallets/Receive/ReceiveQR.tsx
+++ b/src/screens/Wallets/Receive/ReceiveQR.tsx
@@ -124,7 +124,7 @@ const ReceiveQR = ({
 			return;
 		}
 
-		if (lightningBalance.remoteBalance < amount) {
+		if (lightningBalance.remoteBalance < amount && !jitInvoice) {
 			setLightningInvoice('');
 			showToast({
 				type: 'error',
@@ -151,7 +151,7 @@ const ReceiveQR = ({
 
 		setLightningInvoice(response.value.to_str);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [amount, message]);
+	}, [jitInvoice, amount, message]);
 
 	const getAddress = useCallback(async (): Promise<void> => {
 		if (!receiveNavigationIsOpen) {

--- a/src/store/reselect/aggregations.ts
+++ b/src/store/reselect/aggregations.ts
@@ -1,15 +1,10 @@
 import { ETransferType } from '../types/wallet';
-import {
-	blocktankChannelsSizeSelector,
-	lightningBalanceSelector,
-	pendingPaymentsSelector,
-} from './lightning';
+import { lightningBalanceSelector, pendingPaymentsSelector } from './lightning';
 import { newChannelsNotificationsSelector } from './todos';
 import { onChainBalanceSelector, pendingTransfersSelector } from './wallet';
 import { createShallowEqualSelector } from './utils';
 import { activityItemsSelector } from './activity';
 import { EActivityType } from '../types/activity';
-import { blocktankInfoSelector } from './blocktank';
 
 export type TBalance = {
 	/** Total onchain funds */
@@ -88,53 +83,6 @@ export const balanceSelector = createShallowEqualSelector(
 			balanceInTransferToSpending: inTransferToSpending,
 			balanceInTransferToSavings: claimableBalance,
 			totalBalance,
-		};
-	},
-);
-
-/**
- * Returns limits for channel orders with the LSP
- */
-export const transferLimitsSelector = createShallowEqualSelector(
-	[
-		blocktankInfoSelector,
-		onChainBalanceSelector,
-		blocktankChannelsSizeSelector,
-	],
-	(
-		blocktankInfo,
-		onchainBalance,
-		channelsSize,
-	): {
-		minChannelSize: number;
-		maxChannelSize: number;
-		maxClientBalance: number;
-	} => {
-		const { minChannelSizeSat, maxChannelSizeSat } = blocktankInfo.options;
-		// Because LSP limits constantly change depending on network fees
-		// add a 5% buffer to avoid fluctuations while making the order
-		const minChannelSize = Math.round(minChannelSizeSat * 1.05);
-		const maxChannelSize1 = Math.round(maxChannelSizeSat * 0.95);
-		// The maximum channel size the user can open including existing channels
-		const maxChannelSize2 = Math.max(0, maxChannelSize1 - channelsSize);
-		const maxChannelSize = Math.min(maxChannelSize1, maxChannelSize2);
-
-		// 80% cap to leave buffer for fees
-		const localLimit = Math.round(onchainBalance * 0.8);
-		// LSP balance must be at least 1.5% of the client balance
-		// const minLspBalance1 = Math.round(clientBalance * 0.02);
-		// const minLspBalance2 = Math.round(minChannelSize - clientBalance);
-		// const minLspBalance = Math.max(minLspBalance1, minLspBalance2);
-		// LSP balance must be at least half of the channel size
-		// The actual requirement is much lower, but we want to give the user a balanced channel.
-		// TODO: get exact requirements from LSP
-		const lspLimit = Math.round(maxChannelSize / 2);
-		const maxClientBalance = Math.min(localLimit, lspLimit);
-
-		return {
-			minChannelSize,
-			maxChannelSize,
-			maxClientBalance,
 		};
 	},
 );

--- a/src/utils/blocktank/index.ts
+++ b/src/utils/blocktank/index.ts
@@ -8,6 +8,7 @@ import {
 	ICJitEntry,
 } from '@synonymdev/blocktank-lsp-http-client';
 import { err, ok, Result } from '@synonymdev/result';
+import { IBtEstimateFeeResponse2 } from '@synonymdev/blocktank-lsp-http-client/dist/shared/IBtEstimateFeeResponse2';
 
 import { EAvailableNetwork } from '../networks';
 import { addPeers, getNodeId, refreshLdk } from '../lightning';
@@ -122,9 +123,9 @@ export const estimateOrderFee = async ({
 	lspBalance,
 	channelExpiryWeeks = DEFAULT_CHANNEL_DURATION,
 	options,
-}: ICreateOrderRequest): Promise<Result<number>> => {
+}: ICreateOrderRequest): Promise<Result<IBtEstimateFeeResponse2>> => {
 	try {
-		const estimateRes = await bt.estimateOrderFee(
+		const response = await bt.estimateOrderFeeFull(
 			lspBalance,
 			channelExpiryWeeks,
 			{
@@ -133,7 +134,7 @@ export const estimateOrderFee = async ({
 				zeroReserve: true,
 			},
 		);
-		return ok(estimateRes.feeSat);
+		return ok(response);
 	} catch (e) {
 		console.log(e);
 		return err(e);

--- a/src/utils/i18n/locales/en/wallet.json
+++ b/src/utils/i18n/locales/en/wallet.json
@@ -318,10 +318,10 @@
 		"string": "Receive on Spending Balance"
 	},
 	"receive_connect_initial": {
-		"string": "To set up your spending balance, a <accent>{lspFee}</accent> service provider fee will be deducted."
+		"string": "To set up your spending balance, a <accent>{networkFee}</accent> network fee and <accent>{serviceFee}</accent> service provider fee will be deducted."
 	},
 	"receive_connect_additional": {
-		"string": "To receive more instant Bitcoin, Bitkit has to increase your liquidity. A <accent>{lspFee}</accent> service provider fee will be  deducted from the amount you specified."
+		"string": "To receive more instant Bitcoin, Bitkit has to increase your liquidity. A <accent>{networkFee}</accent> network fee and <accent>{serviceFee}</accent> service provider fee will be deducted from the amount you specified."
 	},
 	"receive_liquidity": {
 		"nav_title": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4894,12 +4894,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@synonymdev/blocktank-lsp-http-client@npm:2.0.0":
-  version: 2.0.0
-  resolution: "@synonymdev/blocktank-lsp-http-client@npm:2.0.0"
+"@synonymdev/blocktank-lsp-http-client@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@synonymdev/blocktank-lsp-http-client@npm:2.2.0"
   dependencies:
     axios: ^1.4.0
-  checksum: 05befc91b212ac5dc5f6478b376245b46af3aca0e8950aadf69e4f99eb45026ba0130ed058b4d6aa894bdc615778fa00f1835b3a4bf5aef3fc31c5af0c6ab4ef
+  checksum: 45be9cf61f0701cc2fe7feab2c1b07dbf3254d4a2e2e0de912f8e58edbbc9bc68bd4244b5b9aae40fa46f7710cb2aca270bf77f70b1c2e5fa9e63ad18f558b2e
   languageName: node
   linkType: hard
 
@@ -6585,7 +6585,7 @@ __metadata:
     "@react-navigation/native-stack": 6.10.1
     "@reduxjs/toolkit": 2.2.6
     "@shopify/react-native-skia": 1.3.11
-    "@synonymdev/blocktank-lsp-http-client": 2.0.0
+    "@synonymdev/blocktank-lsp-http-client": 2.2.0
     "@synonymdev/feeds": 3.0.0
     "@synonymdev/react-native-ldk": 0.0.154
     "@synonymdev/react-native-lnurl": 0.0.10


### PR DESCRIPTION
### Description

- update LSP channel balances according to [new policy](https://docs.google.com/document/d/199MW_Zxm8xm0XMBhSE3feSxikYv1oW0D_OHMCrk94q4/edit?tab=t.0#heading=h.yyauh5flml4m)
- show split network and service fees for CJIT

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/1856 https://github.com/synonymdev/bitkit/issues/2054 https://github.com/synonymdev/bitkit/issues/2379

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [x] Detox test
- [ ] Unit test
- [ ] No test

### QA Notes

- although we decided to remove the minimum for the LSP balance there is still a technical minimum required for LDK of 2% of total channel size, so it cannot be 0
- there's also required minimum channel size from blocktank (currently 20k sats on production), in some cases more is added on the LSP side to fulfill this requirement
- we still subtract a buffer of 2% of the maximum channel size from blocktank to account for exchange rate fluctuation
- there is still a 80% cap on the max client balance to account for onchain fees
- sometimes you have to add/subtract the reserve balance (1%) for channel balances to get the numbers you expect
- currently there is an issue where CJIT "you will receive" amount is wrong
