### PR TITLE
fix(transfer): #2451 check for minimum onchain balance

### DIFF
--- a/src/utils/i18n/locales/en/lightning.json
+++ b/src/utils/i18n/locales/en/lightning.json
@@ -113,6 +113,14 @@
 		"quarter": {
 			"string": "25%"
 		},
+		"error_min": {
+			"title": {
+				"string": "Savings Balance Minimum"
+			},
+			"description": {
+				"string": "A minimum of ₿ {amount} is needed to set up your spending balance."
+			}
+		},
 		"error_max": {
 			"title": {
 				"string": "Spending Balance Maximum"


### PR DESCRIPTION
### Description

Adds a check for minimum onchain balance in the transfer to spending flow. The minimum is the transaction fee + service fee rounded to the nearest thousand for better UX.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/2451

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

https://github.com/user-attachments/assets/833b0615-0eca-4543-b4c1-875f1a6cad2c
