### PR TITLE
fix: widgets restore

### DIFF
--- a/src/store/reselect/lightning.ts
+++ b/src/store/reselect/lightning.ts
@@ -166,8 +166,9 @@ export const claimableBalanceSelector = createSelector(
 			return (
 				channel.closureReason &&
 				[
-					EChannelClosureReason.HolderForceClosed,
 					EChannelClosureReason.CounterpartyForceClosed,
+					EChannelClosureReason.ProcessingError,
+					EChannelClosureReason.HolderForceClosed,
 				].includes(channel.closureReason)
 			);
 		});

--- a/src/store/utils/backup.ts
+++ b/src/store/utils/backup.ts
@@ -359,12 +359,12 @@ const performWidgetsRestore = async (): Promise<
 		const backup = backupRes.value.data;
 		const expectedBackupShape = initialWidgetsState;
 
+		// Skip restore if backup contains legacy slashfeed widgets
 		// NOTE: can be removed after all users have updated from 1.0.9
-		const hasSlashfeedWidgets = Object.keys(backup.widgets).some((key) => {
-			return key.includes('slashfeed');
-		});
+		const hasSlashfeedWidgets =
+			Object.keys(backup.widgets).some((key) => key.includes('slashfeed')) ||
+			backup.sortOrder.some((key) => key.includes('slashfeed'));
 
-		// If the backup has slashfeed widgets, skip the restore.
 		if (hasSlashfeedWidgets) {
 			return ok({ backupExists: false });
 		}


### PR DESCRIPTION
### Description

- Widgets: skip restore for legacy slashfeed widgets in backup
- Balance: include pending balances from channels force-closed with `ProcessingError`

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test
