### PR TITLE
fix(ui): fix home screen rerender causing navigation lag

### DIFF
--- a/e2e/backup.e2e.js
+++ b/e2e/backup.e2e.js
@@ -91,7 +91,7 @@ d('Backup', () => {
 		await element(by.id('NavigationClose')).atIndex(0).tap();
 
 		// remove 2 default widgets, leave PriceWidget
-		await element(by.id('WalletsScrollView')).scroll(200, 'down', 0);
+		await element(by.id('HomeScrollView')).scroll(200, 'down', 0);
 		await element(by.id('WidgetsEdit')).tap();
 		for (const w of ['NewsWidget', 'BlocksWidget']) {
 			await element(by.id('WidgetActionDelete').withAncestor(by.id(w))).tap();
@@ -121,7 +121,7 @@ d('Backup', () => {
 		await sleep(200); // animation
 
 		// check widgets
-		await element(by.id('WalletsScrollView')).scroll(300, 'down', 0);
+		await element(by.id('HomeScrollView')).scroll(300, 'down', 0);
 		await expect(element(by.id('PriceWidget'))).toExist();
 		await expect(element(by.id('NewsWidget'))).not.toExist();
 		await expect(element(by.id('BlocksWidget'))).not.toExist();

--- a/e2e/boost.e2e.js
+++ b/e2e/boost.e2e.js
@@ -96,7 +96,7 @@ d('Boost', () => {
 		await element(by.id('Close')).tap();
 
 		// check Activity
-		await element(by.id('WalletsScrollView')).scrollTo('bottom', 0);
+		await element(by.id('HomeScrollView')).scrollTo('bottom', 0);
 		await expect(element(by.id('ActivityShort-1'))).toBeVisible();
 		await expect(
 			element(by.text('100 000').withAncestor(by.id('ActivityShort-2'))),
@@ -207,7 +207,7 @@ d('Boost', () => {
 		await element(by.id('Close')).tap();
 
 		// check Activity
-		await element(by.id('WalletsScrollView')).scrollTo('bottom', 0);
+		await element(by.id('HomeScrollView')).scrollTo('bottom', 0);
 		await expect(element(by.id('ActivityShort-1'))).toBeVisible();
 		await expect(
 			element(by.text('100 000').withAncestor(by.id('ActivityShort-2'))),
@@ -273,7 +273,7 @@ d('Boost', () => {
 		await restoreWallet(seed);
 
 		// check activity after restore
-		await element(by.id('WalletsScrollView')).scrollTo('bottom', 0);
+		await element(by.id('HomeScrollView')).scrollTo('bottom', 0);
 		await expect(element(by.id('BoostingIcon'))).toBeVisible();
 		await element(by.id('ActivityShort-1')).tap();
 		await expect(element(by.id('BoostedButton'))).toBeVisible();

--- a/e2e/lightning.e2e.js
+++ b/e2e/lightning.e2e.js
@@ -230,7 +230,7 @@ d('Lightning', () => {
 				.withTimeout(10000);
 
 			// check tx history
-			await element(by.id('WalletsScrollView')).scroll(1000, 'down', 0);
+			await element(by.id('HomeScrollView')).scroll(1000, 'down', 0);
 			await expect(
 				element(by.text('1 000').withAncestor(by.id('ActivityShort-1'))),
 			).toBeVisible();
@@ -322,7 +322,7 @@ d('Lightning', () => {
 				.withTimeout(10000);
 
 			// check tx history
-			await element(by.id('WalletsScrollView')).scroll(1000, 'down', 0);
+			await element(by.id('HomeScrollView')).scroll(1000, 'down', 0);
 			await expect(
 				element(by.text('111').withAncestor(by.id('ActivityShort-2'))),
 			).toBeVisible();

--- a/e2e/lnurl.e2e.js
+++ b/e2e/lnurl.e2e.js
@@ -195,7 +195,7 @@ d('LNURL', () => {
 			.withTimeout(10000);
 		await element(by.id('Close')).tap();
 		// check if comment is displayed
-		await element(by.id('WalletsScrollView')).scrollTo('bottom', 0);
+		await element(by.id('HomeScrollView')).scrollTo('bottom', 0);
 		await element(by.id('ActivityShort-1')).tap();
 		await expect(element(by.id('InvoiceComment'))).toHaveText('test comment');
 		await element(by.id('NavigationClose')).tap();

--- a/e2e/onchain.e2e.js
+++ b/e2e/onchain.e2e.js
@@ -140,7 +140,7 @@ d('Onchain', () => {
 			).toHaveText('0');
 
 			// check Activity
-			await element(by.id('WalletsScrollView')).scroll(1000, 'down', 0);
+			await element(by.id('HomeScrollView')).scroll(1000, 'down', 0);
 			await expect(element(by.id('ActivityShort-1'))).toBeVisible();
 			await expect(element(by.id('ActivityShort-2'))).toBeVisible();
 			await expect(element(by.id('ActivityShort-3'))).toBeVisible();
@@ -306,7 +306,7 @@ d('Onchain', () => {
 			).toHaveText('0');
 
 			// check number of outputs for send tx
-			await element(by.id('WalletsScrollView')).scroll(1000, 'down', 0);
+			await element(by.id('HomeScrollView')).scroll(1000, 'down', 0);
 			await expect(element(by.id('ActivityShort-1'))).toBeVisible();
 			await expect(element(by.id('ActivityShort-2'))).toBeVisible();
 			await element(by.id('ActivityShowAll')).tap();

--- a/e2e/transfer.e2e.js
+++ b/e2e/transfer.e2e.js
@@ -214,7 +214,7 @@ d('Transfer', () => {
 		await expect(element(by.id('Suggestion-lightningSettingUp'))).toBeVisible();
 
 		// check activity after restore
-		await element(by.id('WalletsScrollView')).scrollTo('bottom', 0);
+		await element(by.id('HomeScrollView')).scrollTo('bottom', 0);
 		await element(by.id('ActivityShort-1')).tap();
 		await expect(element(by.id('StatusTransfer'))).toBeVisible();
 
@@ -235,7 +235,7 @@ d('Transfer', () => {
 		await restoreWallet(seed);
 
 		// check activity after restore
-		await element(by.id('WalletsScrollView')).scrollTo('bottom', 0);
+		await element(by.id('HomeScrollView')).scrollTo('bottom', 0);
 		await expect(element(by.id('BoostingIcon'))).toBeVisible();
 		await element(by.id('ActivityShort-1')).tap();
 		await expect(element(by.id('StatusBoosting'))).toBeVisible();
@@ -327,7 +327,7 @@ d('Transfer', () => {
 		await expect(element(by.id('Suggestion-lightningSettingUp'))).toBeVisible();
 
 		// check activity
-		await element(by.id('WalletsScrollView')).scrollTo('bottom', 0);
+		await element(by.id('HomeScrollView')).scrollTo('bottom', 0);
 		await expect(element(by.text('From Savings (±30m)'))).toBeVisible();
 		await element(by.id('ActivityShort-1')).tap();
 		await expect(element(by.text('Transfer (±30m)'))).toBeVisible();

--- a/e2e/widgets.e2e.js
+++ b/e2e/widgets.e2e.js
@@ -35,7 +35,7 @@ d('Widgets', () => {
 		}
 
 		// add price widget
-		await element(by.id('WalletsScrollView')).scroll(300, 'down', 0);
+		await element(by.id('HomeScrollView')).scroll(300, 'down', 0);
 		await element(by.id('WidgetsAdd')).tap();
 		await element(by.id('WidgetsOnboarding-button')).tap();
 		await element(by.id('WidgetListItem-price')).tap();
@@ -50,7 +50,7 @@ d('Widgets', () => {
 		await element(by.id('WidgetEditField-showSource')).tap();
 		await element(by.id('WidgetEditPreview')).tap();
 		await element(by.id('WidgetSave')).tap();
-		await element(by.id('WalletsScrollView')).scroll(200, 'down', 0);
+		await element(by.id('HomeScrollView')).scroll(200, 'down', 0);
 		await expect(element(by.id('PriceWidget'))).toBeVisible();
 		await expect(element(by.id('PriceWidgetRow-BTC/EUR'))).toBeVisible();
 		await expect(element(by.id('PriceWidgetSource'))).toBeVisible();

--- a/src/components/NavigationHeader.tsx
+++ b/src/components/NavigationHeader.tsx
@@ -94,7 +94,7 @@ const NavigationHeader = ({
 
 		if (hasWalletRoute || parent) {
 			// for nested navigators, pop to top of parent navigator
-			navigation.popTo('Wallet', { screen: 'Wallets' });
+			navigation.popTo('Wallet', { screen: 'Home' });
 		} else {
 			navigation.popToTop();
 		}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -7,7 +7,7 @@ import {
 	StyleSheet,
 	ViewStyle,
 } from 'react-native';
-import { FadeIn } from 'react-native-reanimated';
+import Animated, { FadeIn } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { receiveIcon, sendIcon } from '../assets/icons/tabs';
@@ -18,8 +18,8 @@ import type { RootNavigationProp } from '../navigation/types';
 import { resetSendTransaction } from '../store/actions/wallet';
 import { spendingOnboardingSelector } from '../store/reselect/aggregations';
 import { viewControllersSelector } from '../store/reselect/ui';
+import { TViewController } from '../store/types/ui';
 import { toggleBottomSheet } from '../store/utils/ui';
-import { AnimatedView } from '../styles/components';
 import { ScanIcon } from '../styles/icons';
 import ButtonBlur from './buttons/ButtonBlur';
 
@@ -35,8 +35,15 @@ const TabBar = ({
 	const isSpendingOnboarding = useAppSelector(spendingOnboardingSelector);
 
 	const shouldHide = useMemo(() => {
-		const activityFilterSheets = ['timeRangePrompt', 'tagsPrompt'];
-		return activityFilterSheets.some((view) => viewControllers[view].isOpen);
+		const viewControllerKeys: TViewController[] = [
+			'backupPrompt',
+			'PINNavigation',
+			'highBalance',
+			'appUpdatePrompt',
+			'timeRangePrompt',
+			'tagsPrompt',
+		];
+		return viewControllerKeys.some((view) => viewControllers[view].isOpen);
 	}, [viewControllers]);
 
 	const onReceivePress = (): void => {
@@ -73,19 +80,16 @@ const TabBar = ({
 		return Platform.OS === 'android' ? androidStyles : iosStyles;
 	}, [white10]);
 
-	const bottom = useMemo(() => Math.max(insets.bottom, 16), [insets.bottom]);
-	const sendXml = useMemo(() => sendIcon('white'), []);
-	const receiveXml = useMemo(() => receiveIcon('white'), []);
+	const bottom = Math.max(insets.bottom, 16);
+	const sendXml = sendIcon('white');
+	const receiveXml = receiveIcon('white');
 
 	if (shouldHide) {
 		return <></>;
 	}
 
 	return (
-		<AnimatedView
-			style={[styles.tabRoot, { bottom }]}
-			color="transparent"
-			entering={FadeIn}>
+		<Animated.View style={[styles.tabRoot, { bottom }]} entering={FadeIn}>
 			<ButtonBlur
 				style={styles.send}
 				text={t('send')}
@@ -110,7 +114,7 @@ const TabBar = ({
 				testID="Receive"
 				onPress={onReceivePress}
 			/>
-		</AnimatedView>
+		</Animated.View>
 	);
 };
 

--- a/src/navigation/bottom-sheet/AppUpdatePrompt.tsx
+++ b/src/navigation/bottom-sheet/AppUpdatePrompt.tsx
@@ -26,7 +26,7 @@ const imageSrc = require('../../assets/illustrations/wand.png');
 const ASK_INTERVAL = 1000 * 60 * 60 * 12; // 12h - how long this prompt will be hidden if user taps Later
 const CHECK_DELAY = 2500; // how long user needs to stay on Wallets screen before he will see this prompt
 
-const AppUpdatePrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
+const AppUpdatePrompt = (): ReactElement => {
 	const { t } = useTranslation('other');
 	const snapPoints = useSnapPoints('large');
 	const dispatch = useAppDispatch();
@@ -50,14 +50,13 @@ const AppUpdatePrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
 	const shouldShowBottomSheet = useMemo(() => {
 		const isTimeoutOver = Number(new Date()) - ignoreTimestamp > ASK_INTERVAL;
 		return (
-			enabled &&
 			!__E2E__ &&
 			updateInfo !== null &&
 			!updateInfo.critical &&
 			isTimeoutOver &&
 			!anyBottomSheetIsOpen
 		);
-	}, [enabled, updateInfo, ignoreTimestamp, anyBottomSheetIsOpen]);
+	}, [updateInfo, ignoreTimestamp, anyBottomSheetIsOpen]);
 
 	useEffect(() => {
 		if (!shouldShowBottomSheet) {
@@ -104,6 +103,7 @@ const AppUpdatePrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
 				}
 				description={t('update_text')}
 				image={imageSrc}
+				showBackButton={false}
 				continueText={t('update_button')}
 				cancelText={t('cancel')}
 				testID="AppUpdatePrompt"

--- a/src/navigation/bottom-sheet/BackupPrompt.tsx
+++ b/src/navigation/bottom-sheet/BackupPrompt.tsx
@@ -1,30 +1,30 @@
 import React, { memo, ReactElement, useMemo, useEffect } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 
-import BottomSheetScreen from '../../../components/BottomSheetScreen';
-import BottomSheetWrapper from '../../../components/BottomSheetWrapper';
-import { __E2E__ } from '../../../constants/env';
+import BottomSheetScreen from '../../components/BottomSheetScreen';
+import BottomSheetWrapper from '../../components/BottomSheetWrapper';
+import { __E2E__ } from '../../constants/env';
 import {
 	useBottomSheetBackPress,
 	useSnapPoints,
-} from '../../../hooks/bottomSheet';
-import { useAppDispatch, useAppSelector } from '../../../hooks/redux';
-import { useBalance } from '../../../hooks/wallet';
-import { viewControllersSelector } from '../../../store/reselect/ui';
-import { backupVerifiedSelector } from '../../../store/reselect/user';
-import { ignoreBackupTimestampSelector } from '../../../store/reselect/user';
-import { closeSheet } from '../../../store/slices/ui';
-import { ignoreBackup } from '../../../store/slices/user';
-import { showBottomSheet } from '../../../store/utils/ui';
-import { Display } from '../../../styles/text';
-import { objectKeys } from '../../../utils/objectKeys';
+} from '../../hooks/bottomSheet';
+import { useAppDispatch, useAppSelector } from '../../hooks/redux';
+import { useBalance } from '../../hooks/wallet';
+import { viewControllersSelector } from '../../store/reselect/ui';
+import { backupVerifiedSelector } from '../../store/reselect/user';
+import { ignoreBackupTimestampSelector } from '../../store/reselect/user';
+import { closeSheet } from '../../store/slices/ui';
+import { ignoreBackup } from '../../store/slices/user';
+import { showBottomSheet } from '../../store/utils/ui';
+import { Display } from '../../styles/text';
+import { objectKeys } from '../../utils/objectKeys';
 
-const imageSrc = require('../../../assets/illustrations/safe.png');
+const imageSrc = require('../../assets/illustrations/safe.png');
 
 const ASK_INTERVAL = 1000 * 60 * 60 * 24; // 1 day - how long this prompt will be hidden if user taps Later
 const CHECK_DELAY = 2000; // how long user needs to stay on Wallets screen before he will see this prompt
 
-const BackupPrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
+const BackupPrompt = (): ReactElement => {
 	const { t } = useTranslation('security');
 	const snapPoints = useSnapPoints('medium');
 	const dispatch = useAppDispatch();
@@ -60,20 +60,13 @@ const BackupPrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
 	const shouldShowBottomSheet = useMemo(() => {
 		const isTimeoutOver = Number(new Date()) - ignoreTimestamp > ASK_INTERVAL;
 		return (
-			enabled &&
 			!__E2E__ &&
 			!backupVerified &&
 			totalBalance > 0 &&
 			isTimeoutOver &&
 			!anyBottomSheetIsOpen
 		);
-	}, [
-		enabled,
-		backupVerified,
-		totalBalance,
-		ignoreTimestamp,
-		anyBottomSheetIsOpen,
-	]);
+	}, [backupVerified, totalBalance, ignoreTimestamp, anyBottomSheetIsOpen]);
 
 	useEffect(() => {
 		if (!shouldShowBottomSheet) {
@@ -89,10 +82,7 @@ const BackupPrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
 		};
 	}, [shouldShowBottomSheet]);
 
-	const text = useMemo(
-		() => t(totalBalance > 0 ? 'backup_funds' : 'backup_funds_no'),
-		[totalBalance, t],
-	);
+	const text = totalBalance > 0 ? t('backup_funds') : t('backup_funds_no');
 
 	return (
 		<BottomSheetWrapper
@@ -112,6 +102,7 @@ const BackupPrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
 				}
 				description={text}
 				image={imageSrc}
+				showBackButton={false}
 				continueText={t('backup_button')}
 				cancelText={t('later')}
 				testID="BackupPrompt"

--- a/src/navigation/bottom-sheet/ConnectionClosed.tsx
+++ b/src/navigation/bottom-sheet/ConnectionClosed.tsx
@@ -30,7 +30,10 @@ const ConnectionClosed = (): ReactElement => {
 	return (
 		<BottomSheetWrapper view="connectionClosed" snapPoints={snapPoints}>
 			<View style={styles.container}>
-				<BottomSheetNavigationHeader title={t('connection_closed.title')} />
+				<BottomSheetNavigationHeader
+					title={t('connection_closed.title')}
+					showBackButton={false}
+				/>
 				<BodyM color="secondary">{t('connection_closed.description')}</BodyM>
 
 				<View style={styles.imageContainer}>
@@ -54,7 +57,7 @@ const ConnectionClosed = (): ReactElement => {
 const styles = StyleSheet.create({
 	container: {
 		flex: 1,
-		marginHorizontal: 32,
+		marginHorizontal: 16,
 	},
 	imageContainer: {
 		flexShrink: 1,

--- a/src/navigation/bottom-sheet/HighBalanceWarning.tsx
+++ b/src/navigation/bottom-sheet/HighBalanceWarning.tsx
@@ -31,11 +31,7 @@ const BALANCE_THRESHOLD_SATS = 700000; // how high the balance must be to show t
 const ASK_INTERVAL = 1000 * 60 * 60 * 24; // 1 day - how long this prompt will be hidden if user taps Later
 const CHECK_DELAY = 3000; // how long user needs to stay on Wallets screen before he will see this prompt
 
-const HighBalanceWarning = ({
-	enabled,
-}: {
-	enabled: boolean;
-}): ReactElement => {
+const HighBalanceWarning = (): ReactElement => {
 	const { t } = useTranslation('other');
 	const { totalBalance } = useBalance();
 	const snapPoints = useSnapPoints('large');
@@ -74,21 +70,13 @@ const HighBalanceWarning = ({
 		const belowMaxWarnings = count < MAX_WARNINGS;
 		const isTimeoutOver = Number(new Date()) - ignoreTimestamp > ASK_INTERVAL;
 		return (
-			enabled &&
 			!__E2E__ &&
 			thresholdReached &&
 			belowMaxWarnings &&
 			isTimeoutOver &&
 			!anyBottomSheetIsOpen
 		);
-	}, [
-		enabled,
-		fiatValue,
-		totalBalance,
-		count,
-		ignoreTimestamp,
-		anyBottomSheetIsOpen,
-	]);
+	}, [fiatValue, totalBalance, count, ignoreTimestamp, anyBottomSheetIsOpen]);
 
 	useEffect(() => {
 		if (!shouldShowBottomSheet) {
@@ -137,6 +125,7 @@ const HighBalanceWarning = ({
 					/>
 				}
 				image={imageSrc}
+				showBackButton={false}
 				continueText={t('high_balance.continue')}
 				cancelText={t('high_balance.cancel')}
 				testID="HighBalance"

--- a/src/navigation/bottom-sheet/QuickPayPrompt.tsx
+++ b/src/navigation/bottom-sheet/QuickPayPrompt.tsx
@@ -24,7 +24,7 @@ const imageSrc = require('../../assets/illustrations/fast-forward.png');
 
 const CHECK_DELAY = 3000; // how long user needs to stay on Wallets screen before he will see this prompt
 
-const QuickPayPrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
+const QuickPayPrompt = (): ReactElement => {
 	const { t } = useTranslation('settings');
 	const navigation = useNavigation<RootNavigationProp>();
 	const { spendingBalance } = useBalance();
@@ -48,13 +48,12 @@ const QuickPayPrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
 	// and user on "Wallets" screen for CHECK_DELAY
 	const shouldShowBottomSheet = useMemo(() => {
 		return (
-			enabled &&
 			!__E2E__ &&
 			!anyBottomSheetIsOpen &&
 			!quickpayIntroSeen &&
 			spendingBalance > 0
 		);
-	}, [enabled, anyBottomSheetIsOpen, quickpayIntroSeen, spendingBalance]);
+	}, [anyBottomSheetIsOpen, quickpayIntroSeen, spendingBalance]);
 
 	useEffect(() => {
 		if (!shouldShowBottomSheet) {
@@ -105,6 +104,7 @@ const QuickPayPrompt = ({ enabled }: { enabled: boolean }): ReactElement => {
 					/>
 				}
 				image={imageSrc}
+				showBackButton={false}
 				continueText={t('learn_more')}
 				cancelText={t('later')}
 				testID="QuickPayPrompt"

--- a/src/navigation/wallet/WalletNavigator.tsx
+++ b/src/navigation/wallet/WalletNavigator.tsx
@@ -3,22 +3,18 @@ import {
 	NativeStackNavigationProp,
 	createNativeStackNavigator,
 } from '@react-navigation/native-stack';
-import React, { ReactElement, useState } from 'react';
+import React, { ReactElement } from 'react';
 
 import TabBar from '../../components/TabBar';
 import { __E2E__ } from '../../constants/env';
 import ActivityFiltered from '../../screens/Activity/ActivityFiltered';
 import ActivitySavings from '../../screens/Activity/ActivitySavings';
 import ActivitySpending from '../../screens/Activity/ActivitySpending';
-import BackupPrompt from '../../screens/Settings/Backup/BackupPrompt';
-import WalletsScreen from '../../screens/Wallets';
-import AppUpdatePrompt from '../bottom-sheet/AppUpdatePrompt';
-import HighBalanceWarning from '../bottom-sheet/HighBalanceWarning';
-import QuickPayPrompt from '../bottom-sheet/QuickPayPrompt';
+import Home from '../../screens/Wallets/Home';
 import type { RootStackScreenProps } from '../types';
 
 export type WalletStackParamList = {
-	Wallets: { onFocus: (focused: boolean) => void } | undefined;
+	Home: undefined;
 	ActivitySavings: undefined;
 	ActivitySpending: undefined;
 	ActivityFiltered: undefined;
@@ -33,34 +29,22 @@ const screenOptions: NativeStackNavigationOptions = {
 	animation: __E2E__ ? 'none' : 'default',
 };
 
-const WalletsStack = ({
+const WalletStack = ({
 	navigation,
 }: RootStackScreenProps<'Wallet'>): ReactElement => {
-	const [isWalletsScreenFocused, setIsFocused] = useState(false);
-
 	return (
 		<>
 			<Stack.Navigator screenOptions={screenOptions}>
-				<Stack.Screen name="Wallets">
-					{(props): ReactElement => (
-						<WalletsScreen {...props} onFocus={setIsFocused} />
-					)}
-				</Stack.Screen>
+				<Stack.Screen name="Home" component={Home} />
 				<Stack.Screen name="ActivitySavings" component={ActivitySavings} />
 				<Stack.Screen name="ActivitySpending" component={ActivitySpending} />
 				<Stack.Screen name="ActivityFiltered" component={ActivityFiltered} />
 			</Stack.Navigator>
 
+			{/* TabBar should be visible on all of the above screens */}
 			<TabBar navigation={navigation} />
-
-			{/* Put these here so they appear above the TabBar (zIndex) */}
-			{/* Should only ever show when user is on the main wallet screen */}
-			<BackupPrompt enabled={isWalletsScreenFocused} />
-			<HighBalanceWarning enabled={isWalletsScreenFocused} />
-			<AppUpdatePrompt enabled={isWalletsScreenFocused} />
-			<QuickPayPrompt enabled={isWalletsScreenFocused} />
 		</>
 	);
 };
 
-export default WalletsStack;
+export default WalletStack;

--- a/src/screens/Settings/Advanced/index.tsx
+++ b/src/screens/Settings/Advanced/index.tsx
@@ -160,7 +160,7 @@ const AdvancedSettings = ({
 				onConfirm={(): void => {
 					dispatch(resetHiddenTodos());
 					setShowDialog(false);
-					navigation.popTo('Wallet', { screen: 'Wallets' });
+					navigation.popTo('Wallet', { screen: 'Home' });
 				}}
 			/>
 		</>

--- a/src/screens/Transfer/Availability.tsx
+++ b/src/screens/Transfer/Availability.tsx
@@ -17,7 +17,7 @@ const Availability = ({
 	const { t } = useTranslation('lightning');
 
 	const onCancel = (): void => {
-		navigation.popTo('Wallet', { screen: 'Wallets' });
+		navigation.popTo('Wallet', { screen: 'Home' });
 	};
 
 	const onContinue = (): void => {

--- a/src/screens/Transfer/ExternalNode/Success.tsx
+++ b/src/screens/Transfer/ExternalNode/Success.tsx
@@ -14,7 +14,7 @@ const ExternalSuccess = ({
 	const { t } = useTranslation('lightning');
 
 	const onContinue = (): void => {
-		navigation.popTo('Wallet', { screen: 'Wallets' });
+		navigation.popTo('Wallet', { screen: 'Home' });
 	};
 
 	return (

--- a/src/screens/Transfer/Funding.tsx
+++ b/src/screens/Transfer/Funding.tsx
@@ -33,7 +33,7 @@ const Funding = ({
 	};
 
 	const onFund = (): void => {
-		navigation.popTo('Wallet', { screen: 'Wallets' });
+		navigation.popTo('Wallet', { screen: 'Home' });
 		showBottomSheet('receiveNavigation', { receiveScreen: 'ReceiveAmount' });
 	};
 

--- a/src/screens/Transfer/Interrupted.tsx
+++ b/src/screens/Transfer/Interrupted.tsx
@@ -13,7 +13,7 @@ const Interrupted = ({
 	const { t } = useTranslation('lightning');
 
 	const onContinue = (): void => {
-		navigation.popTo('Wallet', { screen: 'Wallets' });
+		navigation.popTo('Wallet', { screen: 'Home' });
 	};
 
 	return (

--- a/src/screens/Transfer/LNURLChannel.tsx
+++ b/src/screens/Transfer/LNURLChannel.tsx
@@ -50,7 +50,7 @@ const LNURLChannel = ({
 	};
 
 	const onClosePress = (): void => {
-		navigation.popTo('Wallet', { screen: 'Wallets' });
+		navigation.popTo('Wallet', { screen: 'Home' });
 	};
 
 	return (

--- a/src/screens/Transfer/SettingUp.tsx
+++ b/src/screens/Transfer/SettingUp.tsx
@@ -35,7 +35,7 @@ const SettingUp = ({
 	}, [lightningSettingUpStep, navigation]);
 
 	const onClose = (): void => {
-		navigation.popTo('Wallet', { screen: 'Wallets' });
+		navigation.popTo('Wallet', { screen: 'Home' });
 	};
 
 	return (

--- a/src/screens/Transfer/Success.tsx
+++ b/src/screens/Transfer/Success.tsx
@@ -16,7 +16,7 @@ const Success = ({
 	const { type } = route.params;
 
 	const onContinue = (): void => {
-		navigation.popTo('Wallet', { screen: 'Wallets' });
+		navigation.popTo('Wallet', { screen: 'Home' });
 	};
 
 	const isTransferToSavings = type === 'savings';

--- a/src/screens/Wallets/Header.tsx
+++ b/src/screens/Wallets/Header.tsx
@@ -1,7 +1,7 @@
 import { useNavigation } from '@react-navigation/native';
 import React, { memo, ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
-import { StyleSheet, View } from 'react-native';
+import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
 
 import ProfileImage from '../../components/ProfileImage';
 import VerticalShadow from '../../components/VerticalShadow';
@@ -12,7 +12,7 @@ import { ProfileIcon, SettingsIcon } from '../../styles/icons';
 import { Title } from '../../styles/text';
 import { truncate } from '../../utils/helpers';
 
-const Header = (): ReactElement => {
+const Header = ({ style }: { style?: StyleProp<ViewStyle> }): ReactElement => {
 	const navigation = useNavigation<RootNavigationProp>();
 	const { t } = useTranslation('slashtags');
 	const { url } = useSlashtags();
@@ -31,7 +31,7 @@ const Header = (): ReactElement => {
 	};
 
 	return (
-		<View style={styles.container}>
+		<View style={[styles.container, style]}>
 			<View style={styles.shadowContainer}>
 				<VerticalShadow />
 			</View>


### PR DESCRIPTION
### Description

Fixes a rerender on the home screen caused by smelly `onFocus` code. This moves the timed/conditional bottom sheets into the home screen and extends the check in the `<TabBar />` so it hides properly. This significantly improves navigation responsiveness especially on Android. Also renames `Wallets/index.ts` to `Home.tsx`.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
