### PR TITLE
fix(lightning): max fee estimate increase

### DIFF
--- a/__tests__/lightning.test.ts
+++ b/__tests__/lightning.test.ts
@@ -56,7 +56,7 @@ describe('getFees', () => {
 			nonAnchorChannelFee: 110,
 			channelCloseMinimum: 108,
 			outputSpendingFee: 111,
-			maximumFeeEstimate: 111,
+			maximumFeeEstimate: 111 * 10,
 			urgentOnChainSweep: 111,
 		});
 		expect(fetch).toHaveBeenCalledTimes(2);
@@ -87,7 +87,7 @@ describe('getFees', () => {
 			nonAnchorChannelFee: 998,
 			channelCloseMinimum: 997,
 			outputSpendingFee: 999,
-			maximumFeeEstimate: 999,
+			maximumFeeEstimate: 999 * 10,
 			urgentOnChainSweep: 999,
 		});
 		expect(fetch).toHaveBeenCalledTimes(3);

--- a/src/utils/lightning/index.ts
+++ b/src/utils/lightning/index.ts
@@ -355,7 +355,7 @@ export const getFees: TGetFees = async () => {
 		nonAnchorChannelFee: fees.normal,
 		channelCloseMinimum: fees.minimum,
 		outputSpendingFee: fees.fast,
-		maximumFeeEstimate: fees.fast,
+		maximumFeeEstimate: fees.fast * 10, //To avoid htlc_minimum_msat limit issue when making payments until LND fixes this https://github.com/lightningnetwork/lnd/pull/8876#issuecomment-2665969183
 		urgentOnChainSweep: fees.fast,
 	};
 };


### PR DESCRIPTION
### Description

To avoid htlc_minimum_msat limit issue when making payments until LND fixes this https://github.com/lightningnetwork/lnd/pull/8876#issuecomment-2665969183

### Linked Issues/Tasks

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (improving code without creating new functionality)

### Tests

- [ ] Detox test
- [ ] Unit test
- [x] No test

### Screenshot / Video

### QA Notes

Test small payments < 340 sats.