### PR TITLE
fix: remove home swipes

### DIFF
--- a/src/components/SliderDots.tsx
+++ b/src/components/SliderDots.tsx
@@ -5,7 +5,7 @@ import Animated, {
 	interpolate,
 	useAnimatedStyle,
 } from 'react-native-reanimated';
-import { View } from '../styles/components';
+import { Pressable } from '../styles/components';
 
 const DOT_SIZE = 7;
 
@@ -13,10 +13,12 @@ const Dot = ({
 	animValue,
 	index,
 	length,
+	onPress,
 }: {
 	index: number;
 	length: number;
 	animValue: SharedValue<number>;
+	onPress: () => void;
 }): ReactElement => {
 	const width = DOT_SIZE;
 
@@ -39,9 +41,9 @@ const Dot = ({
 	}, [animValue, index, length]);
 
 	return (
-		<View style={styles.dotRoot} color="gray2">
+		<Pressable style={styles.dotRoot} color="gray2" onPress={onPress}>
 			<Animated.View style={[styles.dot, animStyle]} />
-		</View>
+		</Pressable>
 	);
 };
 

--- a/src/navigation/root/RootNavigator.tsx
+++ b/src/navigation/root/RootNavigator.tsx
@@ -202,18 +202,10 @@ const RootNavigator = (): ReactElement => {
 					name="ActivityAssignContact"
 					component={ActivityAssignContact}
 				/>
-				<Stack.Screen
-					name="Scanner"
-					component={ScannerScreen}
-					options={{ animation: 'slide_from_right' }}
-				/>
+				<Stack.Screen name="Scanner" component={ScannerScreen} />
 				<Stack.Screen name="TransferRoot" component={TransferNavigator} />
 				<Stack.Screen name="Settings" component={SettingsNavigator} />
-				<Stack.Screen
-					name="Profile"
-					component={Profile}
-					options={{ animation: 'slide_from_left' }}
-				/>
+				<Stack.Screen name="Profile" component={Profile} />
 				<Stack.Screen name="ProfileEdit" component={ProfileEdit} />
 				<Stack.Screen name="Contacts" component={Contacts} />
 				<Stack.Screen name="ContactEdit" component={ContactEdit} />

--- a/src/screens/Onboarding/Slideshow.tsx
+++ b/src/screens/Onboarding/Slideshow.tsx
@@ -171,11 +171,15 @@ const Slideshow = ({
 		return { opacity };
 	}, [slides.length, progressValue]);
 
+	const scrollToSlide = (index: number): void => {
+		ref.current?.scrollTo({ index, animated: true });
+	};
+
 	const onHeaderButton = (): void => {
 		if (isLastSlide) {
 			navigation.navigate('Passphrase');
 		} else {
-			ref.current?.scrollTo({ index: slides.length - 1, animated: true });
+			scrollToSlide(slides.length - 1);
 		}
 	};
 
@@ -241,13 +245,16 @@ const Slideshow = ({
 				</Animated.View>
 			</View>
 
-			<Animated.View style={[styles.dots, startOpacity]} pointerEvents="none">
+			<Animated.View
+				style={[styles.dots, startOpacity]}
+				pointerEvents={isLastSlide ? 'none' : 'auto'}>
 				{slides.map((_, i) => (
 					<Dot
 						key={i}
 						index={i}
 						animValue={progressValue}
 						length={slides.length}
+						onPress={(): void => scrollToSlide(i)}
 					/>
 				))}
 			</Animated.View>

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -13,9 +13,7 @@ import { StyleSheet, View, useWindowDimensions } from 'react-native';
 import QRCode from 'react-native-qrcode-svg';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
 import Share from 'react-native-share';
-import { useAppSelector } from '../../hooks/redux';
 
-import DetectSwipe from '../../components/DetectSwipe';
 import Divider from '../../components/Divider';
 import NavigationHeader from '../../components/NavigationHeader';
 import ProfileCard from '../../components/ProfileCard';
@@ -24,6 +22,7 @@ import ProfileLinks from '../../components/ProfileLinks';
 import SafeAreaInset from '../../components/SafeAreaInset';
 import Tooltip from '../../components/Tooltip';
 import IconButton from '../../components/buttons/IconButton';
+import { useAppSelector } from '../../hooks/redux';
 import { useProfile, useSlashtags } from '../../hooks/slashtags';
 import type { RootStackScreenProps } from '../../navigation/types';
 import { onboardingProfileStepSelector } from '../../store/reselect/slashtags';
@@ -45,11 +44,11 @@ const Profile = memo((props: RootStackScreenProps<'Profile'>): ReactElement => {
 
 	switch (onboardingProfileStep) {
 		case 'Intro':
-			return <ProfileIntro {...props} />;
+			return <ProfileIntro />;
 		case 'InitialEdit':
 			return <ProfileEdit {...props} />;
 		case 'OfflinePayments':
-			return <OfflinePayments {...props} />;
+			return <OfflinePayments />;
 		default:
 			return <ProfileScreen {...props} />;
 	}
@@ -65,10 +64,6 @@ const ProfileScreen = ({
 
 	const [showCopy, setShowCopy] = useState(false);
 	const [isSharing, setIsSharing] = useState(false);
-
-	const onSwipeLeft = (): void => {
-		navigation.popToTop();
-	};
 
 	const handleCopy = useCallback((): void => {
 		setShowCopy(() => true);
@@ -112,56 +107,54 @@ const ProfileScreen = ({
 				onActionPress={(): void => navigation.navigate('Contacts')}
 			/>
 
-			<DetectSwipe onSwipeLeft={onSwipeLeft}>
-				<ScrollView contentContainerStyle={styles.content}>
-					<ProfileCard url={url} profile={profile} resolving={false} />
-					<Divider />
-					<View style={styles.actions}>
-						<IconButton
-							testID="CopyButton"
-							style={styles.iconButton}
-							onPress={handleCopy}>
-							<CopyIcon height={24} width={24} color="brand" />
-						</IconButton>
-						<IconButton
-							style={styles.iconButton}
-							disabled={isSharing}
-							onPress={handleShare}>
-							<ShareIcon height={24} width={24} color="brand" />
-						</IconButton>
-						<IconButton
-							testID="EditButton"
-							style={styles.iconButton}
-							onPress={(): void => {
-								navigation.navigate('ProfileEdit');
-							}}>
-							<PencilIcon height={20} width={20} color="brand" />
-						</IconButton>
-					</View>
-					<View style={styles.qrContainer}>
-						<QRView
-							url={url}
-							profile={profile}
-							qrRef={qrRef}
-							onPress={handleCopy}
-						/>
-						{showCopy && (
-							<AnimatedView
-								style={styles.tooltip}
-								color="transparent"
-								entering={FadeIn.duration(500)}
-								exiting={FadeOut.duration(500)}>
-								<Tooltip
-									testID="ContactCopiedTooltip"
-									text={t('contact_copied')}
-								/>
-							</AnimatedView>
-						)}
-					</View>
-					<ProfileLinksView profile={profile} />
-					<SafeAreaInset type="bottom" minPadding={16} />
-				</ScrollView>
-			</DetectSwipe>
+			<ScrollView contentContainerStyle={styles.content}>
+				<ProfileCard url={url} profile={profile} resolving={false} />
+				<Divider />
+				<View style={styles.actions}>
+					<IconButton
+						testID="CopyButton"
+						style={styles.iconButton}
+						onPress={handleCopy}>
+						<CopyIcon height={24} width={24} color="brand" />
+					</IconButton>
+					<IconButton
+						style={styles.iconButton}
+						disabled={isSharing}
+						onPress={handleShare}>
+						<ShareIcon height={24} width={24} color="brand" />
+					</IconButton>
+					<IconButton
+						testID="EditButton"
+						style={styles.iconButton}
+						onPress={(): void => {
+							navigation.navigate('ProfileEdit');
+						}}>
+						<PencilIcon height={20} width={20} color="brand" />
+					</IconButton>
+				</View>
+				<View style={styles.qrContainer}>
+					<QRView
+						url={url}
+						profile={profile}
+						qrRef={qrRef}
+						onPress={handleCopy}
+					/>
+					{showCopy && (
+						<AnimatedView
+							style={styles.tooltip}
+							color="transparent"
+							entering={FadeIn.duration(500)}
+							exiting={FadeOut.duration(500)}>
+							<Tooltip
+								testID="ContactCopiedTooltip"
+								text={t('contact_copied')}
+							/>
+						</AnimatedView>
+					)}
+				</View>
+				<ProfileLinksView profile={profile} />
+				<SafeAreaInset type="bottom" minPadding={16} />
+			</ScrollView>
 		</ThemedView>
 	);
 };

--- a/src/screens/Profile/ProfileOnboarding.tsx
+++ b/src/screens/Profile/ProfileOnboarding.tsx
@@ -1,4 +1,3 @@
-import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import React, {
 	memo,
 	ReactElement,
@@ -8,17 +7,12 @@ import React, {
 } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Image, ImageSourcePropType, StyleSheet, View } from 'react-native';
-import { useAppDispatch, useAppSelector } from '../../hooks/redux';
 
-import DetectSwipe from '../../components/DetectSwipe';
 import NavigationHeader from '../../components/NavigationHeader';
 import SafeAreaInset from '../../components/SafeAreaInset';
 import SwitchRow from '../../components/SwitchRow';
 import Button from '../../components/buttons/Button';
-import type {
-	RootStackParamList,
-	RootStackScreenProps,
-} from '../../navigation/types';
+import { useAppDispatch, useAppSelector } from '../../hooks/redux';
 import {
 	selectedNetworkSelector,
 	selectedWalletSelector,
@@ -33,35 +27,30 @@ import { updateSlashPayConfig } from '../../utils/slashtags';
 const crownImageSrc = require('../../assets/illustrations/crown.png');
 const coinsImageSrc = require('../../assets/illustrations/coin-stack.png');
 
-export const ProfileIntro = memo(
-	({ navigation }: RootStackScreenProps<'Profile'>): ReactElement => {
-		const { t } = useTranslation('slashtags');
+export const ProfileIntro = memo((): ReactElement => {
+	const { t } = useTranslation('slashtags');
 
-		return (
-			<Layout
-				navigation={navigation}
-				illustration={crownImageSrc}
-				nextStep="InitialEdit"
-				buttonText={t('continue')}
-				header={t('profile')}>
-				<Display>
-					<Trans
-						t={t}
-						i18nKey="onboarding_profile1_header"
-						components={{ accent: <Display color="brand" /> }}
-					/>
-				</Display>
-				<BodyM color="secondary" style={styles.introText}>
-					{t('onboarding_profile1_text')}
-				</BodyM>
-			</Layout>
-		);
-	},
-);
+	return (
+		<Layout
+			illustration={crownImageSrc}
+			nextStep="InitialEdit"
+			buttonText={t('continue')}
+			header={t('profile')}>
+			<Display>
+				<Trans
+					t={t}
+					i18nKey="onboarding_profile1_header"
+					components={{ accent: <Display color="brand" /> }}
+				/>
+			</Display>
+			<BodyM color="secondary" style={styles.introText}>
+				{t('onboarding_profile1_text')}
+			</BodyM>
+		</Layout>
+	);
+});
 
-export const OfflinePayments = ({
-	navigation,
-}: RootStackScreenProps<'Profile'>): ReactElement => {
+export const OfflinePayments = (): ReactElement => {
 	const { t } = useTranslation('slashtags');
 	const dispatch = useAppDispatch();
 	const selectedWallet = useAppSelector(selectedWalletSelector);
@@ -75,7 +64,6 @@ export const OfflinePayments = ({
 
 	return (
 		<Layout
-			navigation={navigation}
 			illustration={coinsImageSrc}
 			nextStep="Done"
 			buttonText={t('continue')}
@@ -106,7 +94,6 @@ export const OfflinePayments = ({
 
 const Layout = memo(
 	({
-		navigation,
 		illustration,
 		nextStep,
 		buttonText,
@@ -114,7 +101,6 @@ const Layout = memo(
 		children,
 		onNext,
 	}: {
-		navigation: NativeStackNavigationProp<RootStackParamList, 'Profile'>;
 		illustration: ImageSourcePropType;
 		nextStep: TSlashtagsState['onboardingProfileStep'];
 		buttonText: string;
@@ -124,34 +110,28 @@ const Layout = memo(
 	}): ReactElement => {
 		const dispatch = useAppDispatch();
 
-		const onSwipeLeft = (): void => {
-			navigation.popToTop();
-		};
-
 		return (
 			<ThemedView style={styles.root}>
 				<SafeAreaInset type="top" />
 				<NavigationHeader title={header} />
-				<DetectSwipe onSwipeLeft={onSwipeLeft}>
-					<View style={styles.content}>
-						<View style={styles.imageContainer}>
-							<Image style={styles.image} source={illustration} />
-						</View>
-						<View style={styles.middleContainer}>{children}</View>
-						<View style={styles.buttonContainer}>
-							<Button
-								style={styles.button}
-								text={buttonText}
-								size="large"
-								testID="OnboardingContinue"
-								onPress={(): void => {
-									onNext?.();
-									dispatch(setOnboardingProfileStep(nextStep));
-								}}
-							/>
-						</View>
+				<View style={styles.content}>
+					<View style={styles.imageContainer}>
+						<Image style={styles.image} source={illustration} />
 					</View>
-				</DetectSwipe>
+					<View style={styles.middleContainer}>{children}</View>
+					<View style={styles.buttonContainer}>
+						<Button
+							style={styles.button}
+							text={buttonText}
+							size="large"
+							testID="OnboardingContinue"
+							onPress={(): void => {
+								onNext?.();
+								dispatch(setOnboardingProfileStep(nextStep));
+							}}
+						/>
+					</View>
+				</View>
 				<SafeAreaInset type="bottom" minPadding={16} />
 			</ThemedView>
 		);

--- a/src/screens/Scanner/MainScanner.tsx
+++ b/src/screens/Scanner/MainScanner.tsx
@@ -2,7 +2,6 @@ import React, { memo, ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { StyleSheet } from 'react-native';
 
-import DetectSwipe from '../../components/DetectSwipe';
 import NavigationHeader from '../../components/NavigationHeader';
 import SafeAreaInset from '../../components/SafeAreaInset';
 import type { RootStackScreenProps } from '../../navigation/types';
@@ -17,10 +16,6 @@ const ScannerScreen = ({
 }: RootStackScreenProps<'Scanner'>): ReactElement => {
 	const { t } = useTranslation('other');
 	const onScan = route.params?.onScan;
-
-	const onSwipeRight = (): void => {
-		navigation.popToTop();
-	};
 
 	const onRead = (uri: string): void => {
 		if (!uri) {
@@ -45,15 +40,10 @@ const ScannerScreen = ({
 	};
 
 	return (
-		<DetectSwipe onSwipeRight={onSwipeRight}>
-			<ScannerComponent onRead={onRead}>
-				<SafeAreaInset type="top" />
-				<NavigationHeader
-					style={styles.navigationHeader}
-					title={t('qr_scan')}
-				/>
-			</ScannerComponent>
-		</DetectSwipe>
+		<ScannerComponent onRead={onRead}>
+			<SafeAreaInset type="top" />
+			<NavigationHeader style={styles.navigationHeader} title={t('qr_scan')} />
+		</ScannerComponent>
 	);
 };
 

--- a/src/screens/Wallets/Receive/ReceiveQR.tsx
+++ b/src/screens/Wallets/Receive/ReceiveQR.tsx
@@ -676,13 +676,16 @@ const ReceiveQR = ({
 								gesture.activeOffsetX([-10, 10]);
 							}}
 						/>
-						<View style={styles.dots} pointerEvents="none">
+						<View style={styles.dots}>
 							{slides.map((_slide, index) => (
 								<Dot
 									key={index}
 									index={index}
 									animValue={progress}
 									length={slides.length}
+									onPress={(): void => {
+										carouselRef.current?.scrollTo({ index, animated: true });
+									}}
 								/>
 							))}
 						</View>

--- a/src/screens/Wallets/index.tsx
+++ b/src/screens/Wallets/index.tsx
@@ -41,7 +41,7 @@ type Props = WalletScreenProps<'Wallets'> & {
 	onFocus: (isFocused: boolean) => void;
 };
 
-const Wallets = ({ navigation, onFocus }: Props): ReactElement => {
+const Wallets = ({ onFocus }: Props): ReactElement => {
 	const [refreshing, setRefreshing] = useState(false);
 	const colors = useColors();
 	const dispatch = useAppDispatch();
@@ -84,14 +84,6 @@ const Wallets = ({ navigation, onFocus }: Props): ReactElement => {
 		}
 	};
 
-	const navigateToScanner = (): void => {
-		navigation.navigate('Scanner');
-	};
-
-	const navigateToProfile = (): void => {
-		navigation.navigate('Profile');
-	};
-
 	const onRefresh = async (): Promise<void> => {
 		// only scan all addresses once per hour
 		const scanAllAddresses =
@@ -111,48 +103,44 @@ const Wallets = ({ navigation, onFocus }: Props): ReactElement => {
 			<View style={[styles.header, { top: insets.top }]}>
 				<Header />
 			</View>
-			<DetectSwipe
-				onSwipeLeft={navigateToScanner}
-				onSwipeRight={navigateToProfile}>
-				<ScrollView
-					contentContainerStyle={[
-						styles.content,
-						hideOnboarding && styles.scrollView,
-					]}
-					disableScrollViewPanResponder={true}
-					showsVerticalScrollIndicator={false}
-					testID="WalletsScrollView"
-					refreshControl={
-						<RefreshControl
-							refreshing={refreshing}
-							tintColor={colors.refreshControl}
-							progressViewOffset={HEADER_HEIGHT}
-							onRefresh={onRefresh}
-						/>
-					}>
-					<DetectSwipe
-						enabled={enableSwipeToHideBalance}
-						onSwipeLeft={toggleHideBalance}
-						onSwipeRight={toggleHideBalance}>
-						<View>
-							<BalanceHeader />
-						</View>
-					</DetectSwipe>
+			<ScrollView
+				contentContainerStyle={[
+					styles.content,
+					hideOnboarding && styles.scrollView,
+				]}
+				disableScrollViewPanResponder={true}
+				showsVerticalScrollIndicator={false}
+				testID="WalletsScrollView"
+				refreshControl={
+					<RefreshControl
+						refreshing={refreshing}
+						tintColor={colors.refreshControl}
+						progressViewOffset={HEADER_HEIGHT}
+						onRefresh={onRefresh}
+					/>
+				}>
+				<DetectSwipe
+					enabled={enableSwipeToHideBalance}
+					onSwipeLeft={toggleHideBalance}
+					onSwipeRight={toggleHideBalance}>
+					<View>
+						<BalanceHeader />
+					</View>
+				</DetectSwipe>
 
-					{hideOnboarding ? (
-						<>
-							<Balances />
-							<Suggestions />
-							<View style={styles.contentPadding}>
-								{showWidgets && <Widgets />}
-								<ActivityListShort />
-							</View>
-						</>
-					) : (
-						<MainOnboarding style={styles.contentPadding} />
-					)}
-				</ScrollView>
-			</DetectSwipe>
+				{hideOnboarding ? (
+					<>
+						<Balances />
+						<Suggestions />
+						<View style={styles.contentPadding}>
+							{showWidgets && <Widgets />}
+							<ActivityListShort />
+						</View>
+					</>
+				) : (
+					<MainOnboarding style={styles.contentPadding} />
+				)}
+			</ScrollView>
 		</ThemedView>
 	);
 };


### PR DESCRIPTION
### Description

Removes home screen swipe gestures and add `onPress` to slider dots for navigation. The reason is that after a recent upgrade gestures are partially broken on Android emulator. It's ok to remove these gestures though since that is also part of next design iteration (v54) where a drawer menu is added. 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

