### PR TITLE
feat(lightning): debug function to manual set tx as confirmed

### DIFF
--- a/src/screens/Settings/DevSettings/LdkDebug.tsx
+++ b/src/screens/Settings/DevSettings/LdkDebug.tsx
@@ -1,5 +1,5 @@
 import Clipboard from '@react-native-clipboard/clipboard';
-import lm from '@synonymdev/react-native-ldk';
+import lm, { ldk } from '@synonymdev/react-native-ldk';
 import React, { ReactElement, memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
@@ -46,11 +46,13 @@ const LdkDebug = (): ReactElement => {
 	const dispatch = useAppDispatch();
 	const sheetRef = useSheetRef('forceTransfer');
 	const [peer, setPeer] = useState('');
+	const [txid, setTxid] = useState('');
 	const [payingInvoice, setPayingInvoice] = useState(false);
 	const [refreshingLdk, setRefreshingLdk] = useState(false);
 	const [restartingLdk, setRestartingLdk] = useState(false);
 	const [rebroadcastingLdk, setRebroadcastingLdk] = useState(false);
 	const [spendingStuckOutputs, setSpendingStuckOutputs] = useState(false);
+	const [settingConfirmedTx, setSettingConfirmedTx] = useState(false);
 
 	const { localBalance, remoteBalance } = useLightningBalance();
 	const selectedWallet = useAppSelector(selectedWalletSelector);
@@ -324,6 +326,141 @@ const LdkDebug = (): ReactElement => {
 		setPayingInvoice(false);
 	};
 
+	const onSetConfirmedTx = async (): Promise<void> => {
+		if (!txid) {
+			// Attempt to grab and set txid string from clipboard.
+			const clipboardStr = await Clipboard.getString();
+			setTxid(clipboardStr);
+			return;
+		}
+
+		setSettingConfirmedTx(true);
+		try {
+			// Get network endpoint
+			const baseUrl = 'https://mempool.space/api';
+
+			// Fetch transaction details
+			const txResponse = await fetch(`${baseUrl}/tx/${txid.trim()}`);
+			if (!txResponse.ok) {
+				showToast({
+					type: 'error',
+					title: 'Transaction Not Found',
+					description: 'Unable to find transaction on mempool.space',
+				});
+				setSettingConfirmedTx(false);
+				return;
+			}
+
+			const tx = await txResponse.json();
+
+			// Check if transaction is confirmed
+			if (!tx.status?.confirmed || !tx.status?.block_height) {
+				showToast({
+					type: 'error',
+					title: 'Transaction Not Confirmed',
+					description: 'Transaction is not yet confirmed on the blockchain',
+				});
+				setSettingConfirmedTx(false);
+				return;
+			}
+
+			// Fetch transaction hex data
+			const txHexResponse = await fetch(`${baseUrl}/tx/${txid.trim()}/hex`);
+			if (!txHexResponse.ok) {
+				showToast({
+					type: 'error',
+					title: 'Transaction Hex Error',
+					description: 'Unable to fetch transaction hex data',
+				});
+				setSettingConfirmedTx(false);
+				return;
+			}
+
+			const txHex = await txHexResponse.text();
+
+			// Fetch block header
+			const blockHash = tx.status.block_hash;
+			const blockResponse = await fetch(`${baseUrl}/block/${blockHash}/header`);
+			if (!blockResponse.ok) {
+				showToast({
+					type: 'error',
+					title: 'Block Header Error',
+					description: 'Unable to fetch block header',
+				});
+				setSettingConfirmedTx(false);
+				return;
+			}
+
+			const blockHeader = await blockResponse.text();
+
+			// Validate all required parameters
+			if (!blockHeader) {
+				showToast({
+					type: 'error',
+					title: 'Missing Block Header',
+					description: 'Block header is empty or invalid',
+				});
+				setSettingConfirmedTx(false);
+				return;
+			}
+
+			if (!txHex) {
+				showToast({
+					type: 'error',
+					title: 'Missing Transaction Data',
+					description: 'Transaction hex data is missing',
+				});
+				setSettingConfirmedTx(false);
+				return;
+			}
+
+			if (!tx.status.block_height) {
+				showToast({
+					type: 'error',
+					title: 'Missing Block Height',
+					description: 'Block height is missing or invalid',
+				});
+				setSettingConfirmedTx(false);
+				return;
+			}
+
+			// Call ldk.setTxConfirmed
+			const setTxConfirmedRes = await ldk.setTxConfirmed({
+				header: blockHeader,
+				txData: [
+					{
+						transaction: txHex,
+						pos: tx.status.block_time || 0, // Using block_time as position fallback
+					},
+				],
+				height: tx.status.block_height,
+			});
+
+			if (setTxConfirmedRes.isErr()) {
+				showToast({
+					type: 'error',
+					title: 'Set Confirmed Failed',
+					description: setTxConfirmedRes.error.message,
+				});
+			} else {
+				showToast({
+					type: 'success',
+					title: 'Transaction Confirmed',
+					description: `Transaction ${txid.slice(0, 8)}... set as confirmed at height ${tx.status.block_height}`,
+				});
+			}
+		} catch (error) {
+			showToast({
+				type: 'error',
+				title: 'Error',
+				description:
+					error instanceof Error ? error.message : 'Unknown error occurred',
+			});
+		} finally {
+			setSettingConfirmedTx(false);
+		}
+	};
+
 	return (
 		<ThemedView style={styles.root}>
 			<SafeAreaInset type="top" />
@@ -354,6 +491,31 @@ const LdkDebug = (): ReactElement => {
 						}
 						testID="AddPeerButton"
 						onPress={onAddPeer}
+					/>
+
+					<Caption13Up style={styles.sectionTitle} color="secondary">
+						Set Confirmed Transaction
+					</Caption13Up>
+					<TextInput
+						style={styles.textInput}
+						autoCapitalize="none"
+						autoComplete="off"
+						autoCorrect={false}
+						autoFocus={false}
+						value={txid}
+						placeholder="Transaction ID"
+						returnKeyType="done"
+						testID="TxidInput"
+						onChangeText={setTxid}
+					/>
+					<Button
+						style={styles.button}
+						text={
+							txid ? 'Set Confirmed Tx' : 'Paste Transaction ID From Clipboard'
+						}
+						loading={settingConfirmedTx}
+						testID="SetConfirmedTxButton"
+						onPress={onSetConfirmedTx}
 					/>
 
 					<Caption13Up style={styles.sectionTitle} color="secondary">

--- a/src/screens/Settings/DevSettings/LdkDebug.tsx
+++ b/src/screens/Settings/DevSettings/LdkDebug.tsx
@@ -2,7 +2,13 @@ import Clipboard from '@react-native-clipboard/clipboard';
 import lm, { ldk } from '@synonymdev/react-native-ldk';
 import React, { ReactElement, memo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ScrollView, StyleSheet, TouchableOpacity, View } from 'react-native';
+import {
+	Alert,
+	ScrollView,
+	StyleSheet,
+	TouchableOpacity,
+	View,
+} from 'react-native';
 import RNFS from 'react-native-fs';
 import Share from 'react-native-share';
 
@@ -53,6 +59,8 @@ const LdkDebug = (): ReactElement => {
 	const [rebroadcastingLdk, setRebroadcastingLdk] = useState(false);
 	const [spendingStuckOutputs, setSpendingStuckOutputs] = useState(false);
 	const [settingConfirmedTx, setSettingConfirmedTx] = useState(false);
+	const [runningComprehensiveDebug, setRunningComprehensiveDebug] =
+		useState(false);
 
 	const { localBalance, remoteBalance } = useLightningBalance();
 	const selectedWallet = useAppSelector(selectedWalletSelector);
@@ -446,7 +454,9 @@ const LdkDebug = (): ReactElement => {
 				showToast({
 					type: 'success',
 					title: 'Transaction Confirmed',
-					description: `Transaction ${txid.slice(0, 8)}... set as confirmed at height ${tx.status.block_height}`,
+					description: `Transaction ${txid.slice(0, 8)}... set as confirmed at height ${
+						tx.status.block_height
+					}`,
 				});
 			}
 		} catch (error) {
@@ -459,6 +469,116 @@ const LdkDebug = (): ReactElement => {
 		} finally {
 			setSettingConfirmedTx(false);
 		}
+	};
+
+	const sleep = (ms: number) =>
+		new Promise((resolve) => setTimeout(resolve, ms));
+
+	const onComprehensiveDebug = async (): Promise<void> => {
+		Alert.alert(
+			'Hard Refresh & Recovery',
+			'This will perform a hard refresh of LDK and attempt to recover any stuck funds. This can take up to 2 minutes.\n\nPlease keep the app open on this screen until complete.',
+			[
+				{
+					text: 'Cancel',
+					style: 'cancel',
+				},
+				{
+					text: 'Continue',
+					onPress: async () => {
+						setRunningComprehensiveDebug(true);
+						let currentStep = '';
+
+						try {
+							// Step 1: Refresh LDK
+							currentStep = 'Refreshing LDK';
+							showToast({
+								type: 'info',
+								title: 'Step 1/5',
+								description: currentStep,
+							});
+							await refreshLdk({ selectedWallet, selectedNetwork });
+
+							await sleep(2000);
+
+							// Step 2: Rebroadcast LDK Txs
+							currentStep = 'Rebroadcasting LDK Transactions';
+							showToast({
+								type: 'info',
+								title: 'Step 2/5',
+								description: currentStep,
+							});
+							await rebroadcastAllKnownTransactions();
+
+							await sleep(2000);
+
+							// Step 3: Spend Stuck Outputs
+							currentStep = 'Spending Stuck Outputs';
+							showToast({
+								type: 'info',
+								title: 'Step 3/5',
+								description: currentStep,
+							});
+							const stuckOutputsRes = await recoverOutputs();
+							if (stuckOutputsRes.isOk()) {
+								showToast({
+									type: 'info',
+									title: 'Stuck Outputs',
+									description: stuckOutputsRes.value,
+								});
+							}
+
+							await sleep(2000);
+
+							// Step 4: Spend Outputs from Force Close
+							currentStep = 'Spending Outputs from Force Close';
+							showToast({
+								type: 'info',
+								title: 'Step 4/5',
+								description: currentStep,
+							});
+							const forceCloseRes = await recoverOutputsFromForceClose();
+							if (forceCloseRes.isOk()) {
+								showToast({
+									type: 'info',
+									title: 'Force Close Outputs',
+									description: forceCloseRes.value,
+								});
+							}
+
+							await sleep(2000);
+
+							// Step 5: Final Refresh LDK
+							currentStep = 'Final LDK Refresh';
+							showToast({
+								type: 'info',
+								title: 'Step 5/5',
+								description: currentStep,
+							});
+							await refreshLdk({ selectedWallet, selectedNetwork });
+
+							// Success
+							showToast({
+								type: 'success',
+								title: 'Hard Refresh & Recovery Complete',
+								description: 'All operations completed successfully',
+							});
+						} catch (error) {
+							showToast({
+								type: 'error',
+								title: `Failed at: ${currentStep}`,
+								description:
+									error instanceof Error
+										? error.message
+										: 'Unknown error occurred',
+							});
+						} finally {
+							setRunningComprehensiveDebug(false);
+						}
+					},
+				},
+			],
+		);
 	};
 
 	return (
@@ -504,6 +624,7 @@ const LdkDebug = (): ReactElement => {
 						autoFocus={false}
 						value={txid}
 						placeholder="Transaction ID"
+						blurOnSubmit
 						returnKeyType="done"
 						testID="TxidInput"
 						onChangeText={setTxid}
@@ -521,6 +642,13 @@ const LdkDebug = (): ReactElement => {
 					<Caption13Up style={styles.sectionTitle} color="secondary">
 						Debug
 					</Caption13Up>
+					<Button
+						style={styles.button}
+						text="Hard Refresh & Recovery"
+						loading={runningComprehensiveDebug}
+						testID="HardRefreshRecovery"
+						onPress={onComprehensiveDebug}
+					/>
 					<Button
 						style={styles.button}
 						text="Get Node ID"


### PR DESCRIPTION
### Description

- Helper in LDK debug for force setting a transaction as confirmed.
- All in one hard LDK refresh and recovery functions. Makes it easier for support tickets if user just needs to press one button.

### Linked Issues/Tasks

Could help unstuck user funds where funds are not being swept.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

<img width="1179" height="2556" alt="simulator_screenshot_17521DCE-E452-4FE3-82E5-AB23F6AA4484" src="https://github.com/user-attachments/assets/93ab5bca-c334-4b58-98ca-3f950a2d59e9" />


### QA Notes

