### PR TITLE
fix: hide refresh error toast on app to foreground

### DIFF
--- a/src/utils/appState.ts
+++ b/src/utils/appState.ts
@@ -1,0 +1,26 @@
+import { AppState } from 'react-native';
+
+export const appStateTracker = {
+	lastAppState: AppState.currentState,
+	lastBackgroundTime: 0,
+
+	init() {
+		AppState.addEventListener('change', (nextAppState) => {
+			if (['background', 'inactive'].includes(nextAppState)) {
+				this.lastBackgroundTime = Date.now();
+			} else if (['background', 'inactive'].includes(this.lastAppState)) {
+				// If we're leaving background state, update the time
+				this.lastBackgroundTime = Date.now();
+			}
+			this.lastAppState = nextAppState;
+		});
+	},
+
+	wasRecentlyInBackground(): boolean {
+		const currentState = AppState.currentState;
+		const inBackground = ['background', 'inactive'].includes(currentState);
+		const timeSinceLastBackground = Date.now() - this.lastBackgroundTime;
+
+		return inBackground || timeSinceLastBackground < 3000;
+	},
+};

--- a/src/utils/wallet/index.ts
+++ b/src/utils/wallet/index.ts
@@ -73,6 +73,7 @@ import { updateActivityList } from '../../store/utils/activity';
 import { refreshOrdersList } from '../../store/utils/blocktank';
 import { moveMetaIncTxTags } from '../../store/utils/metadata';
 import { showNewOnchainTxPrompt } from '../../store/utils/ui';
+import { appStateTracker } from '../appState';
 import BitcoinActions from '../bitcoin-actions';
 import { btcToSats } from '../conversion';
 import { promiseTimeout } from '../helpers';
@@ -89,6 +90,9 @@ import { IGenerateAddresses, IGetAddress } from '../types';
 import { BITKIT_WALLET_SEED_HASH_PREFIX } from './constants';
 import { getBlockHeader } from './electrum';
 import { getTransferForTx } from './transfer';
+
+// Initialize app state tracking
+appStateTracker.init();
 
 bitcoin.initEccLib(ecc);
 const bip32 = BIP32Factory(ecc);
@@ -197,7 +201,9 @@ const refreshBeignet = async (scanAllAddresses = false): Promise<void> => {
 		additionalAddresses,
 	});
 	if (refreshWalletRes.isErr()) {
-		handleRefreshError(refreshWalletRes.error.message);
+		if (!appStateTracker.wasRecentlyInBackground()) {
+			handleRefreshError(refreshWalletRes.error.message);
+		}
 	} else {
 		// If refresh was successful, reset the throttled state.
 		if (getStore().ui.isElectrumThrottled) {


### PR DESCRIPTION
### Description

Prevents 'Refresh Failed' toast to appear when app is coming back from background. On Android the electrum connection is not fully ready shortly after app was in background. From my testing if a refresh fails it will retry so we can just hide the error message.

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/2004

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### QA Notes

To reproduce the issue:

1. On Android
2. Create a new wallet
3. Put app in background
4. Wait for 10 seconds
5. Put app in foreground
6. Immediately pull to refresh
