### PR TITLE
fix(wallet): #1733 avoid duplicate notification for received onchain tx

### DIFF
--- a/src/screens/Settings/AddressTypePreference/index.tsx
+++ b/src/screens/Settings/AddressTypePreference/index.tsx
@@ -51,7 +51,7 @@ const AddressTypeSettings = ({
 					onPress: async (): Promise<void> => {
 						navigation.goBack();
 						await updateSelectedAddressType({ addressType: addressType.type });
-						await refreshWallet({ lightning: false, onchain: true });
+						await refreshWallet({ lightning: false });
 					},
 					testID: addressType.type,
 				})),

--- a/src/screens/Settings/DevSettings/index.tsx
+++ b/src/screens/Settings/DevSettings/index.tsx
@@ -279,7 +279,7 @@ const DevSettings = ({
 					const fakeTx = getFakeTransaction(id);
 					fakeTx[id].height = 0;
 					injectFakeTransaction(fakeTx);
-					refreshWallet({ selectedWallet, selectedNetwork }).then();
+					refreshWallet().then();
 				},
 			},
 			{

--- a/src/screens/Settings/ElectrumConfig/index.tsx
+++ b/src/screens/Settings/ElectrumConfig/index.tsx
@@ -308,9 +308,9 @@ const ElectrumConfig = ({
 					autoComplete="off"
 					keyboardType="default"
 					autoCorrect={false}
-					onChangeText={setHost}
 					returnKeyType="done"
 					testID="HostInput"
+					onChangeText={setHost}
 				/>
 
 				<Caption13Up style={styles.label} color="secondary">
@@ -326,8 +326,9 @@ const ElectrumConfig = ({
 					autoComplete="off"
 					keyboardType="number-pad"
 					autoCorrect={false}
-					onChangeText={setPort}
+					returnKeyType="done"
 					testID="PortInput"
+					onChangeText={setPort}
 				/>
 
 				<View

--- a/src/screens/Settings/GapLimit/index.tsx
+++ b/src/screens/Settings/GapLimit/index.tsx
@@ -76,11 +76,7 @@ const GapLimit = (): ReactElement => {
 		});
 		if (res.isOk()) {
 			dispatch(updateWallet({ gapLimitOptions: res.value }));
-			await refreshWallet({
-				lightning: false,
-				onchain: true,
-				scanAllAddresses: true,
-			});
+			await refreshWallet({ lightning: false, scanAllAddresses: true });
 			showToast({
 				type: 'success',
 				title: t('gap.gap_limit_update_title'),

--- a/src/screens/Wallets/BoostPrompt.tsx
+++ b/src/screens/Wallets/BoostPrompt.tsx
@@ -20,11 +20,7 @@ import { useAppDispatch, useAppSelector } from '../../hooks/redux';
 import { rootNavigation } from '../../navigation/root/RootNavigator';
 import { resetSendTransaction } from '../../store/actions/wallet';
 import { viewControllerSelector } from '../../store/reselect/ui';
-import {
-	selectedNetworkSelector,
-	selectedWalletSelector,
-	transactionSelector,
-} from '../../store/reselect/wallet';
+import { transactionSelector } from '../../store/reselect/wallet';
 import { closeSheet } from '../../store/slices/ui';
 import { TOnchainActivityItem } from '../../store/types/activity';
 import { EUnit } from '../../store/types/wallet';
@@ -48,8 +44,6 @@ const BoostForm = ({
 	const { t } = useTranslation('wallet');
 	const dispatch = useAppDispatch();
 	const transaction = useAppSelector(transactionSelector);
-	const selectedNetwork = useAppSelector(selectedNetworkSelector);
-	const selectedWallet = useAppSelector(selectedWalletSelector);
 
 	const [preparing, setPreparing] = useState(true);
 	const [loading, setLoading] = useState(false);
@@ -69,8 +63,6 @@ const BoostForm = ({
 	useEffect(() => {
 		(async (): Promise<void> => {
 			const res = await setupBoost({
-				selectedWallet,
-				selectedNetwork,
 				txid: activityItem.txId,
 			});
 			setPreparing(false);
@@ -84,7 +76,7 @@ const BoostForm = ({
 		return (): void => {
 			resetSendTransaction();
 		};
-	}, [activityItem.txId, selectedNetwork, selectedWallet, dispatch]);
+	}, [activityItem.txId, dispatch]);
 
 	const onSwitchView = (): void => {
 		if (showCustom) {

--- a/src/store/mmkv-storage.ts
+++ b/src/store/mmkv-storage.ts
@@ -19,6 +19,36 @@ export const reduxStorage: Storage = {
 	},
 };
 
+// Used to prevent duplicate notifications for the same txId that seems to occur when:
+// - when Bitkit is brought from background to foreground
+// - connection to electrum server is lost and then re-established
+export const receivedTxIds = {
+	STORAGE_KEY: 'receivedTxIds',
+
+	// Get stored txIds
+	get: (): string[] => {
+		return JSON.parse(storage.getString(receivedTxIds.STORAGE_KEY) || '[]');
+	},
+
+	// Save txIds to storage
+	save: (txIds: string[]): void => {
+		storage.set(receivedTxIds.STORAGE_KEY, JSON.stringify(txIds));
+	},
+
+	// Add a new txId
+	add: (txId: string): void => {
+		const txIds = receivedTxIds.get();
+		txIds.push(txId);
+		receivedTxIds.save(txIds);
+	},
+
+	// Check if txId exists
+	has: (txId: string): boolean => {
+		const txIds = receivedTxIds.get();
+		return txIds.includes(txId);
+	},
+};
+
 export class WebRelayCache {
 	location: string;
 

--- a/src/store/utils/blocktank.ts
+++ b/src/store/utils/blocktank.ts
@@ -244,14 +244,10 @@ export const startChannelPurchase = async ({
 /**
  * Creates, broadcasts and confirms a given Blocktank channel purchase by orderId.
  * @param {string} orderId
- * @param {EAvailableNetwork} [selectedNetwork]
- * @param {TWalletName} [selectedWallet]
  * @returns {Promise<Result<string>>}
  */
 export const confirmChannelPurchase = async ({
 	order,
-	selectedWallet = getSelectedWallet(),
-	selectedNetwork = getSelectedNetwork(),
 }: {
 	order: IBtOrder;
 	selectedNetwork?: EAvailableNetwork;
@@ -293,12 +289,8 @@ export const confirmChannelPurchase = async ({
 
 	watchOrder(order.id).then();
 	dispatch(setLightningSetupStep(0));
-	refreshWallet({
-		onchain: true,
-		lightning: false, // No need to refresh lightning wallet at this time.
-		selectedWallet,
-		selectedNetwork,
-	}).then();
+	// No need to refresh lightning wallet at this time.
+	refreshWallet({ lightning: false }).then();
 
 	if (!__E2E__) {
 		await scheduleNotifications();

--- a/src/store/utils/ui.ts
+++ b/src/store/utils/ui.ts
@@ -48,18 +48,7 @@ export const showNewOnchainTxPrompt = ({
 			value,
 		},
 	});
-
 	dispatch(closeSheet('receiveNavigation'));
-};
-
-export const showNewTxPrompt = (txId: string): void => {
-	const activityItem = getActivityStore().items.find(({ id }) => id === txId);
-
-	if (activityItem) {
-		vibrate({ type: 'default' });
-		showBottomSheet('newTxPrompt', { activityItem });
-		dispatch(closeSheet('receiveNavigation'));
-	}
 };
 
 export const checkForAppUpdate = async (): Promise<void> => {

--- a/src/utils/startup/index.ts
+++ b/src/utils/startup/index.ts
@@ -165,7 +165,6 @@ export const startWalletServices = async ({
 				onchain: restore,
 				lightning,
 				scanAllAddresses: restore,
-				showNotification: !restore,
 			});
 			await runChecks({ selectedWallet, selectedNetwork });
 		}

--- a/src/utils/wallet/checks.ts
+++ b/src/utils/wallet/checks.ts
@@ -145,13 +145,7 @@ export const runStorageCheck = async ({
 	);
 
 	await clearUtxos();
-
-	await refreshWallet({
-		onchain: true,
-		lightning: true,
-		scanAllAddresses: true,
-		showNotification: false,
-	});
+	await refreshWallet({ scanAllAddresses: true });
 
 	return ok('Replaced Impacted Addresses');
 };

--- a/src/utils/wallet/electrum.ts
+++ b/src/utils/wallet/electrum.ts
@@ -211,11 +211,9 @@ export const getAddressHistory = async ({
  */
 export const connectToElectrum = async ({
 	customPeers,
-	showNotification = true,
 	selectedNetwork = getSelectedNetwork(),
 }: {
 	customPeers?: TServer[];
-	showNotification?: boolean;
 	selectedNetwork?: EAvailableNetwork;
 } = {}): Promise<Result<string>> => {
 	const electrum = await getOnChainWalletElectrumAsync();
@@ -240,7 +238,7 @@ export const connectToElectrum = async ({
 	}
 
 	// Check for any new transactions that we might have missed while disconnected.
-	refreshWallet({ showNotification }).then();
+	refreshWallet().then();
 
 	return ok(connectRes.value);
 };

--- a/src/utils/wallet/transactions.ts
+++ b/src/utils/wallet/transactions.ts
@@ -745,26 +745,15 @@ const runCoinSelect = async ({
 
 /**
  *
- * @param {TWalletName} [selectedWallet]
- * @param {EAvailableNetwork} [selectedNetwork]
  * @param {string} txid
  */
 export const setupBoost = async ({
 	txid,
-	selectedWallet = getSelectedWallet(),
-	selectedNetwork = getSelectedNetwork(),
 }: {
 	txid: string;
-	selectedWallet?: TWalletName;
-	selectedNetwork?: EAvailableNetwork;
 }): Promise<Result<Partial<ISendTransaction>>> => {
 	// Ensure all utxos are up-to-date if attempting to boost immediately after a transaction.
-	const refreshResponse = await refreshWallet({
-		onchain: true,
-		lightning: false,
-		selectedWallet,
-		selectedNetwork,
-	});
+	const refreshResponse = await refreshWallet({ lightning: false });
 	if (refreshResponse.isErr()) {
 		return err(refreshResponse.error.message);
 	}


### PR DESCRIPTION
### Description

Persist `receivedTxIds` to mmkv to avoid showing duplicate notifications when electrum connection is re-established. I could've added this to redux but opted to just write straight to storage to avoid redux ceremony until we have a use case. Also removed unused logic in `refreshWallet` around notifications that doesn't seem to be used anymore and cleaned up default params.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/1733

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
