### PR TITLE
fix: show warning if user tryies to use slashpay and LDK is not ready yet

### DIFF
--- a/src/utils/i18n/locales/en/slashtags.json
+++ b/src/utils/i18n/locales/en/slashtags.json
@@ -53,6 +53,9 @@
   "contact_pay_error": {
     "string": "Unable To Pay Contact"
   },
+  "contact_ldk_not_ready": {
+    "string": "Lightning is not ready yet"
+  },
   "contact_share": {
     "string": "Share Profile Key"
   },


### PR DESCRIPTION
### Description

We can probably show BottomSheet with Lightning loading indicator but that's requires adding another sheet + altering Scaner logic. I think it would be enought to just show a toast. It is quite a rare case. 

### Linked Issues/Tasks

closes #2377

### Type of change

Bug fix

### Tests

No test

### Screenshot / Video


https://github.com/user-attachments/assets/cdbf3e2d-bf7a-4633-87b4-6900dc7c7093



### QA Notes
