### PR TITLE
fix(restore): activity after CPFP (transfer) boost

### DIFF
--- a/e2e/boost.e2e.js
+++ b/e2e/boost.e2e.js
@@ -129,7 +129,7 @@ d('Boost', () => {
 		await waitFor(element(by.id('CPFPBoost')))
 			.toBeVisible()
 			.withTimeout(30000);
-		await element(by.id('CostomFeeButton')).tap();
+		await element(by.id('CustomFeeButton')).tap();
 		await element(by.id('Plus')).tap();
 		await element(by.id('Minus')).tap();
 		await element(by.id('RecomendedFeeButton')).tap();
@@ -240,7 +240,7 @@ d('Boost', () => {
 		await waitFor(element(by.id('RBFBoost')))
 			.toBeVisible()
 			.withTimeout(30000);
-		await element(by.id('CostomFeeButton')).tap();
+		await element(by.id('CustomFeeButton')).tap();
 		await element(by.id('Plus')).tap();
 		await element(by.id('Minus')).tap();
 		await element(by.id('RecomendedFeeButton')).tap();

--- a/e2e/transfer.e2e.js
+++ b/e2e/transfer.e2e.js
@@ -199,6 +199,7 @@ d('Transfer', () => {
 
 		// check channel status
 		await element(by.id('NavigationClose')).tap();
+		await sleep(1000);
 		await element(by.id('Settings')).tap();
 		await element(by.id('AdvancedSettings')).atIndex(0).tap();
 		await element(by.id('Channels')).tap();
@@ -219,6 +220,27 @@ d('Transfer', () => {
 		await element(by.id('WalletsScrollView')).scrollTo('bottom', NaN, 0.85);
 		await element(by.id('ActivityShort-1')).tap();
 		await expect(element(by.id('StatusTransfer'))).toBeVisible();
+
+		// boost the transfer
+		await element(by.id('BoostButton')).tap();
+		await waitFor(element(by.id('CPFPBoost')))
+			.toBeVisible()
+			.withTimeout(30000);
+		await element(by.id('GRAB')).swipe('right', 'slow', 0.95, 0.5, 0.5); // Swipe to confirm
+
+		// check Activity
+		await waitFor(element(by.id('BoostingIcon')))
+			.toBeVisible()
+			.withTimeout(30000);
+
+		// reset & restore again
+		await restoreWallet(seed);
+
+		// check activity after restore
+		await element(by.id('WalletsScrollView')).scrollTo('bottom', NaN, 0.85);
+		await expect(element(by.id('BoostingIcon'))).toBeVisible();
+		await element(by.id('ActivityShort-1')).tap();
+		await expect(element(by.id('StatusBoosting'))).toBeVisible();
 
 		markComplete('transfer-1');
 	});

--- a/src/screens/Activity/ActivityDetail.tsx
+++ b/src/screens/Activity/ActivityDetail.tsx
@@ -352,7 +352,7 @@ const OnchainActivityDetail = ({
 
 	if (isBoosted) {
 		status = (
-			<View testID="StatusBoosting" style={styles.row}>
+			<View style={styles.row} testID="StatusBoosting">
 				<TimerIconAlt style={styles.rowIcon} color="yellow" height={14} />
 				<BodySSB color="yellow">{t('activity_boosting')}</BodySSB>
 			</View>
@@ -361,7 +361,7 @@ const OnchainActivityDetail = ({
 
 	if (confirmed) {
 		status = (
-			<View testID="StatusConfirmed" style={styles.row}>
+			<View style={styles.row} testID="StatusConfirmed">
 				<CheckCircleIcon style={styles.rowIcon} color="green" />
 				<BodySSB color="green">{t('activity_confirmed')}</BodySSB>
 			</View>
@@ -455,7 +455,7 @@ const OnchainActivityDetail = ({
 								<Section
 									title={t('activity_transfer_to_spending')}
 									value={
-										<View testID="ActivityAmount" style={styles.row}>
+										<View style={styles.row} testID="ActivityAmount">
 											<LightningHollow
 												style={styles.rowIcon}
 												width={16}
@@ -474,7 +474,7 @@ const OnchainActivityDetail = ({
 								<Section
 									title={t('activity_payment')}
 									value={
-										<View testID="ActivityAmount" style={styles.row}>
+										<View style={styles.row} testID="ActivityAmount">
 											<UserIcon
 												style={styles.rowIcon}
 												width={16}
@@ -494,7 +494,7 @@ const OnchainActivityDetail = ({
 							<Section
 								title={t('activity_fee')}
 								value={
-									<View testID="ActivityFee" style={styles.row}>
+									<View style={styles.row} testID="ActivityFee">
 										<TimerIcon style={styles.rowIcon} color="brand" />
 										<Money
 											sats={fees}

--- a/src/screens/Wallets/BoostPrompt.tsx
+++ b/src/screens/Wallets/BoostPrompt.tsx
@@ -221,7 +221,7 @@ const BoostForm = ({
 						title={t('boost')}
 						description={duration}
 						value={Number(boostFee.toFixed(0))}
-						testID="CostomFeeButton"
+						testID="CustomFeeButton"
 						icon={<TimerIconAlt color="yellow" width={26} height={26} />}
 						onPress={onSwitchView}
 					/>

--- a/src/store/slices/activity.ts
+++ b/src/store/slices/activity.ts
@@ -31,9 +31,9 @@ const { actions, reducer } = activitySlice;
 export const {
 	addActivityItem,
 	addActivityItems,
+	updateActivityItems,
 	removeActivityItem,
 	resetActivityState,
-	updateActivityItems,
 } = actions;
 
 export default reducer;

--- a/src/store/utils/activity.ts
+++ b/src/store/utils/activity.ts
@@ -91,7 +91,7 @@ export const updateOnChainActivityList = async (): Promise<Result<string>> => {
 		);
 		return ok('');
 	}
-	const { selectedNetwork, selectedWallet } = getCurrentWallet();
+	const { selectedNetwork } = getCurrentWallet();
 	const boostedTransactions =
 		currentWallet.boostedTransactions[selectedNetwork];
 
@@ -104,8 +104,6 @@ export const updateOnChainActivityList = async (): Promise<Result<string>> => {
 	const boostFormattedItems = await formatBoostedActivityItems({
 		items: activityItems,
 		boostedTransactions,
-		selectedWallet,
-		selectedNetwork,
 	});
 	dispatch(updateActivityItems(boostFormattedItems));
 

--- a/src/store/utils/backup.ts
+++ b/src/store/utils/backup.ts
@@ -26,7 +26,11 @@ import {
 	getWidgetsStore,
 } from '../helpers';
 import { getDefaultSettingsShape } from '../shapes/settings';
-import { addActivityItems, TActivity } from '../slices/activity';
+import {
+	addActivityItems,
+	resetActivityState,
+	TActivity,
+} from '../slices/activity';
 import { backupError, backupStart, backupSuccess } from '../slices/backup';
 import { updateBlocktank } from '../slices/blocktank';
 import { initialMetadataState, updateMetadata } from '../slices/metadata';
@@ -45,6 +49,7 @@ import { TSlashtagsState } from '../types/slashtags';
 import { getDefaultWalletShape } from '../shapes/wallet';
 import { IWalletItem, TTransfer } from '../types/wallet';
 import { restoreBoostedTransactions, restoreTransfers } from '../slices/wallet';
+import { updateOnChainActivityList } from './activity';
 
 export enum EBackupCategory {
 	wallet = 'bitkit_wallet',
@@ -285,9 +290,13 @@ const performWalletRestore = async (): Promise<
 			return ok({ backupExists: false });
 		}
 
+		// because activity has been updated already before this point
+		// we need to reset the activity state to show boosts correctly
+		dispatch(resetActivityState());
 		dispatch(restoreBoostedTransactions(backup.boostedTransactions));
 		dispatch(restoreTransfers(backup.transfers));
 		dispatch(backupSuccess({ category: EBackupCategory.wallet }));
+		updateOnChainActivityList();
 
 		// Restore success
 		return ok({ backupExists: true });

--- a/src/utils/boost.ts
+++ b/src/utils/boost.ts
@@ -51,42 +51,6 @@ export const getBoostedTransactionParents = ({
 };
 
 /**
- * Determines if a given txId has any boosted parents.
- * // TODO: Migrate to Beignet
- * @param {string} txId
- * @param {IBoostedTransactions} [boostedTransactions]
- * @param {TWalletName} [selectedWallet]
- * @param {EAvailableNetwork} [selectedNetwork]
- * @returns {boolean}
- */
-export const hasBoostedParents = ({
-	wallet,
-	txId,
-	boostedTransactions,
-	selectedWallet = getSelectedWallet(),
-	selectedNetwork = getSelectedNetwork(),
-}: {
-	wallet: TWallet;
-	txId: string;
-	boostedTransactions?: IBoostedTransactions;
-	selectedWallet?: TWalletName;
-	selectedNetwork?: EAvailableNetwork;
-}): boolean => {
-	if (!boostedTransactions) {
-		boostedTransactions = getBoostedTransactions({
-			selectedWallet,
-			selectedNetwork,
-		});
-	}
-	const boostedParents = getBoostedTransactionParents({
-		wallet,
-		txId,
-		boostedTransactions,
-	});
-	return boostedParents.length > 0;
-};
-
-/**
  * Returns the initially boosted transaction's activity item for a given txId.
  * @param {string} txId
  * @param {IActivityItem[]} [items]
@@ -99,21 +63,15 @@ const getRootParentActivity = async ({
 	txId,
 	items,
 	boostedTransactions,
-	selectedWallet = getSelectedWallet(),
-	selectedNetwork = getSelectedNetwork(),
 }: {
 	txId: string;
 	items: TOnchainActivityItem[];
 	boostedTransactions?: IBoostedTransactions;
-	selectedWallet?: TWalletName;
-	selectedNetwork?: EAvailableNetwork;
 }): Promise<TOnchainActivityItem | undefined> => {
 	const wallet = await getOnChainWalletAsync();
+
 	if (!boostedTransactions) {
-		boostedTransactions = getBoostedTransactions({
-			selectedWallet,
-			selectedNetwork,
-		});
+		boostedTransactions = getBoostedTransactions();
 	}
 	const boostedParents = getBoostedTransactionParents({
 		wallet,
@@ -158,13 +116,9 @@ export const getParentsActivity = ({
 export const formatBoostedActivityItems = async ({
 	items,
 	boostedTransactions,
-	selectedWallet,
-	selectedNetwork,
 }: {
 	items: TOnchainActivityItem[];
 	boostedTransactions: IBoostedTransactions;
-	selectedWallet: TWalletName;
-	selectedNetwork: EAvailableNetwork;
 }): Promise<TOnchainActivityItem[]> => {
 	const wallet = await getOnChainWalletAsync();
 	const formattedItems: TOnchainActivityItem[] = [];
@@ -193,8 +147,6 @@ export const formatBoostedActivityItems = async ({
 			txId,
 			items,
 			boostedTransactions,
-			selectedWallet,
-			selectedNetwork,
 		});
 
 		// If no root parent (RBF), just add the item marked as boosted


### PR DESCRIPTION
### Description

Fix boosted transfer to spending (CPFP) to correctly show in activity after restore. The child transaction was showing as a separate activity item. Added e2e test.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/1844

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [x] Detox test
- [ ] Unit test
- [ ] No test
