### PR TITLE
chore: tiny-secp256k1 dependency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,9 @@
     "rn-electrum-client": "^0.0.22",
     "typescript": "5.7.3"
   },
+  "resolutions": {
+    "tiny-secp256k1": "1.1.7"
+  },
   "react-native": {
     "net": "react-native-tcp-socket",
     "tls": "react-native-tcp-socket"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14539,9 +14539,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-secp256k1@npm:^1.1.3":
-  version: 1.1.6
-  resolution: "tiny-secp256k1@npm:1.1.6"
+"tiny-secp256k1@npm:1.1.7":
+  version: 1.1.7
+  resolution: "tiny-secp256k1@npm:1.1.7"
   dependencies:
     bindings: ^1.3.0
     bn.js: ^4.11.8
@@ -14549,7 +14549,7 @@ __metadata:
     elliptic: ^6.4.0
     nan: ^2.13.2
     node-gyp: latest
-  checksum: f8f705f8a76dc9ccc9aa46f7bc353c00be63940c0a1198175fd77c9b85bdf24eb6db3d72c4756d24af320900290313c580c07695cda645d98410822f94ee01f5
+  checksum: adacb1ec9019dde209ea26fe11a10aec3f96c7212f37d210244e931b689e6787c32d6d93dc7b55ed5053e17ffba4b55444557e922d60891bd76e56a0785a7bd8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description

This PR force-updates `tiny-secp256k1` -- via dependency resolutions -- to the next immediate version supposed to patch the 2 dependabot vulnerability alerts listed below.

### Linked Issues/Tasks
Dependabot alerts:
- https://github.com/synonymdev/bitkit/security/dependabot/97
- https://github.com/synonymdev/bitkit/security/dependabot/96

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [x] Existing suite should pass

### Screenshot / Video

n/a

### QA Notes

If automated tests pass we are ok.