### PR TITLE
perf: force Intl polyfill

### DIFF
--- a/shim.js
+++ b/shim.js
@@ -7,21 +7,23 @@ install();
 require('./src/polyfills/textdecoder-polyfill');
 
 // RN still doesn't support full spec of Intl API
+// Don't remove -force from these because detection is VERY slow on low-end Android.
+// https://github.com/formatjs/formatjs/issues/4463#issuecomment-2176070577
 if (!Intl.Locale) {
-	require('@formatjs/intl-locale/polyfill');
+	require('@formatjs/intl-locale/polyfill-force');
 }
 if (!NumberFormat.formatToParts) {
-	require('@formatjs/intl-numberformat/polyfill');
+	require('@formatjs/intl-numberformat/polyfill-force');
 	require('@formatjs/intl-numberformat/locale-data/en');
 	require('@formatjs/intl-numberformat/locale-data/ru');
 }
 if (!Intl.PluralRules) {
-	require('@formatjs/intl-pluralrules/polyfill');
+	require('@formatjs/intl-pluralrules/polyfill-force');
 	require('@formatjs/intl-pluralrules/locale-data/en');
 	require('@formatjs/intl-pluralrules/locale-data/ru');
 }
 if (!Intl.RelativeTimeFormat) {
-	require('@formatjs/intl-relativetimeformat/polyfill');
+	require('@formatjs/intl-relativetimeformat/polyfill-force');
 	require('@formatjs/intl-relativetimeformat/locale-data/en');
 	require('@formatjs/intl-relativetimeformat/locale-data/ru');
 }


### PR DESCRIPTION
### Description

Use `-force` variants for Intl polyfills. On hermes we already know it is not supported, so this skips the checks. Time to first paint is down to 2.34s from 4.4s on my Pixel 6.

### Linked Issues/Tasks

#2014 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
