### PR TITLE
fix(transfer): activity for transfer to savings boosts

### DIFF
--- a/src/screens/Activity/ListItem.tsx
+++ b/src/screens/Activity/ListItem.tsx
@@ -117,7 +117,7 @@ const OnchainListItem = ({
 	if (transfer) {
 		title = t('activity_transfer');
 		icon = (
-			<ThemedView style={styles.icon} color="brand16">
+			<ThemedView style={styles.icon} color="brand16" testID="TransferIcon">
 				<TransferIcon color="brand" />
 			</ThemedView>
 		);

--- a/src/screens/Wallets/index.tsx
+++ b/src/screens/Wallets/index.tsx
@@ -5,6 +5,7 @@ import { RefreshControl, ScrollView } from 'react-native-gesture-handler';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
 
+import { View as ThemedView } from '../../styles/components';
 import { useBalance } from '../../hooks/wallet';
 import useColors from '../../hooks/colors';
 import { useAppDispatch, useAppSelector } from '../../hooks/redux';
@@ -107,7 +108,7 @@ const Wallets = ({ navigation, onFocus }: Props): ReactElement => {
 		Object.keys(widgets).length > 0;
 
 	return (
-		<>
+		<ThemedView style={styles.root}>
 			<SafeAreaInset type="top" />
 			<View style={[styles.header, { top: insets.top }]}>
 				<Header />
@@ -154,11 +155,14 @@ const Wallets = ({ navigation, onFocus }: Props): ReactElement => {
 					)}
 				</ScrollView>
 			</DetectSwipe>
-		</>
+		</ThemedView>
 	);
 };
 
 const styles = StyleSheet.create({
+	root: {
+		flex: 1,
+	},
 	header: {
 		position: 'absolute',
 		left: 0,

--- a/src/store/utils/activity.ts
+++ b/src/store/utils/activity.ts
@@ -97,7 +97,7 @@ export const updateOnChainActivityList = async (): Promise<Result<string>> => {
 
 	const transactions = currentWallet.transactions[selectedNetwork];
 	const promises = Object.values(transactions).map(async (tx) => {
-		return await onChainTransactionToActivityItem({ transaction: tx });
+		return onChainTransactionToActivityItem({ transaction: tx });
 	});
 	const activityItems = await Promise.all(promises);
 

--- a/src/utils/activity/index.ts
+++ b/src/utils/activity/index.ts
@@ -21,13 +21,11 @@ export const onChainTransactionToActivityItem = async ({
 }: {
 	transaction: IFormattedTransaction;
 }): Promise<TOnchainActivityItem> => {
+	const { type, value, fee } = transaction;
 	const transfer = await getTransferForTx(transaction);
 
 	// subtract fee from amount if applicable
-	const amount =
-		transaction.type === 'sent'
-			? transaction.value + transaction.fee
-			: transaction.value;
+	const amount = type === 'sent' ? value + fee : value;
 
 	return {
 		id: transaction.txid,

--- a/src/utils/boost.ts
+++ b/src/utils/boost.ts
@@ -1,7 +1,7 @@
 import { IBoostedTransactions, Wallet as TWallet } from 'beignet';
 
-import { getActivityStore, getWalletStore } from '../store/helpers';
-import { IActivityItem, TOnchainActivityItem } from '../store/types/activity';
+import { getWalletStore } from '../store/helpers';
+import { TOnchainActivityItem } from '../store/types/activity';
 import { TWalletName } from '../store/types/wallet';
 import { EAvailableNetwork } from './networks';
 import {
@@ -86,26 +86,6 @@ const getRootParentActivity = async ({
 };
 
 /**
- * Returns an array of activity items for the provided array of parent txids.
- * CURRENTLY UNUSED
- * // TODO: Migrate to Beignet
- * @param {string[]} [parents]
- * @param {IActivityItem[]} [items]
- */
-export const getParentsActivity = ({
-	parents = [],
-	items = [],
-}: {
-	parents?: string[];
-	items?: IActivityItem[];
-}): IActivityItem[] => {
-	if (!items) {
-		items = getActivityStore().items;
-	}
-	return items.filter((i) => parents.includes(i.id));
-};
-
-/**
  * Loop through activity items and format them to be displayed as boosted if applicable.
  * @param {TOnchainActivityItem[]} [items]
  * @param {IBoostedTransactions} [boostedTransactions]
@@ -172,6 +152,8 @@ export const formatBoostedActivityItems = async ({
 			fee: rootParent.fee + item.fee,
 			address: rootParent.address,
 			isBoosted: true,
+			isTransfer: rootParent.isTransfer,
+			transferTxId: rootParent.transferTxId,
 		});
 	}
 


### PR DESCRIPTION
### Description

Fixes activity for boosted transfers to savings.

### Linked Issues/Tasks

https://github.com/synonymdev/bitkit/pull/2128#issuecomment-2505676160

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

I tested onchain send/receive, transfers and boosts before and after restore.

* [x]  Receive (pending)
* [x]  Receive (confirmed)
* [x]  Receive (pending + boosted)
* [x]  Receive (confirmed + boosted)
* [x]  Send (pending)
* [x]  Send (confirmed)
* [x]  Send (pending + boosted)
* [x]  Send (confirmed + boosted)
* [x]  Transfer from Savings (pending)
* [x]  Transfer from Savings (confirmed)
* [x]  Transfer from Savings (pending + boosted)
* [x]  Transfer from Savings (confirmed + boosted)
* [x]  Transfer from Spending (pending)
* [x]  Transfer from Spending (pending + boosted)
* [x]  Transfer from Spending (confirmed)
* [x]  Transfer from Spending (confirmed + boosted)
