### PR TITLE
fix(backup): adjust restore logic for network conditions

### DIFF
--- a/src/store/utils/backup.ts
+++ b/src/store/utils/backup.ts
@@ -5,6 +5,7 @@ import { IBoostedTransactions } from 'beignet';
 import {
 	__BACKUPS_SERVER_HOST__,
 	__BACKUPS_SERVER_PUBKEY__,
+	__DEFAULT_BITCOIN_NETWORK__,
 } from '../../constants/env';
 import { deepCompareStructure, isObjPartialMatch } from '../../utils/helpers';
 import {
@@ -128,14 +129,21 @@ export const performFullRestoreFromLatestBackup = async (): Promise<
 			serverPubKey: __BACKUPS_SERVER_PUBKEY__,
 		};
 
-		// LDK restore should be performed for all networks
 		for (const network of Object.values(EAvailableNetwork)) {
-			const ldkBackupRes = await performLdkRestore({
-				backupServerDetails,
-				selectedNetwork: network,
-			});
-			if (ldkBackupRes.isErr()) {
-				return err(ldkBackupRes.error.message);
+			// Always run for mainnet, but only run for test networks if in dev mode
+			// or if it matches the default network
+			if (
+				network === EAvailableNetwork.bitcoin ||
+				network === __DEFAULT_BITCOIN_NETWORK__ ||
+				__DEV__
+			) {
+				const ldkBackupRes = await performLdkRestore({
+					backupServerDetails,
+					selectedNetwork: network,
+				});
+				if (ldkBackupRes.isErr()) {
+					return err(ldkBackupRes.error.message);
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description

I'm adjusting restore logic to only restore for mainnet. This significantly speeds up restore for normal users. For devs there is extra logic to be able to test other network restores.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
