### PR TITLE
fix(transfer): remove 80% onchain cap, misc fixes

### DIFF
--- a/e2e/channels.e2e.js
+++ b/e2e/channels.e2e.js
@@ -160,7 +160,7 @@ d('Transfer', () => {
 		// Receiving Capacity
 		// can continue with min amount
 		await element(by.id('SpendingAdvancedMin')).tap();
-		await expect(element(by.text('2 000'))).toBeVisible();
+		await expect(element(by.text('2 500'))).toBeVisible();
 		await element(by.id('SpendingAdvancedContinue')).tap();
 		await element(by.id('SpendingConfirmDefault')).tap();
 		await element(by.id('SpendingConfirmAdvanced')).tap();

--- a/src/screens/Transfer/SpendingAdvanced.tsx
+++ b/src/screens/Transfer/SpendingAdvanced.tsx
@@ -65,13 +65,7 @@ const SpendingAdvanced = ({
 				return;
 			}
 
-			const result = await estimateOrderFee({
-				lspBalance,
-				options: {
-					clientBalanceSat: clientBalance,
-					turboChannel: false,
-				},
-			});
+			const result = await estimateOrderFee({ lspBalance, clientBalance });
 			if (result.isErr()) {
 				return;
 			}

--- a/src/screens/Wallets/Receive/ReceiveAmount.tsx
+++ b/src/screens/Wallets/Receive/ReceiveAmount.tsx
@@ -46,7 +46,7 @@ const ReceiveAmount = ({
 	const switchUnit = useSwitchUnit();
 	const [minimumAmount, setMinimumAmount] = useState(0);
 
-	const { defaultLspBalance: lspBalance } = useTransfer(0);
+	const { defaultLspBalance: lspBalance, maxClientBalance } = useTransfer(0);
 
 	useFocusEffect(
 		useCallback(() => {
@@ -95,7 +95,9 @@ const ReceiveAmount = ({
 	};
 
 	const continueDisabled =
-		minimumAmount === 0 || invoice.amount < minimumAmount;
+		minimumAmount === 0 ||
+		invoice.amount < minimumAmount ||
+		invoice.amount > maxClientBalance;
 
 	return (
 		<GradientView style={styles.container}>

--- a/src/screens/Wallets/Receive/ReceiveConnect.tsx
+++ b/src/screens/Wallets/Receive/ReceiveConnect.tsx
@@ -148,7 +148,10 @@ const ReceiveConnect = ({
 	useEffect(() => {
 		const getFeeEstimation = async (): Promise<void> => {
 			setIsLoading(true);
-			const feeResult = await estimateOrderFee({ lspBalance });
+			const feeResult = await estimateOrderFee({
+				lspBalance,
+				clientBalance: amount,
+			});
 			if (feeResult.isOk()) {
 				const fees = feeResult.value;
 				setFeeEstimate(fees);
@@ -163,7 +166,7 @@ const ReceiveConnect = ({
 		};
 
 		getFeeEstimation();
-	}, [t, lspBalance]);
+	}, [t, lspBalance, amount]);
 
 	return (
 		<GradientView style={styles.container}>

--- a/src/screens/Wallets/Receive/ReceiveDetails.tsx
+++ b/src/screens/Wallets/Receive/ReceiveDetails.tsx
@@ -70,7 +70,7 @@ const ReceiveDetails = ({
 		};
 
 		getFeeEstimation();
-	}, [lspBalance, t]);
+	}, [lspBalance]);
 
 	useEffect(() => {
 		if (invoice.tags.length > 0) {

--- a/src/store/reselect/wallet.ts
+++ b/src/store/reselect/wallet.ts
@@ -194,10 +194,8 @@ export const transactionFeeSelector = createSelector(
 	[walletState],
 	(wallet) => {
 		const { selectedWallet, selectedNetwork } = wallet;
-		return (
-			wallet.wallets[selectedWallet]?.transaction[selectedNetwork].fee ||
-			defaultSendTransaction.fee
-		);
+		const { transaction } = wallet.wallets[selectedWallet];
+		return transaction[selectedNetwork].fee;
 	},
 );
 

--- a/src/utils/blocktank/index.ts
+++ b/src/utils/blocktank/index.ts
@@ -6,6 +6,7 @@ import {
 	IBtInfo,
 	IBtOrder,
 	ICJitEntry,
+	ICreateOrderOptions,
 } from '@synonymdev/blocktank-lsp-http-client';
 import { err, ok, Result } from '@synonymdev/result';
 import { IBtEstimateFeeResponse2 } from '@synonymdev/blocktank-lsp-http-client/dist/shared/IBtEstimateFeeResponse2';
@@ -121,15 +122,20 @@ export const createOrder = async ({
  */
 export const estimateOrderFee = async ({
 	lspBalance,
-	channelExpiryWeeks = DEFAULT_CHANNEL_DURATION,
+	clientBalance,
 	options,
-}: ICreateOrderRequest): Promise<Result<IBtEstimateFeeResponse2>> => {
+}: {
+	lspBalance: number;
+	clientBalance?: number;
+	options?: Partial<ICreateOrderOptions>;
+}): Promise<Result<IBtEstimateFeeResponse2>> => {
 	try {
 		const response = await bt.estimateOrderFeeFull(
 			lspBalance,
-			channelExpiryWeeks,
+			DEFAULT_CHANNEL_DURATION,
 			{
 				...options,
+				clientBalanceSat: clientBalance,
 				source: options?.source ?? 'bitkit',
 				zeroReserve: true,
 			},

--- a/src/utils/i18n/locales/en/lightning.json
+++ b/src/utils/i18n/locales/en/lightning.json
@@ -119,6 +119,9 @@
 			},
 			"description": {
 				"string": "The amount you can transfer to your spending balance is currently limited to ₿ {amount}."
+			},
+			"description_zero": {
+				"string": "You've reached the maximum for your spending balance."
 			}
 		}
 	},


### PR DESCRIPTION
### Description

- remove 80% onchain cap for channel orders, now uses fee estimation from LSP and adds that to the spendable onchain balance
- add CJIT max amount client validation

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/2393 https://github.com/synonymdev/bitkit/issues/2249

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [x] Detox test
- [ ] Unit test
- [ ] No test

### Screenshot / Video

https://github.com/user-attachments/assets/3acea7d9-11cf-493d-a720-2c07f0d9ef4e

### QA Notes

Because the LSP service fee estimation when calculating the max amount is slightly lower than the actual there will be a dust output leftover which is added to the onchain fee.
