### PR TITLE
fix(ui): downgrade react-native-reanimated to 3.16.7

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1843,7 +1843,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.17.1):
+  - RNReanimated (3.16.7):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1855,9 +1855,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-hermes
     - React-ImageManager
-    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1865,10 +1863,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.17.1)
-    - RNReanimated/worklets (= 3.17.1)
+    - RNReanimated/reanimated (= 3.16.7)
+    - RNReanimated/worklets (= 3.16.7)
     - Yoga
-  - RNReanimated/reanimated (3.17.1):
+  - RNReanimated/reanimated (3.16.7):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1880,9 +1878,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-hermes
     - React-ImageManager
-    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1890,9 +1886,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.17.1)
+    - RNReanimated/reanimated/apple (= 3.16.7)
     - Yoga
-  - RNReanimated/reanimated/apple (3.17.1):
+  - RNReanimated/reanimated/apple (3.16.7):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1904,9 +1900,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-hermes
     - React-ImageManager
-    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1915,7 +1909,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.17.1):
+  - RNReanimated/worklets (3.16.7):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1927,33 +1921,7 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
-    - React-hermes
     - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - RNReanimated/worklets/apple (= 3.17.1)
-    - Yoga
-  - RNReanimated/worklets/apple (3.17.1):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -2455,7 +2423,7 @@ SPEC CHECKSUMS:
   RNQrGenerator: afacf12b55dfba0e3aaca963eec23691e8426431
   RNQuickAction: c2c8f379e614428be0babe4d53a575739667744d
   RNReactNativeHapticFeedback: f9cfb40676f21a52e9e172648d033f539156a5ec
-  RNReanimated: cdbe5dfe73c9143df3f750ff547a758eb16d2ab8
+  RNReanimated: f999fb5f61876de2729bc4863f036dd5841200fc
   RNScreens: 96fe858d87d26c3f46f0696f9e8824ce33a05aa7
   RNShare: b1660f26d8bc57cbf9acf11872a8eb2f3ecf4825
   RNSVG: e1b90420e46f8923da4b5023963afd4964d0d12a

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "react-native-quick-base64": "2.1.2",
     "react-native-quick-bip39": "0.0.9",
     "react-native-quick-crypto": "0.7.12",
-    "react-native-reanimated": "3.17.1",
+    "react-native-reanimated": "3.16.7",
     "react-native-reanimated-carousel": "4.0.2",
     "react-native-restart": "0.0.27",
     "react-native-safe-area-context": "5.2.0",

--- a/src/screens/Wallets/Receive/ReceiveDetails.tsx
+++ b/src/screens/Wallets/Receive/ReceiveDetails.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, memo, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Image, Platform, StyleSheet, View } from 'react-native';
+import { Image, StyleSheet, View } from 'react-native';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
 
 import BottomSheetNavigationHeader from '../../../components/BottomSheetNavigationHeader';
@@ -177,9 +177,7 @@ const ReceiveDetails = ({
 							<Animated.View
 								style={styles.bottom}
 								entering={FadeIn}
-								// FadeOut causing a bug on Android
-								exiting={Platform.OS === 'ios' ? FadeOut : undefined}
-							>
+								exiting={FadeOut}>
 								<Caption13Up style={styles.label} color="secondary">
 									{t('tags')}
 								</Caption13Up>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5894,7 +5894,7 @@ __metadata:
     react-native-quick-base64: 2.1.2
     react-native-quick-bip39: 0.0.9
     react-native-quick-crypto: 0.7.12
-    react-native-reanimated: 3.17.1
+    react-native-reanimated: 3.16.7
     react-native-reanimated-carousel: 4.0.2
     react-native-restart: 0.0.27
     react-native-safe-area-context: 5.2.0
@@ -12629,16 +12629,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-is-edge-to-edge@npm:1.1.6":
-  version: 1.1.6
-  resolution: "react-native-is-edge-to-edge@npm:1.1.6"
-  peerDependencies:
-    react: ">=18.2.0"
-    react-native: ">=0.73.0"
-  checksum: 4e07c1e34c01c8d50fd7c1d0460db06f6f0515197405230386a8ffb950cb724b10743af032310d1384df0a90059bfb8992ba2d93344ce86315315f0493feccc2
-  languageName: node
-  linkType: hard
-
 "react-native-keyboard-accessory@npm:0.1.16":
   version: 0.1.16
   resolution: "react-native-keyboard-accessory@npm:0.1.16"
@@ -12818,9 +12808,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:3.17.1":
-  version: 3.17.1
-  resolution: "react-native-reanimated@npm:3.17.1"
+"react-native-reanimated@npm:3.16.7":
+  version: 3.16.7
+  resolution: "react-native-reanimated@npm:3.16.7"
   dependencies:
     "@babel/plugin-transform-arrow-functions": ^7.0.0-0
     "@babel/plugin-transform-class-properties": ^7.0.0-0
@@ -12833,12 +12823,11 @@ __metadata:
     "@babel/preset-typescript": ^7.16.7
     convert-source-map: ^2.0.0
     invariant: ^2.2.4
-    react-native-is-edge-to-edge: 1.1.6
   peerDependencies:
     "@babel/core": ^7.0.0-0
     react: "*"
     react-native: "*"
-  checksum: fd05040a3fc6a8f4efb387657c0cd6c314e5e6b50f859e127d6891d8f81c65b020ddcf78615aa0074b4e134e450d38c40db916c544e1e2efa26c50c82815607d
+  checksum: 108095709cd7a3effc5b5d276d94e161b399bd2d06e32140834168a0051545401bb09228071447e5925571da3f86f335d2a82c76751cdae07f66faf50b25c97f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

Downgrade `react-native-reanimated` to fix frozen UI. See [upstream issue](https://github.com/software-mansion/react-native-reanimated/issues/7109).

### Linked Issues/Tasks

Closes https://github.com/synonymdev/bitkit/issues/2525

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
